### PR TITLE
support wms urls thet have parameters with no =

### DIFF
--- a/lizmap.py
+++ b/lizmap.py
@@ -2377,7 +2377,7 @@ class lizmap(object):
             return None
 
         # Split WMS parameters
-        wmsParams = dict([ [b for b in a.split('=') ] for a in uri.split('&')])
+        wmsParams = dict((p.split('=')+[''])[:2] for p in uri.split('&'))
 
         # urldecode WMS url
         wmsParams['url'] = urllib.parse.unquote(wmsParams['url']).replace('&&', '&').replace('==','=')

--- a/lizmap.py
+++ b/lizmap.py
@@ -1607,8 +1607,8 @@ class lizmap(object):
 
             # layer scale visibility
             if layer.hasScaleBasedVisibility():
-                self.myDic[itemKey]['minScale'] = layer.minimumScale()
-                self.myDic[itemKey]['maxScale'] = layer.maximumScale()
+                self.myDic[itemKey]['minScale'] = layer.maximumScale()
+                self.myDic[itemKey]['maxScale'] = layer.minimumScale()
             # toggled : check if layer is toggled in qgis legend
             #self.myDic[itemKey]['toggled'] = layer.self.iface.legendInterface().isLayerVisible(layer)
             self.myDic[itemKey]['toggled'] = False


### PR DESCRIPTION
for example note the "style" parameter in this URL
`contextualWMSLegend=0&crs=EPSG:2056&dpiMode=7&featureCount=10&format=image/png&layers=topo&styles&url=https://sitn.ne.ch/mapproxy95/service`

Without this, lizmap plugin raises 

> ValueError: dictionary update sequence element #6 has length 1; 2 is required
