### PR TITLE
Change of default mode of popup source to 'auto'

### DIFF
--- a/lizmap.py
+++ b/lizmap.py
@@ -433,7 +433,7 @@ class lizmap:
             },
             'popupSource': {
                 'widget': self.dlg.liPopupSource,
-                'wType': 'list', 'type': 'string', 'default': 'lizmap',
+                'wType': 'list', 'type': 'string', 'default': 'auto',
                 'list':["auto", "lizmap", "qgis"]
             },
             'popupTemplate': {


### PR DESCRIPTION
The default mode of the configuration 'source' in the panel 'layers' in the part about 'popup' is now 'auto' instead of 'lizmap'.