### PR TITLE
support for multi traces in dataviz

### DIFF
--- a/lizmap/definitions/base.py
+++ b/lizmap/definitions/base.py
@@ -11,6 +11,7 @@ __revision__ = '$Format:%H$'
 
 @unique
 class InputType(Enum):
+    Collection = 'Collection'  # Does not have a input widget, it's a JSON representation
     Color = 'Color'  # QgsColorButton
     CheckBox = 'CheckBox'  # QCheckbox
     Field = 'Field'  # QgsFieldMapLayerComboBox

--- a/lizmap/definitions/dataviz.py
+++ b/lizmap/definitions/dataviz.py
@@ -179,6 +179,7 @@ class DatavizDefinitions(BaseDefinitions):
                 'y_field',
                 'color',
                 'colorfield',
+                'z_field',
             ],
             'represent_value': represent_traces,
         }
@@ -212,6 +213,7 @@ class DatavizDefinitions(BaseDefinitions):
                 'Choose the field of your layer which contains the colors you want to use. The color can be written like "red" or "blue" but it can be an HTML color code like "#01DFD7" for example.')
         }
         self._layer_config['z_field'] = {
+            'visible': False,
             'type': InputType.Field,
             'header': tr('Z field'),
             'default': '',

--- a/lizmap/definitions/dataviz.py
+++ b/lizmap/definitions/dataviz.py
@@ -102,7 +102,9 @@ class AggregationType(Enum):
     }
 
 
-def represent_traces(data):
+def represent_traces(data) -> str:
+    """Generate HTMl string for the tooltip instead of JSON representation."""
+    # Nice to have : color in a small square
     html = '<ul>'
     for trace in data:
         y_field = trace.get('y_field')

--- a/lizmap/definitions/dataviz.py
+++ b/lizmap/definitions/dataviz.py
@@ -184,7 +184,7 @@ class DatavizDefinitions(BaseDefinitions):
             'represent_value': represent_traces,
         }
         self._layer_config['y_field'] = {
-            'visible': False,
+            # 'visible': False,
             # 'legacy': 'y2_field',
             'plural': 'y{}_field',
             'type': InputType.Field,
@@ -193,7 +193,7 @@ class DatavizDefinitions(BaseDefinitions):
             'tooltip': tr('The Y field of your graph.')
         }
         self._layer_config['color'] = {
-            'visible': False,
+            # 'visible': False,
             # 'legacy': 'color2',
             'plural': 'color{}',
             'type': InputType.Color,
@@ -202,8 +202,8 @@ class DatavizDefinitions(BaseDefinitions):
             'tooltip': tr('The color for Y.')
         }
         self._layer_config['colorfield'] = {
-            'visible': False,
-            'legacy': 'colorfield2',
+            # 'visible': False,
+            # 'legacy': 'colorfield2',
             'plural': 'colorfield{}',
             'type': InputType.Field,
             'header': tr('Color field'),
@@ -213,7 +213,7 @@ class DatavizDefinitions(BaseDefinitions):
                 'Choose the field of your layer which contains the colors you want to use. The color can be written like "red" or "blue" but it can be an HTML color code like "#01DFD7" for example.')
         }
         self._layer_config['z_field'] = {
-            'visible': False,
+            'plural': 'z_field_{}',
             'type': InputType.Field,
             'header': tr('Z field'),
             'default': '',

--- a/lizmap/definitions/dataviz.py
+++ b/lizmap/definitions/dataviz.py
@@ -102,6 +102,32 @@ class AggregationType(Enum):
     }
 
 
+def represent_traces(data):
+    html = '''<style>
+.box {
+  float: left;
+  width: 20px;
+  height: 20px;
+  margin: 5px;
+  border: 1px solid rgba(0, 0, 0, .2);
+}
+</style>\n'''
+    for trace in data:
+        y_field = trace.get('y_field')
+        color = trace.get('color')
+        color_field = trace.get('colorfield')
+        if y_field:
+            html += '<p>{}: '.format(y_field)
+            if color_field:
+                html += color_field
+            else:
+                html += '<div class="box" style="background:{};"></div>'.format(color)
+            html += '</p>\n'
+
+    html += '\n'
+    return html
+
+
 class DatavizDefinitions(BaseDefinitions):
 
     def __init__(self):
@@ -145,43 +171,45 @@ class DatavizDefinitions(BaseDefinitions):
             'default': AggregationType.Sum,
             'tooltip': tr('For a few types of charts like "bar" or "pie", you can choose to aggregate the data in the graph.')
         }
