### PR TITLE
CFG - Add a new key if the attribute table has a custom config

### DIFF
--- a/lizmap/definitions/attribute_table.py
+++ b/lizmap/definitions/attribute_table.py
@@ -1,4 +1,5 @@
 """Definitions for attribute table."""
+from qgis.core import QgsAttributeTableConfig
 
 from lizmap.definitions.base import BaseDefinitions, InputType
 from lizmap.qgis_plugin_tools.tools.i18n import tr
@@ -7,6 +8,13 @@ __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'
 __email__ = 'info@3liz.org'
 __revision__ = '$Format:%H$'
+
+
+def layer_has_custom_attribute_table(layer) -> bool:
+    # Do not use the isEmpty() on the QgsVectorLayer. It's automatically populated if empty with the fields.
+    config = QgsAttributeTableConfig()
+    config.update(layer.fields())
+    return not config.hasSameColumns(layer.attributeTableConfig())
 
 
 class AttributeTableDefinitions(BaseDefinitions):
@@ -47,7 +55,16 @@ class AttributeTableDefinitions(BaseDefinitions):
             'type': InputType.CheckBox,
             'header': tr('Hide layer in list'),
             'default': False,
-            'tooltip': tr('No button "Detail" will be shown in Lizmap to open the attribute table, but related features such as selection and filter will be available.')
+            'tooltip': tr(
+                'No button "Detail" will be shown in Lizmap to open the attribute table, but related '
+                'features such as selection and filter will be available.'),
+        }
+        self._layer_config['custom_config'] = {
+            'type': InputType.CheckBox,
+            'header': tr('Custom configuration'),
+            'default': layer_has_custom_attribute_table,
+            'tooltip': tr('If the attribute table has a custom order. Read-only field.'),
+            'read_only': True,
         }
 
         self._general_config['limitDataToBbox'] = {

--- a/lizmap/definitions/edition.py
+++ b/lizmap/definitions/edition.py
@@ -117,10 +117,10 @@ class EditionDefinitions(BaseDefinitions):
         }
         self._layer_config['provider'] = {
             'type': InputType.Text,
-            'visible': False,
+            'read_only': True,
             'default': layer_provider,
             'header': tr('Provider name'),
-            'tooltip': tr('Provider name'),
+            'tooltip': tr('Provider name, read only configuration.'),
             'version': LwcVersions.Lizmap_3_3,
         }
 

--- a/lizmap/forms/attribute_table_edition.py
+++ b/lizmap/forms/attribute_table_edition.py
@@ -2,7 +2,10 @@
 
 from qgis.core import QgsMapLayerProxyModel, QgsProject
 
-from lizmap.definitions.attribute_table import AttributeTableDefinitions
+from lizmap.definitions.attribute_table import (
+    AttributeTableDefinitions,
+    layer_has_custom_attribute_table,
+)
 from lizmap.forms.base_edition_dialog import BaseEditionDialog
 from lizmap.qgis_plugin_tools.tools.i18n import tr
 from lizmap.qgis_plugin_tools.tools.resources import load_ui
@@ -28,6 +31,7 @@ class AttributeTableEditionDialog(BaseEditionDialog, CLASS):
         self.config.add_layer_widget('pivot', self.pivot_table)
         self.config.add_layer_widget('hideAsChild', self.hide_subpanels)
         self.config.add_layer_widget('hideLayer', self.hide_layer)
+        self.config.add_layer_widget('custom_config', self.has_custom_config)
 
         self.config.add_layer_label('layerId', self.label_layer)
         self.config.add_layer_label('primaryKey', self.label_primary_key)
@@ -35,14 +39,23 @@ class AttributeTableEditionDialog(BaseEditionDialog, CLASS):
         self.config.add_layer_label('pivot', self.label_pivot_table)
         self.config.add_layer_label('hideAsChild', self.label_hide_subpanels)
         self.config.add_layer_label('hideLayer', self.label_hide_layer)
