### PR TITLE
add some metadata in CFG file about versions

### DIFF
--- a/lizmap.py
+++ b/lizmap.py
@@ -812,7 +812,7 @@ class Lizmap:
 
         # Set the global options (map, tools, etc.)
         for key, item in self.global_options.items():
-            if item['widget']:
+            if item.get('widget'):
                 if item['wType'] == 'checkbox':
                     item['widget'].setChecked(item['default'])
                     if key in json_options:
@@ -858,7 +858,7 @@ class Lizmap:
 
         # Set layer combobox
         for key, item in self.global_options.items():
-            if item['widget']:
+            if item.get('widget'):
                 if item['wType'] == 'layers':
                     if key in json_options:
                         for lyr in self.project.mapLayers().values():
@@ -868,7 +868,7 @@ class Lizmap:
 
         # Then set field combobox
         for key, item in self.global_options.items():
-            if item['widget']:
+            if item.get('widget'):
                 if item['wType'] == 'fields':
                     if key in json_options:
                         item['widget'].setField(str(json_options[key]))
@@ -2168,12 +2168,12 @@ class Lizmap:
         """Get general project options and user edited layers options from plugin gui.
         Save them into the project.qgs.cfg config file in the project.qgs folder (json format)."""
 
-        # get information from Qgis api
-        # r = QgsMapRenderer()
-        # add all the layers to the renderer
-        # r.setLayerSet([a.id() for a in self.iface.legendInterface().layers()])
-        # options
+        metadata = {
+            'lizmap_plugin_version': self.global_options['lizmap_plugin_version']['default'],
+        }
+
         liz2json = dict()
+        liz2json['metadata'] = metadata
         liz2json["options"] = dict()
         liz2json["layers"] = dict()
         # projection
@@ -2199,7 +2199,7 @@ class Lizmap:
 
         # gui user defined options
         for key, item in self.global_options.items():
-            if item['widget']:
+            if item.get('widget'):
                 inputValue = None
                 # Get field value depending on widget type
                 if item['wType'] in ['text', 'html']:

--- a/lizmap_api/config.py
+++ b/lizmap_api/config.py
@@ -53,6 +53,8 @@ from qgis.core import (
     QgsMapLayer,
 )
 
+from ..qgis_plugin_tools.tools.resources import metadata_config
+
 
 class LizmapConfigError(Exception):
     pass
@@ -70,7 +72,12 @@ class LizmapConfig:
         4: 'none'
     }
 
+    lizmap_version = metadata_config()['general']['version']
+
     globalOptionDefinitions = {
+        'lizmap_plugin_version': {
+            'wType': 'spinbox', 'type': 'integer', 'default': int(''.join([format(int(i), '02d') for i in lizmap_version.split('.')])),
+        },
         'mapScales': {
             'wType': 'text', 'type': 'intlist', 'default': [10000, 25000, 50000, 100000, 250000, 500000]
         },


### PR DESCRIPTION
This will create in the CFG file a new section like:

```
    "metadata": {
        "lizmap_plugin_version": 30107,
        "qgis_desktop_version": 30414,
        "date_modified": "2020-01-14 14:08:00"
    },
```

@mdouchin @rldhont and I started talking about versioning CFG file. It's not clear what we should do next, but at least, LWC can have some information about incompatible CFG file. For instance if the CFG file is too recent compare to LWC.

The QGIS desktop version is redundant with the QGS file.

@nboisteault FYI

I think it doesn't hurt to add this kind of information, for tracking anyway.

Any idea?