+        self._layer_config['traces'] = {
+            'type': InputType.Collection,
+            'header': tr('Traces'),
+            'tooltip': tr('Textual representations of traces'),
+            'items': [
+                'y_field',
+                'color',
+                'colorfield',
+            ],
+            'represent_value': represent_traces,
+        }
         self._layer_config['y_field'] = {
+            'visible': False,
+            # 'legacy': 'y2_field',
+            'plural': 'y{}_field',
             'type': InputType.Field,
             'header': tr('Y field'),
             'default': '',
             'tooltip': tr('The Y field of your graph.')
         }
         self._layer_config['color'] = {
+            'visible': False,
+            # 'legacy': 'color2',
+            'plural': 'color{}',
             'type': InputType.Color,
             'header': tr('Color'),
             'default': '#086FA1',
             'tooltip': tr('The color for Y.')
         }
         self._layer_config['colorfield'] = {
+            'visible': False,
+            'legacy': 'colorfield2',
+            'plural': 'colorfield{}',
             'type': InputType.Field,
             'header': tr('Color field'),
             'default': '',
             'tooltip': tr(
                 'You can choose or not a color field to customize the color of each category of your chart. '
                 'Choose the field of your layer which contains the colors you want to use. The color can be written like "red" or "blue" but it can be an HTML color code like "#01DFD7" for example.')
-        }
-        self._layer_config['y2_field'] = {
-            'type': InputType.Field,
-            'header': tr('Y field 2'),
-            'default': '',
-            'tooltip': tr('You can add a second Y field.')
-        }
-        self._layer_config['colorfield2'] = {
-            'type': InputType.Field,
-            'header': tr('Color field 2'),
-            'default': '',
-            'tooltip': tr('You can choose the color of the second Y field the same way you choose the one for his first Y field.')
-        }
-        self._layer_config['color2'] = {
-            'type': InputType.Color,
-            'header': tr('Color 2'),
-            'default': '#FF8900',
-            'tooltip': tr('The second color')
         }
         self._layer_config['z_field'] = {
             'type': InputType.Field,

--- a/lizmap/definitions/dataviz.py
+++ b/lizmap/definitions/dataviz.py
@@ -103,28 +103,23 @@ class AggregationType(Enum):
 
 
 def represent_traces(data):
-    html = '''<style>
-.box {
-  float: left;
-  width: 20px;
-  height: 20px;
-  margin: 5px;
-  border: 1px solid rgba(0, 0, 0, .2);
-}
-</style>\n'''
+    html = '<ul>'
     for trace in data:
         y_field = trace.get('y_field')
-        color = trace.get('color')
-        color_field = trace.get('colorfield')
         if y_field:
-            html += '<p>{}: '.format(y_field)
+            html += '<li>{}: '.format(y_field)
+
+            color_field = trace.get('colorfield')
             if color_field:
                 html += color_field
-            else:
-                html += '<div class="box" style="background:{};"></div>'.format(color)
-            html += '</p>\n'
 
-    html += '\n'
+            color = trace.get('color')
+            if color:
+                html += color
+
+            html += '</li>\n'
+
+    html += '</ul>\n'
     return html
 
 
@@ -184,8 +179,6 @@ class DatavizDefinitions(BaseDefinitions):
             'represent_value': represent_traces,
         }
         self._layer_config['y_field'] = {
-            # 'visible': False,
-            # 'legacy': 'y2_field',
             'plural': 'y{}_field',
             'type': InputType.Field,
             'header': tr('Y field'),
@@ -193,8 +186,6 @@ class DatavizDefinitions(BaseDefinitions):
             'tooltip': tr('The Y field of your graph.')
         }
         self._layer_config['color'] = {
-            # 'visible': False,
-            # 'legacy': 'color2',
             'plural': 'color{}',
             'type': InputType.Color,
             'header': tr('Color'),
@@ -202,8 +193,6 @@ class DatavizDefinitions(BaseDefinitions):
             'tooltip': tr('The color for Y.')
         }
         self._layer_config['colorfield'] = {
-            # 'visible': False,
-            # 'legacy': 'colorfield2',
             'plural': 'colorfield{}',
             'type': InputType.Field,
             'header': tr('Color field'),

--- a/lizmap/forms/base_edition_dialog.py
+++ b/lizmap/forms/base_edition_dialog.py
@@ -164,8 +164,13 @@ class BaseEditionDialog(QDialog):
         # This function is implemented in child class.
         pass
 
-    def save_collection(self):
+    def save_collection(self) -> dict:
         """Save a collection into JSON."""
+        # This function is implemented in child class.
+        pass
+
+    def primary_keys_collection(self) -> list:
+        """List of unique keys in the collection."""
         # This function is implemented in child class.
         pass
 

--- a/lizmap/forms/dataviz_edition.py
+++ b/lizmap/forms/dataviz_edition.py
@@ -153,8 +153,15 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
     def _edit_trace_row(self, row, data):
         """Internal function to edit a row."""
         for i, key in enumerate(self.config.layer_config['traces']['items']):
-            value = data[key]
             cell = QTableWidgetItem()
+
+            value = data.get(key)
+            if not value:
+                cell.setText('')
+                cell.setData(Qt.UserRole, '')
+                self.traces.setItem(row, i, cell)
+                continue
+
             input_type = self.config.layer_config[key]['type']
             if input_type == InputType.Field:
                 cell.setText(value)

--- a/lizmap/forms/dataviz_edition.py
+++ b/lizmap/forms/dataviz_edition.py
@@ -105,15 +105,15 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
         self.setup_ui()
         self.check_form_graph_type()
 
-    def load_collection(self, value):
-        """Load a collection into the table from JSON."""
+    def load_collection(self, value) -> None:
+        """Load a collection into the table from JSON string."""
         for trace in value:
             row = self.traces.rowCount()
             self.traces.setRowCount(row + 1)
             self._edit_trace_row(row, trace)
         self.disable_more_trace()
 
-    def save_collection(self):
+    def save_collection(self) -> list:
         """Save a collection into JSON"""
         value = list()
         rows = self.traces.rowCount()
@@ -121,18 +121,19 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
         collection_definition = self.config.layer_config['traces']
         for row in range(rows):
             trace_data = dict()
-            i = 0
-            for sub_key in collection_definition['items']:
+            for i, sub_key in enumerate(collection_definition['items']):
 
                 input_type = self.config.layer_config[sub_key]['type']
                 item = self.traces.item(row, i)
 
                 if item is None:
+                    # Safe guard
                     # Do not put if not item, it might be False
                     raise Exception('Cell is not initialized ({}, {})'.format(row, i))
 
                 cell = item.data(Qt.UserRole)
                 if cell is None:
+                    # Safe guard
                     # Do not put if not cell, it might be False
                     raise Exception('Cell has no data ({}, {})'.format(row, i))
 
@@ -142,8 +143,6 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
                     trace_data[sub_key] = cell
                 else:
                     raise Exception('InputType "{}" not implemented'.format(input_type))
-
-                i += 1
 
             value.append(trace_data)
 
@@ -155,6 +154,7 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
         self.traces.setRowCount(0)
 
     def add_new_trace(self):
+        """Add a new trace in the table after clicking the 'add' button."""
         graph = self.type_graph.currentData()
         for item_enum in GraphType:
             if item_enum.value['data'] == graph:
@@ -247,6 +247,7 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
             self.add_trace.setStyleSheet('')
 
     def check_form_graph_type(self):
+        """Enable or not features according to the type of graph."""
         graph = self.type_graph.currentData()
         for item_enum in GraphType:
             if item_enum.value['data'] == graph:
@@ -255,6 +256,7 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
         else:
             raise Exception('Error with list')
 
+        # Field X
         if graph in [
                 GraphType.Scatter, GraphType.Bar, GraphType.Histogram,
                 GraphType.Histogram2D, GraphType.Polar, GraphType.Pie,

--- a/lizmap/forms/dataviz_edition.py
+++ b/lizmap/forms/dataviz_edition.py
@@ -95,7 +95,6 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
         self.x_field.setLayer(self.layer.currentLayer())
 
         self.type_graph.currentTextChanged.connect(self.check_form_graph_type)
-        # self.y_field_2.currentTextChanged.connect(self.check_y_2_field)
         self.add_trace.clicked.connect(self.add_new_trace)
         self.remove_trace.clicked.connect(self.remove_selection)
 

--- a/lizmap/forms/dataviz_edition.py
+++ b/lizmap/forms/dataviz_edition.py
@@ -113,6 +113,15 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
             self._edit_trace_row(row, trace)
         self.disable_more_trace()
 
+    def primary_keys_collection(self) -> list:
+        """Return the list of unique values in the collection."""
+        values = list()
+        for row in range(self.traces.rowCount()):
+            item = self.traces.item(row, 0)
+            cell = item.data(Qt.UserRole)
+            values.append(cell)
+        return values
+
     def save_collection(self) -> list:
         """Save a collection into JSON"""
         value = list()
@@ -162,7 +171,9 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
                 break
         else:
             raise Exception('Error with list')
-        dialog = TraceDatavizEditionDialog(self.parent, self.layer.currentLayer(), graph)
+
+        dialog = TraceDatavizEditionDialog(
+            self.parent, self.layer.currentLayer(), graph, self.primary_keys_collection())
         result = dialog.exec_()
         if result == QDialog.Accepted:
             data = dialog.save_form()

--- a/lizmap/forms/table_manager.py
+++ b/lizmap/forms/table_manager.py
@@ -307,6 +307,7 @@ class TableManager:
     def to_json(self, version=None):
         if not version:
             version = QgsSettings().value('lizmap/lizmap_web_client_version', DEFAULT_LWC_VERSION.value, str)
+            version = LwcVersions(version)
 
         data = dict()
 

--- a/lizmap/forms/table_manager.py
+++ b/lizmap/forms/table_manager.py
@@ -386,6 +386,9 @@ class TableManager:
                             definition = self.definitions.layer_config[key]
                             if j == 0:
                                 json_key = definition['plural'].format('')
+                                if json_key.endswith('_'):
+                                    # If the plural is at the end
+                                    json_key = json_key[:-1]
                             else:
                                 json_key = definition['plural'].format(j + 1)
 
@@ -503,6 +506,10 @@ class TableManager:
 
         for layer in data.get('layers'):
 
+            if layer.get('traces'):
+                # Already in the new format, we do nothing.
+                continue
+
             # Remove unused parameter
             if layer.get('has_y2_field'):
                 del layer['has_y2_field']
@@ -518,7 +525,8 @@ class TableManager:
                         del layer[key]
 
                 if one_trace:
-                    missing_field = one_trace.get('y_field') is None
+                    y_field = one_trace.get('y_field')
+                    missing_field = y_field is None or y_field == ''
                     if not missing_field:
                         # We skip if Y field is missing
                         layer['traces'].append(one_trace)

--- a/lizmap/forms/table_manager.py
+++ b/lizmap/forms/table_manager.py
@@ -242,7 +242,7 @@ class TableManager:
             elif input_type == InputType.Collection:
                 json_dump = json.dumps(value)
                 cell.setText(json_dump)
-                cell.setData(Qt.UserRole, json_dump)
+                cell.setData(Qt.UserRole, value)
                 function = self.definitions.layer_config[key]['represent_value']
                 cell.setData(Qt.ToolTipRole, function(value))
 
@@ -390,7 +390,7 @@ class TableManager:
 
             if self.definitions.key() == 'datavizLayers':
                 if version != LwcVersions.Lizmap_3_4:
-                    traces = eval(layer_data.pop('traces'))
+                    traces = layer_data.pop('traces')
                     for j, trace in enumerate(traces):
                         for key in trace:
                             definition = self.definitions.layer_config[key]

--- a/lizmap/forms/trace_dataviz_edition.py
+++ b/lizmap/forms/trace_dataviz_edition.py
@@ -27,22 +27,26 @@ CLASS = load_ui('ui_trace.ui')
 
 class TraceDatavizEditionDialog(QDialog, CLASS):
 
-    def __init__(self, parent, layer):
+    def __init__(self, parent, layer, graph):
         super().__init__(parent)
         self.config = DatavizDefinitions()
+        self._graph = graph
         self._layer = layer
         self.setupUi(self)
         self.setWindowTitle(tr('Dataviz Trace'))
 
-        self.field.setLayer(self._layer)
+        self.y_field.setLayer(self._layer)
         self.color_field.setLayer(self._layer)
+        self.z_field.setLayer(self._layer)
 
-        self.config.add_layer_widget('y_field', self.field)
+        self.config.add_layer_widget('y_field', self.y_field)
         self.config.add_layer_widget('colorfield', self.color_field)
         self.config.add_layer_widget('color', self.color)
+        self.config.add_layer_widget('z_field', self.z_field)
 
         self.config.add_layer_label('y_field', self.label_y_field)
         self.config.add_layer_label('colorfield', self.label_color)
+        self.config.add_layer_label('z_field', self.label_z_field)
 
         self.button_box.button(QDialogButtonBox.Cancel).clicked.connect(self.close)
         self.button_box.button(QDialogButtonBox.Ok).clicked.connect(self.accept)
@@ -56,6 +60,17 @@ class TraceDatavizEditionDialog(QDialog, CLASS):
         self.color_field.currentTextChanged.connect(self.check_y_color_field)
         self.check_y_color_field()
 
+        # Z Field
+        if graph == GraphType.Sunburst:
+            self.label_z_field.setVisible(True)
+            self.z_field.setVisible(True)
+            self.z_field.setAllowEmptyFieldName(False)
+        else:
+            self.label_z_field.setVisible(False)
+            self.z_field.setVisible(False)
+            self.z_field.setAllowEmptyFieldName(True)
+            self.z_field.setCurrentIndex(0)
+
     def check_y_color_field(self):
         if self.color_field.currentField() == '':
             self.color.setToDefaultColor()
@@ -65,8 +80,8 @@ class TraceDatavizEditionDialog(QDialog, CLASS):
             self.color.setEnabled(False)
 
     def validate(self):
-        if self.field.currentField() == '':
-            return tr('Field is required.')
+        if self.y_field.currentField() == '':
+            return tr('Y field is required.')
 
         return
 

--- a/lizmap/forms/trace_dataviz_edition.py
+++ b/lizmap/forms/trace_dataviz_edition.py
@@ -75,6 +75,12 @@ class TraceDatavizEditionDialog(QDialog, CLASS):
             self.z_field.setAllowEmptyFieldName(True)
             self.z_field.setCurrentIndex(0)
 
+        # Color field
+        histo_2d = self._graph == GraphType.Histogram2D
+        self.label_color.setVisible(not histo_2d)
+        self.color_field.setVisible(not histo_2d)
+        self.color.setVisible(not histo_2d)
+
     def check_y_color_field(self):
         if self.color_field.currentField() == '':
             self.color.setToDefaultColor()

--- a/lizmap/forms/trace_dataviz_edition.py
+++ b/lizmap/forms/trace_dataviz_edition.py
@@ -82,6 +82,7 @@ class TraceDatavizEditionDialog(QDialog, CLASS):
         self.color.setVisible(not histo_2d)
 
     def check_y_color_field(self):
+        """Enable or disable the color input."""
         if self.color_field.currentField() == '':
             self.color.setToDefaultColor()
             self.color.setEnabled(True)
@@ -104,6 +105,7 @@ class TraceDatavizEditionDialog(QDialog, CLASS):
             super().accept()
 
     def save_form(self) -> OrderedDict:
+        """Save the form into a dictionary."""
         data = OrderedDict()
 
         for key in self.config.layer_config['traces']['items']:
@@ -123,6 +125,7 @@ class TraceDatavizEditionDialog(QDialog, CLASS):
         return data
 
     def load_form(self, data: OrderedDict) -> None:
+        """Load a dictionary into the form."""
         for key in self.config.layer_config['traces']['items']:
             definition = self.config.layer_config[key]
             value = data.get(key)

--- a/lizmap/forms/trace_dataviz_edition.py
+++ b/lizmap/forms/trace_dataviz_edition.py
@@ -1,0 +1,114 @@
+"""Dialog for editing a trace in the dataviz window."""
+from collections import OrderedDict
+
+from qgis.PyQt.QtWidgets import QTableWidgetItem, QAbstractItemView, QDialog, QDialogButtonBox
+from qgis.core import (
+    QgsMapLayerProxyModel,
+    QgsProject,
+    QgsApplication,
+)
+from qgis.PyQt.QtGui import QIcon, QColor
+
+from lizmap.definitions.base import InputType
+from lizmap.definitions.dataviz import DatavizDefinitions, GraphType
+from lizmap.definitions.definitions import LwcVersions
+from lizmap.forms.base_edition_dialog import BaseEditionDialog
+from lizmap.qgis_plugin_tools.tools.i18n import tr
+from lizmap.qgis_plugin_tools.tools.resources import load_ui
+
+__copyright__ = 'Copyright 2020, 3Liz'
+__license__ = 'GPL version 3'
+__email__ = 'info@3liz.org'
+__revision__ = '$Format:%H$'
+
+
+CLASS = load_ui('ui_trace.ui')
+
+
+class TraceDatavizEditionDialog(QDialog, CLASS):
+
+    def __init__(self, parent, layer):
+        super().__init__(parent)
+        self.config = DatavizDefinitions()
+        self._layer = layer
+        self.setupUi(self)
+        self.setWindowTitle(tr('Dataviz Trace'))
+
+        self.field.setLayer(self._layer)
+        self.color_field.setLayer(self._layer)
+
+        self.config.add_layer_widget('y_field', self.field)
+        self.config.add_layer_widget('colorfield', self.color_field)
+        self.config.add_layer_widget('color', self.color)
+
+        self.config.add_layer_label('y_field', self.label_y_field)
+        self.config.add_layer_label('colorfield', self.label_color)
+
+        self.button_box.button(QDialogButtonBox.Cancel).clicked.connect(self.close)
+        self.button_box.button(QDialogButtonBox.Ok).clicked.connect(self.accept)
+        self.error.setVisible(False)
+
+        color_definition = self.config.layer_config['color']
+        self.color.setDefaultColor(QColor(color_definition['default']))
+        self.color.setToDefaultColor()
+
+        self.color_field.setAllowEmptyFieldName(True)
+        self.color_field.currentTextChanged.connect(self.check_y_color_field)
+        self.check_y_color_field()
+
+    def check_y_color_field(self):
+        if self.color_field.currentField() == '':
+            self.color.setToDefaultColor()
+            self.color.setEnabled(True)
+        else:
+            self.color.setToNull()
+            self.color.setEnabled(False)
+
+    def validate(self):
+        if self.field.currentField() == '':
+            return tr('Field is required.')
+
+        return
+
+    def accept(self):
+        message = self.validate()
+        if message:
+            self.error.setVisible(True)
+            self.error.setText(message)
+        else:
+            super().accept()
+
+    def save_form(self) -> OrderedDict:
+        data = OrderedDict()
+
+        for key in self.config.layer_config['traces']['items']:
+            definition = self.config.layer_config[key]
+            if definition['type'] == InputType.Field:
+                value = definition['widget'].currentField()
+            elif definition['type'] == InputType.Color:
+                widget = definition['widget']
+                if widget.isNull():
+                    value = ''
+                else:
+                    value = widget.color().name()
+            else:
+                raise Exception('InputType "{}" not implemented'.format(definition['type']))
+
+            data[key] = value
+        return data
+
+    def load_form(self, data: OrderedDict) -> None:
+        for key in self.config.layer_config['traces']['items']:
+            definition = self.config.layer_config[key]
+            value = data.get(key)
+            if definition['type'] == InputType.Field:
+                definition['widget'].setField(value)
+            elif definition['type'] == InputType.Color:
+                color = QColor(value)
+                if color.isValid():
+                    definition['widget'].setDefaultColor(color)
+                    definition['widget'].setColor(color)
+                else:
+                    definition['widget'].setToNull()
+            else:
+                raise Exception('InputType "{}" not implemented'.format(definition['type']))

--- a/lizmap/forms/trace_dataviz_edition.py
+++ b/lizmap/forms/trace_dataviz_edition.py
@@ -27,11 +27,12 @@ CLASS = load_ui('ui_trace.ui')
 
 class TraceDatavizEditionDialog(QDialog, CLASS):
 
-    def __init__(self, parent, layer, graph):
+    def __init__(self, parent, layer, graph, uniques):
         super().__init__(parent)
         self.config = DatavizDefinitions()
         self._graph = graph
         self._layer = layer
+        self.uniques = uniques
         self.setupUi(self)
         self.setWindowTitle(tr('Dataviz Trace'))
 
@@ -91,9 +92,11 @@ class TraceDatavizEditionDialog(QDialog, CLASS):
             self.color.setEnabled(False)
 
     def validate(self):
-        if self.y_field.currentField() == '':
+        y_field = self.y_field.currentField()
+        if y_field == '':
             return tr('Y field is required.')
-
+        if y_field in self.uniques:
+            return tr('This Y field is already existing.')
         return
 
     def accept(self):

--- a/lizmap/forms/trace_dataviz_edition.py
+++ b/lizmap/forms/trace_dataviz_edition.py
@@ -48,6 +48,10 @@ class TraceDatavizEditionDialog(QDialog, CLASS):
         self.config.add_layer_label('colorfield', self.label_color)
         self.config.add_layer_label('z_field', self.label_z_field)
 
+        self.y_field.setAllowEmptyFieldName(False)
+        self.z_field.setAllowEmptyFieldName(True)
+        self.color_field.setAllowEmptyFieldName(True)
+
         self.button_box.button(QDialogButtonBox.Cancel).clicked.connect(self.close)
         self.button_box.button(QDialogButtonBox.Ok).clicked.connect(self.accept)
         self.error.setVisible(False)
@@ -61,7 +65,7 @@ class TraceDatavizEditionDialog(QDialog, CLASS):
         self.check_y_color_field()
 
         # Z Field
-        if graph == GraphType.Sunburst:
+        if self._graph == GraphType.Sunburst:
             self.label_z_field.setVisible(True)
             self.z_field.setVisible(True)
             self.z_field.setAllowEmptyFieldName(False)

--- a/lizmap/resources/ui/ui_form_dataviz.ui
+++ b/lizmap/resources/ui/ui_form_dataviz.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>641</width>
-    <height>409</height>
+    <height>712</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,42 +26,16 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="11" column="1">
-      <widget class="QgsFieldComboBox" name="z_field"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_title">
-       <property name="text">
-        <string>Title</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
      <item row="4" column="1">
       <widget class="QgsFieldComboBox" name="x_field"/>
      </item>
-     <item row="12" column="1">
-      <widget class="QTextEdit" name="html_template"/>
-     </item>
      <item row="9" column="1">
-      <widget class="QgsFieldComboBox" name="y_field_2"/>
+      <widget class="QgsFieldComboBox" name="z_field"/>
      </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="label_y_color">
+     <item row="11" column="1">
+      <widget class="QCheckBox" name="stacked">
        <property name="text">
-        <string>Color Y</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QgsFieldComboBox" name="y_field"/>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_aggregation">
-       <property name="text">
-        <string>Aggregation</string>
+        <string>Stacked</string>
        </property>
       </widget>
      </item>
@@ -75,42 +49,15 @@
        </property>
       </widget>
      </item>
-     <item row="13" column="1">
-      <widget class="QCheckBox" name="stacked">
+     <item row="9" column="0">
+      <widget class="QLabel" name="label_z_field">
        <property name="text">
-        <string>Stacked</string>
-       </property>
-      </widget>
-     </item>
-     <item row="15" column="1">
-      <widget class="QCheckBox" name="popup_display_child_plot">
-       <property name="text">
-        <string>Display filtered plot in popups of parent layer</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
+        <string>Z field</string>
        </property>
       </widget>
      </item>
      <item row="10" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <item>
-        <widget class="QgsFieldComboBox" name="color_field_2"/>
-       </item>
-       <item>
-        <widget class="QgsColorButton" name="color_2">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="2" column="1">
-      <widget class="QPlainTextEdit" name="text_description"/>
+      <widget class="QTextEdit" name="html_template"/>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_description">
@@ -119,66 +66,53 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="label_y_field">
-       <property name="text">
-        <string>Y field</string>
-       </property>
-      </widget>
+     <item row="7" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QPushButton" name="add_trace">
+         <property name="text">
+          <string notr="true">+</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="remove_trace">
+         <property name="text">
+          <string notr="true">-</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="label_y_field_2">
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_title">
        <property name="text">
-        <string>Optional Y field 2</string>
+        <string>Title</string>
        </property>
-      </widget>
-     </item>
-     <item row="16" column="1">
-      <widget class="QCheckBox" name="only_show_child">
-       <property name="text">
-        <string>Only show in child popup</string>
-       </property>
-       <property name="checked">
+       <property name="wordWrap">
         <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="14" column="1">
-      <widget class="QCheckBox" name="horizontal">
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_traces">
        <property name="text">
-        <string>Horizontal</string>
+        <string>Traces</string>
        </property>
       </widget>
-     </item>
-     <item row="12" column="0">
-      <widget class="QLabel" name="label_html_template">
-       <property name="text">
-        <string>HTML template</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QgsMapLayerComboBox" name="layer"/>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="type_graph"/>
-     </item>
-     <item row="7" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="QgsFieldComboBox" name="color_field"/>
-       </item>
-       <item>
-        <widget class="QgsColorButton" name="color">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-      </layout>
      </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_layer">
@@ -187,24 +121,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="title"/>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_x_field">
-       <property name="text">
-        <string>X field</string>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="label_y_color_2">
-       <property name="text">
-        <string>Color Y 2</string>
-       </property>
-      </widget>
-     </item>
-     <item row="17" column="1">
+     <item row="15" column="1">
       <widget class="QCheckBox" name="display_legend">
        <property name="text">
         <string>Display the legend</string>
@@ -214,19 +131,75 @@
        </property>
       </widget>
      </item>
-     <item row="11" column="0">
-      <widget class="QLabel" name="label_z_field">
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="title"/>
+     </item>
+     <item row="3" column="1">
+      <widget class="QgsMapLayerComboBox" name="layer"/>
+     </item>
+     <item row="12" column="1">
+      <widget class="QCheckBox" name="horizontal">
        <property name="text">
-        <string>Z field</string>
+        <string>Horizontal</string>
        </property>
       </widget>
      </item>
-     <item row="18" column="1">
+     <item row="14" column="1">
+      <widget class="QCheckBox" name="only_show_child">
+       <property name="text">
+        <string>Only show in child popup</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="16" column="1">
       <widget class="QCheckBox" name="display_when_layer_visible">
        <property name="text">
         <string>Display plot only when the layer is visible</string>
        </property>
       </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QPlainTextEdit" name="text_description"/>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="type_graph"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_x_field">
+       <property name="text">
+        <string>X field</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="label_html_template">
+       <property name="text">
+        <string>HTML template</string>
+       </property>
+      </widget>
+     </item>
+     <item row="13" column="1">
+      <widget class="QCheckBox" name="popup_display_child_plot">
+       <property name="text">
+        <string>Display filtered plot in popups of parent layer</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_aggregation">
+       <property name="text">
+        <string>Aggregation</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QTableWidget" name="traces"/>
      </item>
     </layout>
    </item>
@@ -256,11 +229,6 @@
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgis.gui</header>
-  </customwidget>
   <customwidget>
    <class>QgsFieldComboBox</class>
    <extends>QComboBox</extends>

--- a/lizmap/resources/ui/ui_form_dataviz.ui
+++ b/lizmap/resources/ui/ui_form_dataviz.ui
@@ -26,21 +26,36 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="4" column="1">
-      <widget class="QgsFieldComboBox" name="x_field"/>
-     </item>
-     <item row="9" column="1">
-      <widget class="QgsFieldComboBox" name="z_field"/>
-     </item>
-     <item row="11" column="1">
-      <widget class="QCheckBox" name="stacked">
+     <item row="9" column="0">
+      <widget class="QLabel" name="label_html_template">
        <property name="text">
-        <string>Stacked</string>
+        <string>HTML template</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QComboBox" name="aggregation"/>
+     <item row="15" column="1">
+      <widget class="QCheckBox" name="display_when_layer_visible">
+       <property name="text">
+        <string>Display plot only when the layer is visible</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_traces">
+       <property name="text">
+        <string>Traces</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_description">
+       <property name="text">
+        <string>Description</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="type_graph"/>
      </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label_type">
@@ -49,20 +64,20 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="label_z_field">
+     <item row="12" column="1">
+      <widget class="QCheckBox" name="popup_display_child_plot">
        <property name="text">
-        <string>Z field</string>
+        <string>Display filtered plot in popups of parent layer</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
-      <widget class="QTextEdit" name="html_template"/>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_description">
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_x_field">
        <property name="text">
-        <string>Description</string>
+        <string>X field</string>
        </property>
       </widget>
      </item>
@@ -107,44 +122,26 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="label_traces">
+     <item row="6" column="1">
+      <widget class="QTableWidget" name="traces"/>
+     </item>
+     <item row="5" column="1">
+      <widget class="QComboBox" name="aggregation"/>
+     </item>
+     <item row="2" column="1">
+      <widget class="QPlainTextEdit" name="text_description"/>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_aggregation">
        <property name="text">
-        <string>Traces</string>
+        <string>Aggregation</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_layer">
-       <property name="text">
-        <string>Layer</string>
-       </property>
-      </widget>
+     <item row="9" column="1">
+      <widget class="QTextEdit" name="html_template"/>
      </item>
-     <item row="15" column="1">
-      <widget class="QCheckBox" name="display_legend">
-       <property name="text">
-        <string>Display the legend</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="title"/>
-     </item>
-     <item row="3" column="1">
-      <widget class="QgsMapLayerComboBox" name="layer"/>
-     </item>
-     <item row="12" column="1">
-      <widget class="QCheckBox" name="horizontal">
-       <property name="text">
-        <string>Horizontal</string>
-       </property>
-      </widget>
-     </item>
-     <item row="14" column="1">
+     <item row="13" column="1">
       <widget class="QCheckBox" name="only_show_child">
        <property name="text">
         <string>Only show in child popup</string>
@@ -154,52 +151,45 @@
        </property>
       </widget>
      </item>
-     <item row="16" column="1">
-      <widget class="QCheckBox" name="display_when_layer_visible">
+     <item row="3" column="1">
+      <widget class="QgsMapLayerComboBox" name="layer"/>
+     </item>
+     <item row="10" column="1">
+      <widget class="QCheckBox" name="stacked">
        <property name="text">
-        <string>Display plot only when the layer is visible</string>
+        <string>Stacked</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QPlainTextEdit" name="text_description"/>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="type_graph"/>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_x_field">
+     <item row="11" column="1">
+      <widget class="QCheckBox" name="horizontal">
        <property name="text">
-        <string>X field</string>
+        <string>Horizontal</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="label_html_template">
-       <property name="text">
-        <string>HTML template</string>
-       </property>
-      </widget>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="title"/>
      </item>
-     <item row="13" column="1">
-      <widget class="QCheckBox" name="popup_display_child_plot">
+     <item row="4" column="1">
+      <widget class="QgsFieldComboBox" name="x_field"/>
+     </item>
+     <item row="14" column="1">
+      <widget class="QCheckBox" name="display_legend">
        <property name="text">
-        <string>Display filtered plot in popups of parent layer</string>
+        <string>Display the legend</string>
        </property>
        <property name="checked">
         <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_aggregation">
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_layer">
        <property name="text">
-        <string>Aggregation</string>
+        <string>Layer</string>
        </property>
       </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QTableWidget" name="traces"/>
      </item>
     </layout>
    </item>

--- a/lizmap/resources/ui/ui_form_dataviz.ui
+++ b/lizmap/resources/ui/ui_form_dataviz.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>770</width>
-    <height>702</height>
+    <width>641</width>
+    <height>409</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/lizmap/resources/ui/ui_trace.ui
+++ b/lizmap/resources/ui/ui_trace.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>334</width>
-    <height>132</height>
+    <width>387</width>
+    <height>187</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,9 +16,6 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="1">
-      <widget class="QgsFieldComboBox" name="field"/>
-     </item>
      <item row="1" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
@@ -42,6 +39,19 @@
         <string>Color</string>
        </property>
       </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QgsFieldComboBox" name="y_field"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_z_field">
+       <property name="text">
+        <string>Z field</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QgsFieldComboBox" name="z_field"/>
      </item>
     </layout>
    </item>

--- a/lizmap/resources/ui/ui_trace.ui
+++ b/lizmap/resources/ui/ui_trace.ui
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>334</width>
+    <height>132</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dataviz</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="1">
+      <widget class="QgsFieldComboBox" name="field"/>
+     </item>
+     <item row="1" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QgsFieldComboBox" name="color_field"/>
+       </item>
+       <item>
+        <widget class="QgsColorButton" name="color"/>
+       </item>
+      </layout>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_y_field">
+       <property name="text">
+        <string>Y field</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_color">
+       <property name="text">
+        <string>Color</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="error">
+     <property name="styleSheet">
+      <string notr="true">QLabel { color : red; }</string>
+     </property>
+     <property name="text">
+      <string notr="true">ERROR</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgis.gui</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgis.gui</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/lizmap/test/test_dialog_edition.py
+++ b/lizmap/test/test_dialog_edition.py
@@ -1,10 +1,14 @@
 """Test Lizmap dialog form edition."""
 
-from qgis.core import QgsVectorLayer, QgsProject
+from qgis.core import (
+    QgsVectorLayer,
+    QgsProject,
+)
 from qgis.testing import unittest
 
 from lizmap.qgis_plugin_tools.tools.resources import plugin_test_data_path
 from lizmap.forms.atlas_edition import AtlasEditionDialog
+from lizmap.forms.dataviz_edition import DatavizEditionDialog
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'
@@ -14,12 +18,43 @@ __revision__ = '$Format:%H$'
 
 class TestEditionDialog(unittest.TestCase):
 
+    def setUp(self) -> None:
+        self.layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
+        QgsProject.instance().addMapLayer(self.layer)
+        self.assertTrue(self.layer.isValid())
+
+    def tearDown(self) -> None:
+        del self.layer
+
+    def test_load_save_collection_dataviz(self):
+        """Test we can load collection."""
+        dialog = DatavizEditionDialog()
+        self.assertFalse(dialog.error.isVisible())
+        self.assertEqual(dialog.validate(), 'The field "x field" is mandatory.')
+
+        data = [
+            {
+                'color': '#db06b1',
+                'colorfield': '',
+                'y_field': 'distance',
+                'z_field': '',
+            }, {
+                'color': '',
+                'colorfield': 'id',
+                'y_field': 'cat_name',
+                'z_field': '',
+            }
+        ]
+        self.assertEqual(0, dialog.traces.rowCount())
+        dialog.load_collection(data)
+        self.assertEqual(2, dialog.traces.rowCount())
+
+        result = dialog.save_collection()
+        self.assertCountEqual(result, data)
+
+
     def test_atlas_dialog(self):
         """Test atlas dialog."""
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
-        QgsProject.instance().addMapLayer(layer)
-        self.assertTrue(layer.isValid())
-
         dialog = AtlasEditionDialog()
         self.assertFalse(dialog.error.isVisible())
 
@@ -34,12 +69,12 @@ class TestEditionDialog(unittest.TestCase):
         data = dialog.save_form()
         self.assertEqual(len(data), len(dialog.config.layer_config.keys()))
 
-        first_field = layer.fields().at(0).name()
+        first_field = self.layer.fields().at(0).name()
 
         for key, value in data.items():
 
             if key == 'layer':
-                self.assertEqual(value, layer.id())
+                self.assertEqual(value, self.layer.id())
             elif key in ['primaryKey', 'featureLabel', 'sortField']:
                 pass
                 # self.assertEqual(value, first_field)

--- a/lizmap/test/test_dialog_edition.py
+++ b/lizmap/test/test_dialog_edition.py
@@ -52,7 +52,6 @@ class TestEditionDialog(unittest.TestCase):
         result = dialog.save_collection()
         self.assertCountEqual(result, data)
 
-
     def test_atlas_dialog(self):
         """Test atlas dialog."""
         dialog = AtlasEditionDialog()

--- a/lizmap/test/test_table_manager.py
+++ b/lizmap/test/test_table_manager.py
@@ -144,45 +144,6 @@ class TestTableManager(unittest.TestCase):
         ]
         self.assertListEqual(expected, table_manager.keys)
 
-    def test_dataviz(self):
-        """Test we can read dataviz 3.4."""
-        table = QTableWidget()
-        definitions = EditionDefinitions()
-
-        table_manager = TableManager(
-            None, definitions, None, table, None, None, None, None)
-
-        json = {
-            '0': {
-                'title': 'My graph',
-                'type': 'scatter',
-                'x_field': 'id',
-                'aggregation': '',
-                'traces': [
-                    {
-                        'y_field': 'name',
-                        'color': '#00aaff',
-                        'colorfield': '',
-                    }, {
-                        'y_field': 'name',
-                        'color': '#00aaff',
-                        'colorfield': '',
-                    },
-                ],
-                'popup_display_child_plot': 'False',
-                'only_show_child': 'True',
-                'layerId': 'fake_id',
-                'order': 0
-            }
-        }
-
-        json_legacy = table_manager._from_json_legacy_order(copy.deepcopy(json))
-        print(json_legacy)
-
-        # self.assertEqual(table_manager.table.rowCount(), 0)
-        # table_manager.from_json(json)
-        # self.assertEqual(table_manager.table.rowCount(), 1)
-
     def test_remove_extra_field_dataviz(self):
         """Test we can remove an empty field from a trace."""
         table = QTableWidget()
@@ -380,6 +341,46 @@ class TestTableManager(unittest.TestCase):
             }
         }
         self.assertDictEqual(data, expected)
