### PR TITLE
review TAB order in QtDesigner

### DIFF
--- a/ui_lizmap.ui
+++ b/ui_lizmap.ui
@@ -36,7 +36,16 @@
        <enum>QFrame::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_32">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -257,7 +266,16 @@ QListWidget::item::selected {
        <enum>QFrame::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_33">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -269,11 +287,20 @@ QListWidget::item::selected {
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>8</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="pageMapOptions">
           <layout class="QVBoxLayout" name="verticalLayout_35">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -289,8 +316,8 @@ QListWidget::item::selected {
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>743</width>
-                <height>773</height>
+                <width>820</width>
+                <height>884</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_26">
@@ -829,7 +856,16 @@ This is different to the map maximum extent (defined in QGIS project properties,
          </widget>
          <widget class="QWidget" name="pageLayers">
           <layout class="QVBoxLayout" name="verticalLayout_34">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -845,8 +881,8 @@ This is different to the map maximum extent (defined in QGIS project properties,
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>445</width>
-                <height>139</height>
+                <width>802</width>
+                <height>859</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_28">
@@ -924,8 +960,8 @@ This is different to the map maximum extent (defined in QGIS project properties,
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>477</width>
-                       <height>749</height>
+                       <width>514</width>
+                       <height>813</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -1171,11 +1207,11 @@ This is different to the map maximum extent (defined in QGIS project properties,
                              <property name="minimum">
                               <number>1</number>
                              </property>
-                             <property name="value">
-                              <number>10</number>
-                             </property>
                              <property name="maximum">
                               <number>199</number>
+                             </property>
+                             <property name="value">
+                              <number>10</number>
                              </property>
                             </widget>
                            </item>
@@ -1520,7 +1556,16 @@ This is different to the map maximum extent (defined in QGIS project properties,
          </widget>
          <widget class="QWidget" name="pageBaselayers">
           <layout class="QVBoxLayout" name="verticalLayout_37">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -1536,8 +1581,8 @@ This is different to the map maximum extent (defined in QGIS project properties,
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>594</width>
-                <height>772</height>
+                <width>802</width>
+                <height>859</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -1604,7 +1649,7 @@ This is different to the map maximum extent (defined in QGIS project properties,
                     </item>
                    </layout>
                   </item>
-                              <item>
+                  <item>
                    <layout class="QHBoxLayout" name="horizontalLayout_21">
                     <property name="spacing">
                      <number>5</number>
@@ -1638,7 +1683,6 @@ This is different to the map maximum extent (defined in QGIS project properties,
                       </property>
                      </widget>
                     </item>
-
                     <item>
                      <spacer name="horizontalSpacer_18">
                       <property name="orientation">
@@ -2212,7 +2256,16 @@ This is different to the map maximum extent (defined in QGIS project properties,
          </widget>
          <widget class="QWidget" name="pageLocate">
           <layout class="QVBoxLayout" name="verticalLayout_5">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -2228,8 +2281,8 @@ This is different to the map maximum extent (defined in QGIS project properties,
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>764</width>
-                <height>364</height>
+                <width>802</width>
+                <height>859</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -2486,7 +2539,16 @@ Only the selected feature will be visible on the map.</string>
          </widget>
          <widget class="QWidget" name="pageAttribute">
           <layout class="QVBoxLayout" name="verticalLayout_39">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -2502,8 +2564,8 @@ Only the selected feature will be visible on the map.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>498</width>
-                <height>418</height>
+                <width>802</width>
+                <height>859</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -2698,7 +2760,16 @@ Only the selected feature will be visible on the map.</string>
          </widget>
          <widget class="QWidget" name="pageEditing">
           <layout class="QVBoxLayout" name="verticalLayout_3">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -2714,8 +2785,8 @@ Only the selected feature will be visible on the map.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>764</width>
-                <height>305</height>
+                <width>802</width>
+                <height>859</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -2903,7 +2974,16 @@ Only the selected feature will be visible on the map.</string>
          </widget>
          <widget class="QWidget" name="pageTooltip">
           <layout class="QVBoxLayout" name="verticalLayout_13">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -2919,8 +2999,8 @@ Only the selected feature will be visible on the map.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>430</width>
-                <height>397</height>
+                <width>802</width>
+                <height>859</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -3098,7 +3178,16 @@ Only the selected feature will be visible on the map.</string>
          </widget>
          <widget class="QWidget" name="pageFilter">
           <layout class="QVBoxLayout" name="verticalLayout_38">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -3114,8 +3203,8 @@ Only the selected feature will be visible on the map.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>330</width>
-                <height>305</height>
+                <width>802</width>
+                <height>859</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_29">
@@ -3258,9 +3347,9 @@ Only the selected feature will be visible on the map.</string>
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-123</y>
-                <width>725</width>
-                <height>899</height>
+                <y>0</y>
+                <width>802</width>
+                <height>866</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -3608,14 +3697,14 @@ Only the selected feature will be visible on the map.</string>
                  </item>
                  <item row="11" column="3">
                   <widget class="QgsColorButton" name="inDatavizPlotColor">
-                   <property name="color">
+                   <property name="color" stdset="0">
                     <color>
                      <red>0</red>
                      <green>170</green>
                      <blue>255</blue>
                     </color>
                    </property>
-                   <property name="defaultColor">
+                   <property name="defaultColor" stdset="0">
                     <color>
                      <red>0</red>
                      <green>170</green>
@@ -3636,14 +3725,14 @@ Only the selected feature will be visible on the map.</string>
                  </item>
                  <item row="13" column="3">
                   <widget class="QgsColorButton" name="inDatavizPlotColor2">
-                   <property name="color">
+                   <property name="color" stdset="0">
                     <color>
                      <red>255</red>
                      <green>170</green>
                      <blue>0</blue>
                     </color>
                    </property>
-                   <property name="defaultColor">
+                   <property name="defaultColor" stdset="0">
                     <color>
                      <red>255</red>
                      <green>170</green>
@@ -3728,7 +3817,16 @@ Only the selected feature will be visible on the map.</string>
          </widget>
          <widget class="QWidget" name="pageTimemanager">
           <layout class="QVBoxLayout" name="verticalLayout_30">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -3744,8 +3842,8 @@ Only the selected feature will be visible on the map.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>439</width>
-                <height>471</height>
+                <width>820</width>
+                <height>884</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_43">
@@ -4048,8 +4146,8 @@ Only the selected feature will be visible on the map.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>487</width>
-                <height>651</height>
+                <width>800</width>
+                <height>864</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_41">
@@ -4336,7 +4434,16 @@ Only the selected feature will be visible on the map.</string>
          </widget>
          <widget class="QWidget" name="pageLog">
           <layout class="QVBoxLayout" name="verticalLayout_40">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -4402,29 +4509,6 @@ Only the selected feature will be visible on the map.</string>
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>treeLayer</tabstop>
-  <tabstop>cbHideGroupCheckbox</tabstop>
-  <tabstop>inLayerTitle</tabstop>
-  <tabstop>teLayerAbstract</tabstop>
-  <tabstop>inLayerLink</tabstop>
-  <tabstop>cbToggled</tabstop>
-  <tabstop>cbDisplayInLegend</tabstop>
-  <tabstop>cbGroupAsLayer</tabstop>
-  <tabstop>cbLayerIsBaseLayer</tabstop>
-  <tabstop>cbPopup</tabstop>
-  <tabstop>liPopupSource</tabstop>
-  <tabstop>cbPopupDisplayChildren</tabstop>
-  <tabstop>btConfigurePopup</tabstop>
-  <tabstop>liImageFormat</tabstop>
-  <tabstop>inClientCacheExpiration</tabstop>
-  <tabstop>cbExternalWms</tabstop>
-  <tabstop>cbSingleTile</tabstop>
-  <tabstop>cbCached</tabstop>
-  <tabstop>inCacheExpiration</tabstop>
-  <tabstop>inMetatileSize</tabstop>
-  <tabstop>inSourceRepository</tabstop>
-  <tabstop>inSourceProject</tabstop>
-  <tabstop>buttonBox</tabstop>
   <tabstop>mOptionsListWidget</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>cbHideProject</tabstop>
@@ -4437,9 +4521,9 @@ Only the selected feature will be visible on the map.</string>
   <tabstop>inPointTolerance</tabstop>
   <tabstop>inLineTolerance</tabstop>
   <tabstop>inPolygonTolerance</tabstop>
+  <tabstop>inMapScales</tabstop>
   <tabstop>inMinScale</tabstop>
   <tabstop>inMaxScale</tabstop>
-  <tabstop>inMapScales</tabstop>
   <tabstop>inInitialExtent</tabstop>
   <tabstop>btSetExtentFromProject</tabstop>
   <tabstop>btSetExtentFromCanvas</tabstop>
@@ -4450,12 +4534,31 @@ Only the selected feature will be visible on the map.</string>
   <tabstop>cbHideNavbar</tabstop>
   <tabstop>liPopupContainer</tabstop>
   <tabstop>scrollArea_7</tabstop>
+  <tabstop>treeLayer</tabstop>
   <tabstop>scrollArea_10</tabstop>
-  <tabstop>mGroupBox_2</tabstop>
+  <tabstop>inLayerTitle</tabstop>
+  <tabstop>teLayerAbstract</tabstop>
+  <tabstop>inLayerLink</tabstop>
+  <tabstop>cbToggled</tabstop>
+  <tabstop>cbDisplayInLegend</tabstop>
   <tabstop>cbNoLegendImage</tabstop>
-  <tabstop>mGroupBox_3</tabstop>
-  <tabstop>mGroupBox_4</tabstop>
-  <tabstop>mGroupBox_5</tabstop>
+  <tabstop>cbGroupAsLayer</tabstop>
+  <tabstop>cbLayerIsBaseLayer</tabstop>
+  <tabstop>cbPopup</tabstop>
+  <tabstop>liPopupSource</tabstop>
+  <tabstop>btConfigurePopup</tabstop>
+  <tabstop>sbPopupMaxFeatures</tabstop>
+  <tabstop>cbPopupDisplayChildren</tabstop>
+  <tabstop>liImageFormat</tabstop>
+  <tabstop>inClientCacheExpiration</tabstop>
+  <tabstop>cbExternalWms</tabstop>
+  <tabstop>cbSingleTile</tabstop>
+  <tabstop>cbCached</tabstop>
+  <tabstop>inCacheExpiration</tabstop>
+  <tabstop>inMetatileSize</tabstop>
+  <tabstop>inSourceRepository</tabstop>
+  <tabstop>inSourceProject</tabstop>
+  <tabstop>cbHideGroupCheckbox</tabstop>
   <tabstop>scrollArea_3</tabstop>
   <tabstop>cbOsmMapnik</tabstop>
   <tabstop>cbOsmStamenToner</tabstop>
@@ -4478,32 +4581,31 @@ Only the selected feature will be visible on the map.</string>
   <tabstop>cbAddEmptyBaselayer</tabstop>
   <tabstop>cbStartupBaselayer</tabstop>
   <tabstop>twLizmapBaselayers</tabstop>
-  <tabstop>inLizmapBaselayerLayer</tabstop>
-  <tabstop>inLizmapBaselayerProject</tabstop>
-  <tabstop>inLizmapBaselayerTitle</tabstop>
   <tabstop>inLizmapBaselayerRepository</tabstop>
+  <tabstop>inLizmapBaselayerProject</tabstop>
+  <tabstop>inLizmapBaselayerLayer</tabstop>
+  <tabstop>inLizmapBaselayerTitle</tabstop>
   <tabstop>inLizmapBaselayerImageFormat</tabstop>
   <tabstop>btLizmapBaselayerAdd</tabstop>
-  <tabstop>sbPopupMaxFeatures</tabstop>
   <tabstop>btLizmapBaselayerDel</tabstop>
   <tabstop>scrollArea_4</tabstop>
   <tabstop>twLocateByLayerList</tabstop>
-  <tabstop>cbLocateByLayerDisplayGeom</tabstop>
   <tabstop>liLocateByLayerLayers</tabstop>
-  <tabstop>inLocateByLayerMinLength</tabstop>
   <tabstop>liLocateByLayerFields</tabstop>
-  <tabstop>cbFilterOnLocate</tabstop>
   <tabstop>liLocateByLayerFilterFields</tabstop>
+  <tabstop>cbLocateByLayerDisplayGeom</tabstop>
+  <tabstop>inLocateByLayerMinLength</tabstop>
+  <tabstop>cbFilterOnLocate</tabstop>
   <tabstop>btLocateByLayerAdd</tabstop>
   <tabstop>btLocateByLayerDel</tabstop>
   <tabstop>scrollArea_6</tabstop>
   <tabstop>cbLimitDataToBbox</tabstop>
   <tabstop>twAttributeLayerList</tabstop>
-  <tabstop>liAttributeLayerFields</tabstop>
-  <tabstop>cbAttributeLayerIsPivot</tabstop>
-  <tabstop>inAttributeLayerHiddenFields</tabstop>
-  <tabstop>cbAttributeLayerHideAsChild</tabstop>
   <tabstop>liAttributeLayer</tabstop>
+  <tabstop>liAttributeLayerFields</tabstop>
+  <tabstop>inAttributeLayerHiddenFields</tabstop>
+  <tabstop>cbAttributeLayerIsPivot</tabstop>
+  <tabstop>cbAttributeLayerHideAsChild</tabstop>
   <tabstop>cbAttributeLayerHideLayer</tabstop>
   <tabstop>btAttributeLayerAdd</tabstop>
   <tabstop>btAttributeLayerDel</tabstop>
@@ -4519,8 +4621,8 @@ Only the selected feature will be visible on the map.</string>
   <tabstop>btEditionLayerDel</tabstop>
   <tabstop>scrollArea_8</tabstop>
   <tabstop>twTooltipLayerList</tabstop>
-  <tabstop>inTooltipLayerFields</tabstop>
   <tabstop>liTooltipLayer</tabstop>
+  <tabstop>inTooltipLayerFields</tabstop>
   <tabstop>cbTooltipLayerDisplayGeom</tabstop>
   <tabstop>inTooltipLayerColorGeom</tabstop>
   <tabstop>btTooltipLayerAdd</tabstop>
@@ -4547,21 +4649,23 @@ Only the selected feature will be visible on the map.</string>
   <tabstop>inDatavizPlotColor</tabstop>
   <tabstop>cbDatavizYField2</tabstop>
   <tabstop>inDatavizPlotYfield2</tabstop>
-  <tabstop>inDatavizPlotColor2</tabstop>
   <tabstop>cbDatavizUseColorField2</tabstop>
   <tabstop>inDatavizColorField2</tabstop>
+  <tabstop>inDatavizPlotColor2</tabstop>
+  <tabstop>cbDatavizDisplayChildPlot</tabstop>
+  <tabstop>cbDatavizOnlyShowChild</tabstop>
   <tabstop>btDatavizAddLayer</tabstop>
   <tabstop>btDatavizRemoveLayer</tabstop>
   <tabstop>scrollArea_9</tabstop>
   <tabstop>inTimeFrameSize</tabstop>
-  <tabstop>inAnimationFrameLength</tabstop>
   <tabstop>liTimeFrameType</tabstop>
+  <tabstop>inAnimationFrameLength</tabstop>
   <tabstop>twTimemanager</tabstop>
-  <tabstop>liTimemanagerStartAttribute</tabstop>
   <tabstop>liTimemanagerLayers</tabstop>
+  <tabstop>liTimemanagerStartAttribute</tabstop>
+  <tabstop>liTimemanagerLabelAttribute</tabstop>
   <tabstop>inTimemanagerGroup</tabstop>
   <tabstop>inTimemanagerGroupTitle</tabstop>
-  <tabstop>liTimemanagerLabelAttribute</tabstop>
   <tabstop>btTimemanagerLayerAdd</tabstop>
   <tabstop>btTimemanagerLayerDel</tabstop>
   <tabstop>scrollArea_12</tabstop>


### PR DESCRIPTION
TAB order sequence is wrong in the QGIS 2 version.
I made the fix in QGIS 3 version because I'm not sure you will release a new version for QGIS 2.