### PR TITLE
use absolute instead of relative imports

### DIFF
--- a/lizmap/__init__.py
+++ b/lizmap/__init__.py
@@ -52,7 +52,7 @@ DEFAULT_LWC_VERSION = LwcVersions.Lizmap_3_3
 
 
 def classFactory(iface):
-    from .lizmap import Lizmap
+    from lizmap.plugin import Lizmap
     return Lizmap(iface)
 
 
@@ -62,5 +62,5 @@ def serverClassFactory(serverIface):  # pylint: disable=invalid-name
     :param serverIface: A QGIS Server interface instance.
     :type serverIface: QgsServerInterface
     """
-    from .server.lizmap_server import LizmapServer
+    from lizmap.server.lizmap_server import LizmapServer
     return LizmapServer(serverIface)

--- a/lizmap/definitions/atlas.py
+++ b/lizmap/definitions/atlas.py
@@ -2,8 +2,8 @@
 
 from enum import Enum, unique
 
-from .base import BaseDefinitions, InputType
-from ..qgis_plugin_tools.tools.i18n import tr
+from lizmap.definitions.base import BaseDefinitions, InputType
+from lizmap.qgis_plugin_tools.tools.i18n import tr
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/definitions/attribute_table.py
+++ b/lizmap/definitions/attribute_table.py
@@ -1,7 +1,7 @@
 """Definitions for attribute table."""
 
-from .base import BaseDefinitions, InputType
-from ..qgis_plugin_tools.tools.i18n import tr
+from lizmap.definitions.base import BaseDefinitions, InputType
+from lizmap.qgis_plugin_tools.tools.i18n import tr
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/definitions/dataviz.py
+++ b/lizmap/definitions/dataviz.py
@@ -2,9 +2,9 @@
 
 from enum import Enum, unique
 
-from .base import BaseDefinitions, InputType
-from ..qgis_plugin_tools.tools.i18n import tr
-from ..qgis_plugin_tools.tools.resources import resources_path
+from lizmap.definitions.base import BaseDefinitions, InputType
+from lizmap.qgis_plugin_tools.tools.i18n import tr
+from lizmap.qgis_plugin_tools.tools.resources import resources_path
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/definitions/edition.py
+++ b/lizmap/definitions/edition.py
@@ -1,7 +1,7 @@
 """Definitions for edition."""
 
-from .base import BaseDefinitions, InputType
-from ..qgis_plugin_tools.tools.i18n import tr
+from lizmap.definitions.base import BaseDefinitions, InputType
+from lizmap.qgis_plugin_tools.tools.i18n import tr
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/definitions/filter_by_form.py
+++ b/lizmap/definitions/filter_by_form.py
@@ -1,7 +1,7 @@
 """Definitions for filter by form."""
 
-from .base import BaseDefinitions, InputType
-from ..qgis_plugin_tools.tools.i18n import tr
+from lizmap.definitions.base import BaseDefinitions, InputType
+from lizmap.qgis_plugin_tools.tools.i18n import tr
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/definitions/filter_by_login.py
+++ b/lizmap/definitions/filter_by_login.py
@@ -1,7 +1,7 @@
 """Definitions for filter by login."""
 
-from .base import BaseDefinitions, InputType
-from ..qgis_plugin_tools.tools.i18n import tr
+from lizmap.definitions.base import BaseDefinitions, InputType
+from lizmap.qgis_plugin_tools.tools.i18n import tr
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/definitions/locate_by_layer.py
+++ b/lizmap/definitions/locate_by_layer.py
@@ -1,7 +1,7 @@
 """Definitions for locate by layer."""
 
-from .base import BaseDefinitions, InputType
-from ..qgis_plugin_tools.tools.i18n import tr
+from lizmap.definitions.base import BaseDefinitions, InputType
+from lizmap.qgis_plugin_tools.tools.i18n import tr
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/definitions/time_manager.py
+++ b/lizmap/definitions/time_manager.py
@@ -1,7 +1,7 @@
 """Definitions for time manager."""
 
-from .base import BaseDefinitions, InputType
-from ..qgis_plugin_tools.tools.i18n import tr
+from lizmap.definitions.base import BaseDefinitions, InputType
+from lizmap.qgis_plugin_tools.tools.i18n import tr
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/definitions/tooltip.py
+++ b/lizmap/definitions/tooltip.py
@@ -1,7 +1,7 @@
 """Definitions for tooltip."""
 
-from .base import BaseDefinitions, InputType
-from ..qgis_plugin_tools.tools.i18n import tr
+from lizmap.definitions.base import BaseDefinitions, InputType
+from lizmap.qgis_plugin_tools.tools.i18n import tr
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/forms/atlas_edition.py
+++ b/lizmap/forms/atlas_edition.py
@@ -2,10 +2,9 @@
 
 from qgis.core import QgsMapLayerProxyModel
 
-from .base_edition_dialog import BaseEditionDialog
-from ..definitions.atlas import AtlasDefinitions
-from ..qgis_plugin_tools.tools.i18n import tr
-from ..qgis_plugin_tools.tools.resources import load_ui
+from lizmap.forms.base_edition_dialog import BaseEditionDialog
+from lizmap.definitions.atlas import AtlasDefinitions
+from lizmap.qgis_plugin_tools.tools.resources import load_ui
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/forms/attribute_table_edition.py
+++ b/lizmap/forms/attribute_table_edition.py
@@ -2,10 +2,10 @@
 
 from qgis.core import QgsMapLayerProxyModel, QgsProject
 
-from .base_edition_dialog import BaseEditionDialog
-from ..definitions.attribute_table import AttributeTableDefinitions
-from ..qgis_plugin_tools.tools.i18n import tr
-from ..qgis_plugin_tools.tools.resources import load_ui
+from lizmap.forms.base_edition_dialog import BaseEditionDialog
+from lizmap.definitions.attribute_table import AttributeTableDefinitions
+from lizmap.qgis_plugin_tools.tools.i18n import tr
+from lizmap.qgis_plugin_tools.tools.resources import load_ui
 
 
 __copyright__ = 'Copyright 2020, 3Liz'

--- a/lizmap/forms/base_edition_dialog.py
+++ b/lizmap/forms/base_edition_dialog.py
@@ -8,8 +8,8 @@ from qgis.PyQt.QtGui import QColor, QIcon
 from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox
 from qgis.core import QgsProject
 
-from ..definitions.base import InputType
-from ..qgis_plugin_tools.tools.i18n import tr
+from lizmap.definitions.base import InputType
+from lizmap.qgis_plugin_tools.tools.i18n import tr
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/forms/dataviz_edition.py
+++ b/lizmap/forms/dataviz_edition.py
@@ -1,11 +1,10 @@
 """Dialog for dataviz edition."""
 from qgis.core import QgsMapLayerProxyModel, QgsProject
 
-from .base_edition_dialog import BaseEditionDialog
-from ..definitions.base import InputType
-from ..definitions.dataviz import DatavizDefinitions, GraphType
-from ..qgis_plugin_tools.tools.i18n import tr
-from ..qgis_plugin_tools.tools.resources import load_ui
+from lizmap.forms.base_edition_dialog import BaseEditionDialog
+from lizmap.definitions.dataviz import DatavizDefinitions, GraphType
+from lizmap.qgis_plugin_tools.tools.i18n import tr
+from lizmap.qgis_plugin_tools.tools.resources import load_ui
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/forms/edition_edition.py
+++ b/lizmap/forms/edition_edition.py
@@ -3,11 +3,11 @@
 from qgis.PyQt.QtWidgets import QMessageBox
 from qgis.core import QgsMapLayerProxyModel, QgsProject, QgsWkbTypes
 
-from .base_edition_dialog import BaseEditionDialog
-from ..definitions.edition import EditionDefinitions
-from ..qgis_plugin_tools.tools.i18n import tr
-from ..qgis_plugin_tools.tools.resources import load_ui
-from ..tools import excluded_providers
+from lizmap.forms.base_edition_dialog import BaseEditionDialog
+from lizmap.definitions.edition import EditionDefinitions
+from lizmap.qgis_plugin_tools.tools.i18n import tr
+from lizmap.qgis_plugin_tools.tools.resources import load_ui
+from lizmap.tools import excluded_providers
 
 
 __copyright__ = 'Copyright 2020, 3Liz'

--- a/lizmap/forms/filter_by_form_edition.py
+++ b/lizmap/forms/filter_by_form_edition.py
@@ -2,10 +2,10 @@
 
 from qgis.core import QgsMapLayerProxyModel, QgsProject
 
-from .base_edition_dialog import BaseEditionDialog
-from ..definitions.filter_by_form import FilterByFormDefinitions
-from ..qgis_plugin_tools.tools.i18n import tr
-from ..qgis_plugin_tools.tools.resources import load_ui
+from lizmap.forms.base_edition_dialog import BaseEditionDialog
+from lizmap.definitions.filter_by_form import FilterByFormDefinitions
+from lizmap.qgis_plugin_tools.tools.i18n import tr
+from lizmap.qgis_plugin_tools.tools.resources import load_ui
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/forms/filter_by_login.py
+++ b/lizmap/forms/filter_by_login.py
@@ -2,10 +2,10 @@
 
 from qgis.core import QgsMapLayerProxyModel
 
-from .base_edition_dialog import BaseEditionDialog
-from ..definitions.filter_by_login import FilterByLoginDefinitions
-from ..qgis_plugin_tools.tools.i18n import tr
-from ..qgis_plugin_tools.tools.resources import load_ui
+from lizmap.forms.base_edition_dialog import BaseEditionDialog
+from lizmap.definitions.filter_by_login import FilterByLoginDefinitions
+from lizmap.qgis_plugin_tools.tools.i18n import tr
+from lizmap.qgis_plugin_tools.tools.resources import load_ui
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/forms/locate_layer_edition.py
+++ b/lizmap/forms/locate_layer_edition.py
@@ -2,10 +2,10 @@
 
 from qgis.core import QgsMapLayerProxyModel, QgsProject
 
-from .base_edition_dialog import BaseEditionDialog
-from ..definitions.locate_by_layer import LocateByLayerDefinitions
-from ..qgis_plugin_tools.tools.i18n import tr
-from ..qgis_plugin_tools.tools.resources import load_ui
+from lizmap.forms.base_edition_dialog import BaseEditionDialog
+from lizmap.definitions.locate_by_layer import LocateByLayerDefinitions
+from lizmap.qgis_plugin_tools.tools.i18n import tr
+from lizmap.qgis_plugin_tools.tools.resources import load_ui
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/forms/table_manager.py
+++ b/lizmap/forms/table_manager.py
@@ -14,10 +14,10 @@ from qgis.PyQt.QtWidgets import (
     QMessageBox,
 )
 
-from ..definitions.base import BaseDefinitions, InputType
-from ..qgis_plugin_tools.tools.i18n import tr
-from ..qgis_plugin_tools.tools.resources import plugin_name
-from ..qgis_plugin_tools.tools.version import is_dev_version
+from lizmap.definitions.base import BaseDefinitions, InputType
+from lizmap.qgis_plugin_tools.tools.i18n import tr
+from lizmap.qgis_plugin_tools.tools.resources import plugin_name
+from lizmap.qgis_plugin_tools.tools.version import is_dev_version
 
 LOGGER = logging.getLogger(plugin_name())
 

--- a/lizmap/forms/time_manager_edition.py
+++ b/lizmap/forms/time_manager_edition.py
@@ -2,10 +2,10 @@
 
 from qgis.core import QgsMapLayerProxyModel, QgsProject
 
-from .base_edition_dialog import BaseEditionDialog
-from ..definitions.time_manager import TimeManagerDefinitions
-from ..qgis_plugin_tools.tools.i18n import tr
-from ..qgis_plugin_tools.tools.resources import load_ui
+from lizmap.forms.base_edition_dialog import BaseEditionDialog
+from lizmap.definitions.time_manager import TimeManagerDefinitions
+from lizmap.qgis_plugin_tools.tools.i18n import tr
+from lizmap.qgis_plugin_tools.tools.resources import load_ui
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/forms/tooltip_edition.py
+++ b/lizmap/forms/tooltip_edition.py
@@ -3,10 +3,10 @@
 from qgis.core import QgsMapLayerProxyModel, QgsProject
 from qgis.PyQt.QtGui import QColor
 
-from .base_edition_dialog import BaseEditionDialog
-from ..definitions.tooltip import ToolTipDefinitions
-from ..qgis_plugin_tools.tools.i18n import tr
-from ..qgis_plugin_tools.tools.resources import load_ui
+from lizmap.forms.base_edition_dialog import BaseEditionDialog
+from lizmap.definitions.tooltip import ToolTipDefinitions
+from lizmap.qgis_plugin_tools.tools.i18n import tr
+from lizmap.qgis_plugin_tools.tools.resources import load_ui
 
 
 __copyright__ = 'Copyright 2020, 3Liz'

--- a/lizmap/lizmap_api/commands.py
+++ b/lizmap/lizmap_api/commands.py
@@ -54,6 +54,7 @@ from .config import LizmapConfig
 # And not make this object garbage collected
 qgis_application = None
 
+
 def init_qgis(verbose=False):
     """ Initialize qgis application
     """

--- a/lizmap/lizmap_api/config.py
+++ b/lizmap/lizmap_api/config.py
@@ -53,9 +53,9 @@ from qgis.core import (
     QgsMapLayer,
 )
 
-from .. import DEFAULT_LWC_VERSION
-from ..qgis_plugin_tools.tools.resources import metadata_config
-from ..qgis_plugin_tools.tools.version import format_version_integer
+from lizmap import DEFAULT_LWC_VERSION
+from lizmap.qgis_plugin_tools.tools.resources import metadata_config
+from lizmap.qgis_plugin_tools.tools.version import format_version_integer
 
 
 class LizmapConfigError(Exception):

--- a/lizmap/lizmap_dialog.py
+++ b/lizmap/lizmap_dialog.py
@@ -46,7 +46,7 @@
 
 from qgis.PyQt.QtWidgets import QDialog
 
-from .qgis_plugin_tools.tools.resources import load_ui
+from lizmap.qgis_plugin_tools.tools.resources import load_ui
 
 FORM_CLASS = load_ui('ui_lizmap.ui')
 

--- a/lizmap/lizmap_popup_dialog.py
+++ b/lizmap/lizmap_popup_dialog.py
@@ -46,7 +46,7 @@
 
 from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox
 
-from .qgis_plugin_tools.tools.resources import load_ui
+from lizmap.qgis_plugin_tools.tools.resources import load_ui
 
 FORM_CLASS = load_ui('ui_lizmap_popup.ui')
 

--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -84,37 +84,37 @@ from qgis.core import (
     QgsMapLayer,
 )
 
-from . import DEFAULT_LWC_VERSION
-from .definitions.atlas import AtlasDefinitions
-from .definitions.attribute_table import AttributeTableDefinitions
-from .definitions.dataviz import DatavizDefinitions
-from .definitions.definitions import LwcVersions
-from .definitions.edition import EditionDefinitions
-from .definitions.filter_by_form import FilterByFormDefinitions
-from .definitions.filter_by_login import FilterByLoginDefinitions
-from .definitions.locate_by_layer import LocateByLayerDefinitions
-from .definitions.time_manager import TimeManagerDefinitions
-from .definitions.tooltip import ToolTipDefinitions
-from .forms.atlas_edition import AtlasEditionDialog
-from .forms.attribute_table_edition import AttributeTableEditionDialog
-from .forms.dataviz_edition import DatavizEditionDialog
-from .forms.edition_edition import EditionLayerDialog
-from .forms.filter_by_form_edition import FilterByFormEditionDialog
-from .forms.filter_by_login import FilterByLoginEditionDialog
-from .forms.locate_layer_edition import LocateLayerEditionDialog
-from .forms.table_manager import TableManager
-from .forms.time_manager_edition import TimeManagerEditionDialog
-from .forms.tooltip_edition import ToolTipEditionDialog
-from .html_and_expressions import STYLESHEET, NEW_FEATURE
-from .lizmap_api.config import LizmapConfig
-from .lizmap_dialog import LizmapDialog
-from .lizmap_popup_dialog import LizmapPopupDialog
-from .qgis_plugin_tools.tools.custom_logging import setup_logger
-from .qgis_plugin_tools.tools.i18n import setup_translation, tr
-from .qgis_plugin_tools.tools.resources import resources_path, plugin_path, plugin_name
-from .qgis_plugin_tools.tools.ghost_layers import remove_all_ghost_layers
-from .qgis_plugin_tools.tools.version import is_dev_version, version, format_version_integer
-from .tooltip import Tooltip
+from lizmap import DEFAULT_LWC_VERSION
+from lizmap.definitions.atlas import AtlasDefinitions
+from lizmap.definitions.attribute_table import AttributeTableDefinitions
+from lizmap.definitions.dataviz import DatavizDefinitions
+from lizmap.definitions.definitions import LwcVersions
+from lizmap.definitions.edition import EditionDefinitions
+from lizmap.definitions.filter_by_form import FilterByFormDefinitions
+from lizmap.definitions.filter_by_login import FilterByLoginDefinitions
+from lizmap.definitions.locate_by_layer import LocateByLayerDefinitions
+from lizmap.definitions.time_manager import TimeManagerDefinitions
+from lizmap.definitions.tooltip import ToolTipDefinitions
+from lizmap.forms.atlas_edition import AtlasEditionDialog
+from lizmap.forms.attribute_table_edition import AttributeTableEditionDialog
+from lizmap.forms.dataviz_edition import DatavizEditionDialog
+from lizmap.forms.edition_edition import EditionLayerDialog
+from lizmap.forms.filter_by_form_edition import FilterByFormEditionDialog
+from lizmap.forms.filter_by_login import FilterByLoginEditionDialog
+from lizmap.forms.locate_layer_edition import LocateLayerEditionDialog
+from lizmap.forms.table_manager import TableManager
+from lizmap.forms.time_manager_edition import TimeManagerEditionDialog
+from lizmap.forms.tooltip_edition import ToolTipEditionDialog
+from lizmap.html_and_expressions import STYLESHEET, NEW_FEATURE
+from lizmap.lizmap_api.config import LizmapConfig
+from lizmap.lizmap_dialog import LizmapDialog
+from lizmap.lizmap_popup_dialog import LizmapPopupDialog
+from lizmap.qgis_plugin_tools.tools.custom_logging import setup_logger
+from lizmap.qgis_plugin_tools.tools.i18n import setup_translation, tr
+from lizmap.qgis_plugin_tools.tools.resources import resources_path, plugin_path, plugin_name
+from lizmap.qgis_plugin_tools.tools.ghost_layers import remove_all_ghost_layers
+from lizmap.qgis_plugin_tools.tools.version import is_dev_version, version, format_version_integer
+from lizmap.tooltip import Tooltip
 
 
 LOGGER = logging.getLogger(plugin_name())

--- a/lizmap/server/lizmap_server.py
+++ b/lizmap/server/lizmap_server.py
@@ -7,6 +7,7 @@ from .expression_service import ExpressionService
 from .lizmap_service import LizmapService
 from .lizmap_filter import LizmapFilter
 
+
 class LizmapServer:
     """Plugin for QGIS server
     this plugin loads atlasprint filter"""

--- a/lizmap/test/test_code_layout.py
+++ b/lizmap/test/test_code_layout.py
@@ -4,7 +4,7 @@ import os
 import re
 import unittest
 
-from ..qgis_plugin_tools.tools.resources import resources_path
+from lizmap.qgis_plugin_tools.tools.resources import resources_path
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/test/test_dialog_edition.py
+++ b/lizmap/test/test_dialog_edition.py
@@ -3,8 +3,8 @@
 from qgis.core import QgsVectorLayer, QgsProject
 from qgis.testing import unittest
 
-from ..qgis_plugin_tools.tools.resources import plugin_test_data_path
-from ..forms.atlas_edition import AtlasEditionDialog
+from lizmap.qgis_plugin_tools.tools.resources import plugin_test_data_path
+from lizmap.forms.atlas_edition import AtlasEditionDialog
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/test/test_table_manager.py
+++ b/lizmap/test/test_table_manager.py
@@ -7,18 +7,18 @@ from qgis.core import QgsVectorLayer, QgsProject
 from qgis.testing import unittest
 
 
-from ..definitions.atlas import AtlasDefinitions
-from ..definitions.attribute_table import AttributeTableDefinitions
-from ..definitions.dataviz import DatavizDefinitions
-from ..definitions.edition import EditionDefinitions
-from ..definitions.filter_by_form import FilterByFormDefinitions
-from ..definitions.filter_by_login import FilterByLoginDefinitions
-from ..definitions.locate_by_layer import LocateByLayerDefinitions
-from ..definitions.tooltip import ToolTipDefinitions
-from ..definitions.time_manager import TimeManagerDefinitions
-from ..forms.table_manager import TableManager
-from ..forms.atlas_edition import AtlasEditionDialog
-from ..qgis_plugin_tools.tools.resources import plugin_test_data_path
+from lizmap.definitions.atlas import AtlasDefinitions
+from lizmap.definitions.attribute_table import AttributeTableDefinitions
+from lizmap.definitions.dataviz import DatavizDefinitions
+from lizmap.definitions.edition import EditionDefinitions
+from lizmap.definitions.filter_by_form import FilterByFormDefinitions
+from lizmap.definitions.filter_by_login import FilterByLoginDefinitions
+from lizmap.definitions.locate_by_layer import LocateByLayerDefinitions
+from lizmap.definitions.tooltip import ToolTipDefinitions
+from lizmap.definitions.time_manager import TimeManagerDefinitions
+from lizmap.forms.table_manager import TableManager
+from lizmap.forms.atlas_edition import AtlasEditionDialog
+from lizmap.qgis_plugin_tools.tools.resources import plugin_test_data_path
 
 
 __copyright__ = 'Copyright 2020, 3Liz'

--- a/lizmap/test/test_tooltip.py
+++ b/lizmap/test/test_tooltip.py
@@ -14,8 +14,8 @@ from qgis.gui import QgsExternalResourceWidget
 from qgis.testing import unittest
 
 
-from ..qgis_plugin_tools.tools.resources import plugin_test_data_path
-from ..tooltip import Tooltip
+from lizmap.qgis_plugin_tools.tools.resources import plugin_test_data_path
+from lizmap.tooltip import Tooltip
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'

--- a/lizmap/test/test_ui.py
+++ b/lizmap/test/test_ui.py
@@ -6,8 +6,8 @@ from qgis.core import QgsVectorLayer, QgsProject
 from qgis.testing import unittest
 from qgis.testing.mocked import get_iface
 
-from ..lizmap import Lizmap
-from ..qgis_plugin_tools.tools.resources import plugin_test_data_path
+from lizmap.plugin import Lizmap
+from lizmap.qgis_plugin_tools.tools.resources import plugin_test_data_path
 
 
 __copyright__ = 'Copyright 2019, 3Liz'


### PR DESCRIPTION
* Rename `lizmap.py` to `plugin.py`, the filename was in conflict with the name of the package `lizmap` which was bringing errors.
* Use absolute imports instead of relative imports.

We already use absolute imports in some places, like in UI files.

I'm struggling to setup the Python debugger and run tests locally (without the need of docker) if the project is using relative imports. This would help me for debugging from Pycharm etc. (PyCharm has a builtin debugger that you can run on tests for instance).

> An important caveat is that because of PEP 338 and PEP 366, relative imports require the python file to be imported as a module - you cannot execute a file.py that has a relative import or you'll get a ValueError: Attempted relative import in non-package. This limitation should be taken into account when evaluating the best approach.

I was running in this issue.