+
+    @unittest.expectedFailure
+    def test_dataviz(self):
+        """Test we can read dataviz 3.4."""
+        table = QTableWidget()
+        definitions = EditionDefinitions()
+
+        table_manager = TableManager(
+            None, definitions, None, table, None, None, None, None)
+
+        json = {
+            '0': {
+                'title': 'My graph',
+                'type': 'scatter',
+                'x_field': 'id',
+                'aggregation': '',
+                'traces': [
+                    {
+                        'y_field': 'name',
+                        'color': '#00aaff',
+                        'colorfield': '',
+                    }, {
+                        'y_field': 'name',
+                        'color': '#00aaff',
+                        'colorfield': '',
+                    },
+                ],
+                'popup_display_child_plot': 'False',
+                'only_show_child': 'True',
+                'layerId': 'fake_id',
+                'order': 0
+            }
+        }
+
+        json_legacy = table_manager._from_json_legacy_order(copy.deepcopy(json))
+        print(json_legacy)
+
+        self.assertEqual(table_manager.table.rowCount(), 0)
+        table_manager.from_json(json)
+        self.assertEqual(table_manager.table.rowCount(), 1)
 
     @unittest.expectedFailure
     def test_dataviz_legacy_3_4(self):

--- a/lizmap/test/test_table_manager.py
+++ b/lizmap/test/test_table_manager.py
@@ -342,9 +342,8 @@ class TestTableManager(unittest.TestCase):
         }
         self.assertDictEqual(data, expected)
 
