### PR TITLE
check QGZ files when we open lizmap

### DIFF
--- a/lizmap.py
+++ b/lizmap.py
@@ -2522,8 +2522,9 @@ class Lizmap:
         error_message = ''
         # Get the project data from api
         project = QgsProject.instance()
-        if not project.fileName():
-            error_message += '* ' + tr('You need to open a qgis project before using Lizmap') + '\n'
+        if not project.fileName() or not project.fileName().lower().endswith('qgs'):
+            error_message += tr(
+                'You need to open a QGIS project, using the QGS extension, before using Lizmap.')
             is_valid = False
 
         project_dir = None

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -30,7 +30,7 @@ class TestUiLizmapDialog(unittest.TestCase):
 
         flag, message = lizmap.check_global_project_options()
         self.assertFalse(flag, message)
-        self.assertEqual(message, '* You need to open a qgis project before using Lizmap\n')
+        self.assertEqual(message, 'You need to open a QGIS project, using the QGS extension, before using Lizmap.')
 
         project.write(plugin_test_data_path('unittest.qgs'))
         flag, message = lizmap.check_global_project_options()


### PR DESCRIPTION
fix #166 

Disable loading lizmap if the project is stored in QGZ, geopackage or postgis.