### PR TITLE
support wms urls thet have parameters with no =

### DIFF
--- a/lizmap.py
+++ b/lizmap.py
@@ -2378,7 +2378,7 @@ class lizmap(object):
             return None
 
         # Split WMS parameters
-        wmsParams = dict([ [b for b in a.split('=') ] for a in uri.split('&')])
+        wmsParams = dict((p.split('=')+[''])[:2] for p in uri.split('&'))
 
         # urldecode WMS url
         wmsParams['url'] = urllib.parse.unquote(wmsParams['url']).replace('&&', '&').replace('==','=')


### PR DESCRIPTION
for example note the "style" parameter in this URL
contextualWMSLegend=0&crs=EPSG:2056&dpiMode=7&featureCount=10&format=image/png&layers=topo&styles&url=https://sitn.ne.ch/mapproxy95/service