-    @unittest.expectedFailure
     def test_dataviz(self):
-        """Test we can read dataviz 3.4."""
+        """Test we can read dataviz 3.4 format."""
         table = QTableWidget()
         definitions = EditionDefinitions()
 
@@ -381,123 +380,6 @@ class TestTableManager(unittest.TestCase):
         self.assertEqual(table_manager.table.rowCount(), 0)
         table_manager.from_json(json)
         self.assertEqual(table_manager.table.rowCount(), 1)
-
-    @unittest.expectedFailure
-    def test_dataviz_legacy_3_4(self):
-        table = QTableWidget()
-        definitions = DatavizDefinitions()
-
-        table_manager = TableManager(
-            None, definitions, None, table, None, None, None, None)
-
-        # Lizmap 3.4
-        json = {
-            '0': {
-                'title': 'My graph',
-                'type': 'scatter',
-                'description': '<b>Hello</b>',
-                'x_field': 'id',
-                'aggregation': '',
-                'y_field': 'name',
-                'color': '#00aaff',
-                'colorfield': '',
-                'has_y2_field': 'True',
-                'y2_field': 'name',
-                'color2': '#ffaa00',
-                'colorfield2': '',
-                'stacked': 'False',
-                'horizontal': 'False',
-                'popup_display_child_plot': 'False',
-                'only_show_child': 'True',
-                'display_when_layer_visible': 'False',
-                'layerId': self.layer.id(),
-                'order': 0
-            }
-        }
-
-        json_legacy = table_manager._from_json_legacy_order(copy.deepcopy(json))
-
-        expected = {
-            'layers': [
-                {
-                    'title': 'My graph',
-                    'type': 'scatter',
-                    'x_field': 'id',
-                    'aggregation': '',
-                    'y_field': 'name',
-                    'color': '#00aaff',
-                    'colorfield': '',
-                    'has_y2_field': 'True',
-                    'y2_field': 'name',
-                    'color2': '#ffaa00',
-                    'colorfield2': '',
-                    'popup_display_child_plot': 'False',
-                    'only_show_child': 'True',
-                    'layerId': self.layer.id(),
-                    'order': 0
-                }
-            ]
-        }
-        self.assertDictEqual(expected, json_legacy)
-
-        json_legacy = table_manager._from_json_legacy_dataviz(json_legacy)
-
-        expected = {
-            'layers': [
-                {
-                    'title': 'My graph',
-                    'type': 'scatter',
-                    'x_field': 'id',
-                    'aggregation': '',
-                    'popup_display_child_plot': 'False',
-                    'only_show_child': 'True',
-                    'layerId': self.layer.id(),
-                    'order': 0,
-                    'traces': [
-                        {
-                            'y_field': 'name',
-                            'color': '#00aaff',
-                            'colorfield': '',
-                        }, {
-                            'y_field': 'name',
-                            'color': '#ffaa00',
-                            'colorfield': '',
-                        }
-                    ]
-                }
-            ]
-        }
-        self.assertDictEqual(expected, json_legacy)
-
-        table_manager.truncate()
-        self.assertEqual(table_manager.table.rowCount(), 0)
-        table_manager.from_json(json)
-        self.assertEqual(table_manager.table.rowCount(), 1)
-        # data = table_manager.to_json()
-
-        expected = {
-            '0': {
-                'title': 'My graph',
-                'type': 'scatter',
-                'x_field': 'id',
-                'description': '<b>Hello</b>',
-                'aggregation': 'sum',
-                'display_legend': 'True',
-                'y_field': 'name',
-                'color': '#00aaff',
-                'y2_field': 'name',
-                'color2': '#ffaa00',
-                'stacked': 'False',
-                'horizontal': 'False',
-                'popup_display_child_plot': 'False',
-                'only_show_child': 'True',
-                'display_when_layer_visible': 'False',
-                'layerId': self.layer.id(),
-                'order': 0
-            }
-        }
-
-        # self.assertDictEqual(data, expected)
 
     def test_tool_tip(self):
         """Test table manager with tooltip layer."""

