### PR TITLE
Fix: Disable lizmap layer filter expression access control

### DIFF
--- a/lizmap/server/lizmap_accesscontrol.py
+++ b/lizmap/server/lizmap_accesscontrol.py
@@ -34,12 +34,14 @@ class LizmapAccessControlFilter(QgsAccessControlFilter):
 
     def layerFilterExpression(self, layer: 'QgsVectorLayer') -> str:
         """ Return an additional expression filter """
-        QgsMessageLog.logMessage("Lizmap layerFilterExpression", "lizmap", Qgis.Info)
-        filter_exp = self.get_lizmap_layer_filter(layer)
-        if filter_exp:
-            return filter_exp
-
-        return super().layerFilterExpression(layer)
+        # Disable lizmap layer filter expression while fixing an issue in QGIS Server
+        return ''
+        # QgsMessageLog.logMessage("Lizmap layerFilterExpression", "lizmap", Qgis.Info)
+        # filter_exp = self.get_lizmap_layer_filter(layer)
+        # if filter_exp:
+        #     return filter_exp
+        #
+        # return super().layerFilterExpression(layer)
 
     def layerFilterSubsetString(self, layer: 'QgsVectorLayer') -> str:
         """ Return an additional subset string (typically SQL) filter """


### PR DESCRIPTION
Disbale the lizmap layer filter expression acces control while fixing QGIS Server.
We are facing an issue due to a filter expressions cache in QgsAccessControl.

mFilterFeaturesExpressions in QgsAccessControl is never cleared and it is set only by WMS Request in QgsRenderer::layersRendering with
mContext.accessControl()->resolveFilterFeatures( mapSettings.layers() );