### PR TITLE
[FEATURE] add opencyclemap option in the maps

### DIFF
--- a/lizmap.py
+++ b/lizmap.py
@@ -198,6 +198,13 @@ class lizmap:
                 'widget': self.dlg.cbGoogleStreets,
                 'wType': 'checkbox', 'type': 'boolean', 'default': False
             },
+			'osmCyclemap' : {
+                'widget': self.dlg.cbOCM,
+                'wType': 'checkbox', 'type': 'boolean', 'default': False
+            },'OCMKey': {
+                'widget': self.dlg.inOCMKey,
+                'wType': 'text', 'type': 'string', 'default': ''
+            },
             'osmMapnik' : {
                 'widget': self.dlg.cbOsmMapnik,
                 'wType': 'checkbox', 'type': 'boolean', 'default': False
@@ -544,6 +551,7 @@ class lizmap:
             'layer': self.dlg.cbLayerIsBaseLayer,
             'osm-mapnik': self.dlg.cbOsmMapnik,
             'osm-stamen-toner': self.dlg.cbOsmStamenToner,
+			'osmCyclemap': self.dlg.cbOCM,
             'google-street': self.dlg.cbGoogleStreets,
             'google-satellite': self.dlg.cbGoogleSatellite,
             'google-hybrid': self.dlg.cbGoogleHybrid,

--- a/ui_lizmap.ui
+++ b/ui_lizmap.ui
@@ -1565,7 +1565,7 @@ This is different to the map maximum extent (defined in QGIS project properties,
                        </font>
                       </property>
                       <property name="text">
-                       <string>OpenStreetMaps</string>
+                       <string>OpenStreetMap</string>
                       </property>
                      </widget>
                     </item>

--- a/ui_lizmap.ui
+++ b/ui_lizmap.ui
@@ -1565,7 +1565,7 @@ This is different to the map maximum extent (defined in QGIS project properties,
                        </font>
                       </property>
                       <property name="text">
-                       <string>OpenStreetMap</string>
+                       <string>OpenStreetMaps</string>
                       </property>
                      </widget>
                     </item>
@@ -1598,6 +1598,73 @@ This is different to the map maximum extent (defined in QGIS project properties,
                        </size>
                       </property>
                      </spacer>
+                    </item>
+                   </layout>
+                  </item>
+				              <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_21">
+                    <property name="spacing">
+                     <number>5</number>
+                    </property>
+                    <property name="sizeConstraint">
+                     <enum>QLayout::SetDefaultConstraint</enum>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <item>
+                     <widget class="QLabel" name="label_33">
+                      <property name="font">
+                       <font>
+                        <weight>75</weight>
+                        <bold>true</bold>
+                       </font>
+                      </property>
+                      <property name="text">
+                       <string>ThunderForest</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QCheckBox" name="cbOCM">
+                      <property name="text">
+                       <string>Open Cycle Map</string>
+                      </property>
+                     </widget>
+                    </item>
+                    
+                    <item>
+                     <spacer name="horizontalSpacer_18">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="label_31">
+                      <property name="text">
+                       <string>Key</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="inOCMKey">
+                      <property name="maximumSize">
+                       <size>
+                        <width>100</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                     </widget>
                     </item>
                    </layout>
                   </item>
@@ -4389,6 +4456,8 @@ Only the selected feature will be visible on the map.</string>
   <tabstop>scrollArea_3</tabstop>
   <tabstop>cbOsmMapnik</tabstop>
   <tabstop>cbOsmStamenToner</tabstop>
+  <tabstop>cbOCM</tabstop>
+  <tabstop>inOCMKey</tabstop>
   <tabstop>cbGoogleStreets</tabstop>
   <tabstop>cbGoogleSatellite</tabstop>
   <tabstop>cbGoogleHybrid</tabstop>


### PR DESCRIPTION
allow user to select thunderforest OpenCycleMap as a map and record the API key
cf #109 
cf https://github.com/3liz/lizmap-web-client/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+440

data exploited in the lizmap web client : https://github.com/3liz/lizmap-web-client/pull/934

tested in QGIS 2.18.21