+        self.config.add_layer_label('custom_config', self.label_has_custom_config)
 
         self.layer.setFilters(QgsMapLayerProxyModel.VectorLayer)
+        self.layer.layerChanged.connect(self.layer_changed)
         self.layer.layerChanged.connect(self.field_primary_key.setLayer)
         self.field_primary_key.setLayer(self.layer.currentLayer())
         self.layer.layerChanged.connect(self.fields_to_hide.set_layer)
         self.fields_to_hide.set_layer(self.layer.currentLayer())
 
         self.setup_ui()
+
+    def post_load_form(self):
+        self.layer_changed()
+
+    def layer_changed(self):
+        layer = self.layer.currentLayer()
+        self.has_custom_config.setChecked(layer_has_custom_attribute_table(layer))
 
     def validate(self) -> str:
         upstream = super().validate()

--- a/lizmap/forms/edition_edition.py
+++ b/lizmap/forms/edition_edition.py
@@ -51,6 +51,7 @@ class EditionLayerDialog(BaseEditionDialog, CLASS):
         self.config.add_layer_label('snap_layers', self.label_layers_snapping)
         self.config.add_layer_label('provider', self.label_provider)
 
+        self.layer.layerChanged.connect(self.layer_changed)
         self.layer.setFilters(QgsMapLayerProxyModel.VectorLayer)
         self.layer.setExcludedProviders(excluded_providers())
         self.layers.set_project(QgsProject.instance())
@@ -60,6 +61,13 @@ class EditionLayerDialog(BaseEditionDialog, CLASS):
         ]
 
         self.setup_ui()
+
+    def post_load_form(self):
+        self.layer_changed()
+
+    def layer_changed(self):
+        layer = self.layer.currentLayer()
+        self.provider.setText(layer_provider(layer))
 
     def validate(self) -> str:
         layer = self.layer.currentLayer()
@@ -79,8 +87,6 @@ class EditionLayerDialog(BaseEditionDialog, CLASS):
                 'The layers you have chosen for this tool must be checked in the "WFS Capabilities"\n'
                 ' option of the QGIS Server tab in the "Project Properties" dialog.')
             return msg
-
-        self.provider.setText(layer_provider(layer))
 
         create_feature = self.create_feature.isChecked()
         modify_attribute = self.edit_attributes.isChecked()

--- a/lizmap/resources/ui/ui_form_attribute_table.ui
+++ b/lizmap/resources/ui/ui_form_attribute_table.ui
@@ -91,6 +91,20 @@
      <item row="2" column="1">
       <widget class="ListFieldsSelection" name="fields_to_hide"/>
      </item>
+     <item row="6" column="1">
+      <widget class="QCheckBox" name="has_custom_config">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_has_custom_config">
+       <property name="text">
+        <string notr="true">Has a custom config</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/lizmap/test/test_table_manager.py
+++ b/lizmap/test/test_table_manager.py
@@ -679,6 +679,10 @@ class TestTableManager(unittest.TestCase):
         table_manager.from_json(json)
         self.assertEqual(table_manager.table.rowCount(), 1)
         data = table_manager.to_json()
+
+        # Automatically added, so we add it manually for the comparaison
+        json['lines']['custom_config'] = 'False'
+
         self.assertDictEqual(data, json)
 
     def test_time_manager_table(self):


### PR DESCRIPTION
<!---
PUT "dev" branch for any new features or next Lizmap version
PUT "master" for bug fix
-->

* **Funded by**: Altétia
* **Description**: 
  * Ticket fix #317  

Hum, so it seems I think i have a weird behavior.
In QGIS Desktop, it seems **always** not empty : 
```python
[ col.name for col in iface.activeLayer().attributeTableConfig().columns()]
```

While in the QGS file : 
```xml
      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
        <columns></columns>
      </attributetableconfig>
```

https://www.qgis.org/api/classQgsAttributeTableConfig.html#a1af932ad500b11eebc2d88fe6308ed84