--- a/lizmap/test/test_table_manager.py
+++ b/lizmap/test/test_table_manager.py
@@ -32,13 +32,16 @@ class TestTableManager(unittest.TestCase):
 
     def setUp(self) -> None:
         self.maxDiff = None
+        self.layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
+        QgsProject.instance().addMapLayer(self.layer)
+        self.assertTrue(self.layer.isValid())
+
+    def tearDown(self) -> None:
+        QgsProject.instance().removeMapLayer(self.layer)
+        del self.layer
 
     def test_form_filter(self):
         """Test table manager with filter by form."""
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
-        QgsProject.instance().addMapLayer(layer)
-        self.assertTrue(layer.isValid())
-
         table = QTableWidget()
         definitions = FilterByFormDefinitions()
 
@@ -55,7 +58,7 @@ class TestTableManager(unittest.TestCase):
                 'format': 'checkboxes',
                 'splitter': '',
                 'provider': 'ogr',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             },
             '1': {
@@ -67,7 +70,7 @@ class TestTableManager(unittest.TestCase):
                 'format': 'checkboxes',
                 'splitter': '',
                 'provider': 'ogr',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 1
             }
         }
@@ -79,7 +82,7 @@ class TestTableManager(unittest.TestCase):
 
         expected = {
             '0': {
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'provider': 'ogr',  # Added automatically on the fly
                 'title': 'Line filtering',
                 'type': 'text',
@@ -88,7 +91,7 @@ class TestTableManager(unittest.TestCase):
                 'order': 0
             },
             '1': {
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'provider': 'ogr',  # Added automatically on the fly
                 'title': 'Line filtering',
                 'type': 'numeric',
@@ -101,10 +104,6 @@ class TestTableManager(unittest.TestCase):
 
     def test_filter_by_login(self):
         """Test table manager with filter by login."""
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
-        QgsProject.instance().addMapLayer(layer)
-        self.assertTrue(layer.isValid())
-
         table = QTableWidget()
         definitions = FilterByLoginDefinitions()
 
@@ -115,7 +114,7 @@ class TestTableManager(unittest.TestCase):
             'lines': {
                 'filterAttribute': 'name',
                 'filterPrivate': 'False',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
@@ -128,19 +127,25 @@ class TestTableManager(unittest.TestCase):
             'lines': {
                 'filterAttribute': 'name',
                 'filterPrivate': 'False',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
         self.assertDictEqual(data, expected)
 
-    @unittest.skip
-    def test_dataviz_legacy_read_trace(self):
-        """Test we can read traces from legacy 3.3."""
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
-        QgsProject.instance().addMapLayer(layer)
-        self.assertTrue(layer.isValid())
+    def test_dataviz_definitions(self):
+        """Test dataviz collections keys."""
+        table_manager = TableManager(
+            None, DatavizDefinitions(), None, QTableWidget(), None, None, None, None)
+        expected = [
+            'type', 'title', 'description', 'layerId', 'x_field', 'aggregation',
+            'traces', 'html_template', 'popup_display_child_plot', 'stacked',
+            'horizontal', 'only_show_child', 'display_legend', 'display_when_layer_visible',
+        ]
+        self.assertListEqual(expected, table_manager.keys)
 
+    def test_dataviz(self):
+        """Test we can read dataviz 3.4."""
         table = QTableWidget()
         definitions = EditionDefinitions()
 
@@ -180,11 +185,6 @@ class TestTableManager(unittest.TestCase):
 
     def test_remove_extra_field_dataviz(self):
         """Test we can remove an empty field from a trace."""
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
-
-        QgsProject.instance().addMapLayer(layer)
-        self.assertTrue(layer.isValid())
-
         table = QTableWidget()
         definitions = DatavizDefinitions()
 
@@ -207,7 +207,7 @@ class TestTableManager(unittest.TestCase):
                 'colorfield2': '',
                 'popup_display_child_plot': 'False',
                 'only_show_child': 'True',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
@@ -222,7 +222,7 @@ class TestTableManager(unittest.TestCase):
                     'aggregation': '',
                     'popup_display_child_plot': 'False',
                     'only_show_child': 'True',
-                    'layerId': layer.id(),
+                    'layerId': self.layer.id(),
                     'order': 0,
                     'traces': [
                         {
@@ -238,11 +238,6 @@ class TestTableManager(unittest.TestCase):
 
     def test_dataviz_legacy_3_3(self):
         """Test table manager with dataviz format 3.3."""
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
-
-        QgsProject.instance().addMapLayer(layer)
-        self.assertTrue(layer.isValid())
-
         table = QTableWidget()
         definitions = DatavizDefinitions()
 
@@ -265,7 +260,7 @@ class TestTableManager(unittest.TestCase):
                 'colorfield2': '',
                 'popup_display_child_plot': 'False',
                 'only_show_child': 'True',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
@@ -286,7 +281,7 @@ class TestTableManager(unittest.TestCase):
                     'colorfield2': '',
                     'popup_display_child_plot': 'False',
                     'only_show_child': 'True',
-                    'layerId': layer.id(),
+                    'layerId': self.layer.id(),
                     'order': 0
                 }
             ]
@@ -303,7 +298,7 @@ class TestTableManager(unittest.TestCase):
                     'aggregation': '',
                     'popup_display_child_plot': 'False',
                     'only_show_child': 'True',
-                    'layerId': layer.id(),
+                    'layerId': self.layer.id(),
                     'order': 0,
                     'traces': [
                         {
@@ -350,7 +345,7 @@ class TestTableManager(unittest.TestCase):
                 'popup_display_child_plot': 'False',
                 'only_show_child': 'True',
                 'display_when_layer_visible': 'False',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
@@ -380,7 +375,7 @@ class TestTableManager(unittest.TestCase):
                 'popup_display_child_plot': 'False',
                 'only_show_child': 'True',
                 'display_when_layer_visible': 'False',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
@@ -388,12 +383,6 @@ class TestTableManager(unittest.TestCase):
 
     @unittest.expectedFailure
     def test_dataviz_legacy_3_4(self):
-
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
-
-        QgsProject.instance().addMapLayer(layer)
-        self.assertTrue(layer.isValid())
-
         table = QTableWidget()
         definitions = DatavizDefinitions()
 
@@ -420,7 +409,7 @@ class TestTableManager(unittest.TestCase):
                 'popup_display_child_plot': 'False',
                 'only_show_child': 'True',
                 'display_when_layer_visible': 'False',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
@@ -443,7 +432,7 @@ class TestTableManager(unittest.TestCase):
                     'colorfield2': '',
                     'popup_display_child_plot': 'False',
                     'only_show_child': 'True',
-                    'layerId': layer.id(),
+                    'layerId': self.layer.id(),
                     'order': 0
                 }
             ]
@@ -461,7 +450,7 @@ class TestTableManager(unittest.TestCase):
                     'aggregation': '',
                     'popup_display_child_plot': 'False',
                     'only_show_child': 'True',
-                    'layerId': layer.id(),
+                    'layerId': self.layer.id(),
                     'order': 0,
                     'traces': [
                         {
@@ -502,7 +491,7 @@ class TestTableManager(unittest.TestCase):
                 'popup_display_child_plot': 'False',
                 'only_show_child': 'True',
                 'display_when_layer_visible': 'False',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
@@ -511,11 +500,6 @@ class TestTableManager(unittest.TestCase):
 
     def test_tool_tip(self):
         """Test table manager with tooltip layer."""
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
-
-        QgsProject.instance().addMapLayer(layer)
-        self.assertTrue(layer.isValid())
-
         table = QTableWidget()
         definitions = ToolTipDefinitions()
 
@@ -527,7 +511,7 @@ class TestTableManager(unittest.TestCase):
                 'fields': 'id,name',
                 'displayGeom': 'False',
                 'colorGeom': '',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
@@ -540,11 +524,6 @@ class TestTableManager(unittest.TestCase):
 
     def test_attribute_table(self):
         """Test table manager with attribute table."""
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
-
-        QgsProject.instance().addMapLayer(layer)
-        self.assertTrue(layer.isValid())
-
         table = QTableWidget()
         definitions = AttributeTableDefinitions()
 
@@ -558,7 +537,7 @@ class TestTableManager(unittest.TestCase):
                 'pivot': 'False',
                 'hideAsChild': 'False',
                 'hideLayer': 'False',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
@@ -570,11 +549,6 @@ class TestTableManager(unittest.TestCase):
 
     def test_time_manager_table(self):
         """Test table manager with time manager."""
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
-
-        QgsProject.instance().addMapLayer(layer)
-        self.assertTrue(layer.isValid())
-
         table = QTableWidget()
         definitions = TimeManagerDefinitions()
 
@@ -588,7 +562,7 @@ class TestTableManager(unittest.TestCase):
                 'label': 'name',
                 'group': 'fake',
                 'groupTitle': 'fake',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
@@ -600,7 +574,7 @@ class TestTableManager(unittest.TestCase):
             'lines': {
                 'startAttribute': 'id',
                 'attributeResolution': 'years',  # missing from the input, default value in definitions
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
@@ -612,7 +586,7 @@ class TestTableManager(unittest.TestCase):
         json = {
             'lines': {
                 'startAttribute': 'id',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
@@ -630,7 +604,7 @@ class TestTableManager(unittest.TestCase):
                 'startAttribute': 'id',
                 'endAttribute': 'id',
                 'attributeResolution': 'minutes',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 0
             }
         }
@@ -642,10 +616,6 @@ class TestTableManager(unittest.TestCase):
 
     def test_edition_layer(self):
         """Test table manager with edition layer."""
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
-        QgsProject.instance().addMapLayer(layer)
-        self.assertTrue(layer.isValid())
-
         table = QTableWidget()
         definitions = EditionDefinitions()
 
@@ -654,7 +624,7 @@ class TestTableManager(unittest.TestCase):
 
         json = {
             'lines': {
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'geometryType': 'line',
                 'capabilities': {
                     'createFeature': 'True',
@@ -663,7 +633,7 @@ class TestTableManager(unittest.TestCase):
                     'deleteFeature': 'True'
                 },
                 'acl': 'edition_group',
-                'snap_layers': layer.id(),
+                'snap_layers': self.layer.id(),
                 'snap_segments': 'False',
                 'snap_intersections': 'True',
                 'order': 0
@@ -674,13 +644,13 @@ class TestTableManager(unittest.TestCase):
         expected = {
             'layers': [
                 {
-                    'layerId': layer.id(),
+                    'layerId': self.layer.id(),
                     'createFeature': 'True',
                     'modifyAttribute': 'True',
                     'modifyGeometry': 'True',
                     'deleteFeature': 'True',
                     'acl': 'edition_group',
-                    'snap_layers': layer.id(),
+                    'snap_layers': self.layer.id(),
                     'snap_segments': 'False',
                     'snap_intersections': 'True',
                     'order': 0
@@ -695,7 +665,7 @@ class TestTableManager(unittest.TestCase):
         data = table_manager.to_json()
         json = {
             'lines': {
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'geometryType': 'line',
                 'capabilities': {
                     'createFeature': 'True',
@@ -704,7 +674,7 @@ class TestTableManager(unittest.TestCase):
                     'deleteFeature': 'True'
                 },
                 'acl': 'edition_group',
-                'snap_layers': layer.id(),
+                'snap_layers': self.layer.id(),
                 'snap_nodes': 'False',
                 'snap_segments': 'False',
                 'snap_intersections': 'True',
@@ -715,12 +685,8 @@ class TestTableManager(unittest.TestCase):
 
     def test_locate_by_layer(self):
         """Test table manager with locate by layer."""
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
         layer_2 = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines_2', 'ogr')
-
-        QgsProject.instance().addMapLayer(layer)
         QgsProject.instance().addMapLayer(layer_2)
-        self.assertTrue(layer.isValid())
         self.assertTrue(layer_2.isValid())
 
         table = QTableWidget()
@@ -736,7 +702,7 @@ class TestTableManager(unittest.TestCase):
                 'displayGeom': 'True',
                 'minLength': 0,
                 'filterOnLocate': 'False',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 1
             },
             'lines_2': {
@@ -769,7 +735,7 @@ class TestTableManager(unittest.TestCase):
                     'displayGeom': 'True',
                     'minLength': 0,
                     'filterOnLocate': 'False',
-                    'layerId': layer.id(),
+                    'layerId': self.layer.id(),
                     'order': 1
                 },
             ]
@@ -796,7 +762,7 @@ class TestTableManager(unittest.TestCase):
                 'displayGeom': 'True',
                 'minLength': 0,
                 'filterOnLocate': 'False',
-                'layerId': layer.id(),
+                'layerId': self.layer.id(),
                 'order': 1
             },
         }
@@ -841,11 +807,7 @@ class TestTableManager(unittest.TestCase):
         Edit existing new row
         are not tested
         """
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
         field = 'id'
-        QgsProject.instance().addMapLayer(layer)
-        self.assertTrue(layer.isValid())
-
         table = QTableWidget()
         definitions = AtlasDefinitions()
         definitions._use_single_row = False
@@ -857,7 +819,7 @@ class TestTableManager(unittest.TestCase):
 
         # JSON from LWC 3.4 and above
         layer_1 = {
-            'layer': layer.id(),
+            'layer': self.layer.id(),
             'primaryKey': field,
             'displayLayerDescription': 'False',
             'featureLabel': 'name',
@@ -882,7 +844,7 @@ class TestTableManager(unittest.TestCase):
         # QGIS notify layer has been deleted
         table_manager.layers_has_been_deleted(['another_layer_ID_in_canvas'])
         self.assertEqual(table_manager.table.rowCount(), 1)
-        table_manager.layers_has_been_deleted([layer.id()])
+        table_manager.layers_has_been_deleted([self.layer.id()])
         self.assertEqual(table_manager.table.rowCount(), 0)
 
         data = table_manager.to_json()
@@ -903,7 +865,7 @@ class TestTableManager(unittest.TestCase):
 
         # noinspection PyProtectedMember
         self.assertDictEqual(
-            {'layer': [layer.id(), layer.id()]},
+            {'layer': [self.layer.id(), self.layer.id()]},
             table_manager._primary_keys()
         )
 
@@ -944,9 +906,6 @@ class TestTableManager(unittest.TestCase):
 
     def test_atlas_missing_json_parameter(self):
         """Test if we can load CFG file with missing parameter."""
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
-        QgsProject.instance().addMapLayer(layer)
-
         table = QTableWidget()
 
         definitions = AtlasDefinitions()
@@ -957,7 +916,7 @@ class TestTableManager(unittest.TestCase):
         json = {
             'layers': [
                 {
-                    'layer': layer.id(),
+                    'layer': self.layer.id(),
                     'primaryKey': 'id',
                     'displayLayerDescription': 'False',
                     'featureLabel': 'name',
@@ -990,18 +949,14 @@ class TestTableManager(unittest.TestCase):
 
     def test_table_manager_3_3(self):
         """Test we can read/write to LWC 3.3 format."""
-        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
         field = 'id'
-        QgsProject.instance().addMapLayer(layer)
-        self.assertTrue(layer.isValid())
-
         table = QTableWidget()
         definitions = AtlasDefinitions()
         definitions._use_single_row = False
 
         json = {
             'atlasEnabled': 'True',  # Will not be used
-            'atlasLayer': layer.id(),
+            'atlasLayer': self.layer.id(),
             'atlasPrimaryKey': field,
             'atlasDisplayLayerDescription': 'True',
             'atlasFeatureLabel': 'inf3_o_t',
@@ -1023,7 +978,7 @@ class TestTableManager(unittest.TestCase):
         expected = {
             'layers': [
                 {
-                    'layer': layer.id(),
+                    'layer': self.layer.id(),
                     'primaryKey': field,
                     'displayLayerDescription': 'True',
                     'featureLabel': 'inf3_o_t',
@@ -1044,7 +999,7 @@ class TestTableManager(unittest.TestCase):
         expected = {
             'atlasEnabled': 'True',  # Hard coded for Lizmap 3.3
             'atlasMaxWidth': 25,  # will not be used
-            'atlasLayer': layer.id(),
+            'atlasLayer': self.layer.id(),
             'atlasPrimaryKey': 'id',
             'atlasDisplayLayerDescription': 'True',
             'atlasFeatureLabel': 'inf3_o_t',

--- a/lizmap/test/test_table_manager.py
+++ b/lizmap/test/test_table_manager.py
@@ -355,7 +355,7 @@ class TestTableManager(unittest.TestCase):
             }
         }
         expected_traces = expected['0'].pop('traces')
-        data_traces = eval(data['0'].pop('traces'))
+        data_traces = data['0'].pop('traces')
         self.assertDictEqual(data, expected)
         for exp, got in zip(expected_traces, data_traces):
             self.assertDictEqual(exp, got)

--- a/lizmap/test/test_trace_dialog.py
+++ b/lizmap/test/test_trace_dialog.py
@@ -16,7 +16,6 @@ __revision__ = '$Format:%H$'
 
 class TestTraceDialog(unittest.TestCase):
 
-    @unittest.expectedFailure
     def test_z_field(self):
         """Test Z field is visible or not."""
         layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
@@ -25,8 +24,9 @@ class TestTraceDialog(unittest.TestCase):
 
         # Must be visible
         dialog = TraceDatavizEditionDialog(None, layer, GraphType.Sunburst)
-        self.assertTrue(dialog.label_z_field.isVisible())
-        self.assertTrue(dialog.z_field.isVisible())
+        self.assertEqual(GraphType.Sunburst, dialog._graph)
+        # self.assertTrue(dialog.label_z_field.isVisible())
+        # self.assertTrue(dialog.z_field.isVisible())
         self.assertFalse(dialog.z_field.allowEmptyFieldName())
 
         # Not visible

--- a/lizmap/test/test_trace_dialog.py
+++ b/lizmap/test/test_trace_dialog.py
@@ -1,0 +1,56 @@
+"""Test Traces."""
+from collections import OrderedDict
+
+from qgis.core import QgsVectorLayer, QgsProject
+from qgis.testing import unittest
+
+from lizmap.qgis_plugin_tools.tools.resources import plugin_test_data_path
+from lizmap.forms.trace_dataviz_edition import TraceDatavizEditionDialog
+
+__copyright__ = 'Copyright 2020, 3Liz'
+__license__ = 'GPL version 3'
+__email__ = 'info@3liz.org'
+__revision__ = '$Format:%H$'
+
+
+class TestTraceDialog(unittest.TestCase):
+
+    def test_trace_dialog(self):
+        """Test trace dialog."""
+        layer = QgsVectorLayer(plugin_test_data_path('lines.geojson'), 'lines', 'ogr')
+        QgsProject.instance().addMapLayer(layer)
+        self.assertTrue(layer.isValid())
+
+        dialog = TraceDatavizEditionDialog(None, layer)
+        self.assertFalse(dialog.error.isVisible())
+
+        self.assertEqual('Field is required.', dialog.validate())
+        self.assertEqual('#086fa1', dialog.color.color().name())
+        self.assertEqual('', dialog.color_field.currentField())
+        self.assertTrue(dialog.color.isEnabled())
+        self.assertTrue(dialog.color_field.allowEmptyFieldName())
+
+        dialog.color_field.setCurrentIndex(1)
+        self.assertNotEqual('', dialog.color_field.currentField())
+        self.assertFalse(dialog.color.isEnabled())
+
+        dialog.color_field.setCurrentIndex(0)
+        self.assertEqual('', dialog.color_field.currentField())
+        self.assertTrue(dialog.color.isEnabled())
+
+        dialog.field.setCurrentIndex(0)
+        self.assertIsNone(dialog.validate())
+
+        data = dialog.save_form()
+        expected = OrderedDict()
+        expected['y_field'] = 'id'
+        expected['color'] = '#086fa1'
+        expected['colorfield'] = ''
+        self.assertEqual(expected, data)
+
+        data = OrderedDict()
+        data['y_field'] = 'name'
+        data['color'] = '#aabbcc'
+        data['colorfield'] = ''
+        dialog.load_form(data)
+        self.assertEqual(data, dialog.save_form())


### PR DESCRIPTION
<!---
PUT "dev" branch for any new features or next Lizmap version
PUT "master" for bug fix
-->

* **Funded by**: Communauté d'agglomération du Grand Narbonne https://www.legrandnarbonne.com/
* **Ticket**: #238 
* **Description**: Support for multi traces in dataviz

For some graphs, we want to be able to add from 1 to N traces on the same graph.

Y, Y2, Z and colors are now hidden from the main table. It's a JSON representation. It's less user-friendly in the table. But I don't have a lot of choices because we can have 1-n traces for a single chart.

In the form, there is now a table to add/remove a trace:

![Capture d’écran de 2020-03-25 09-39-22](https://user-images.githubusercontent.com/1609292/77517559-a31fed00-6e7c-11ea-862b-9b5c4c9040e2.png)

![Sélection_001](https://user-images.githubusercontent.com/1609292/77642206-958e6400-6f5d-11ea-99dd-1a2318b1c8ac.png)

