### PR TITLE
Server - Add custom URL to the server part to fetch informations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
           -e PIP_CACHE_DIR=/.cache
           -w /src/test/server
           -e PYTEST_ADDOPTS=""
+          -e QGIS_SERVER_LIZMAP_REVEAL_SETTINGS=TRUE
           -v ${GITHUB_WORKSPACE}:/src
           -v ${GITHUB_WORKSPACE}/.local:/.local
           3liz/qgis-platform:3.10

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ test_server:
 		-v $$(pwd)/.local:/.local \
 		-v $(LOCAL_HOME)/.cache:/.cache \
 		-e PIP_CACHE_DIR=/.cache \
+		-e QGIS_SERVER_LIZMAP_REVEAL_SETTINGS=TRUE \
 		-e PYTEST_ADDOPTS="$(TEST_OPTS)" \
 		$(QGIS_IMAGE) ./run-tests.sh
 	@flake8

--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ If it's from a previous GitHub repository:
 
 Lizmap is also a QGIS Server plugin.
 
+Starting from Lizmap 3.6, the plugin is required.
+
+* lizmap/server.json
 * SERVICE=LIZMAP
-    * REQUEST=GetServerSettings
+    * ~REQUEST=GetServerSettings~ deprecated for the JSON URL above
     * REQUEST=GetSubsetString
       * LAYER=
       * LIZMAP_USER_GROUPS=

--- a/lizmap/server/lizmap_api.py
+++ b/lizmap/server/lizmap_api.py
@@ -1,0 +1,69 @@
+__copyright__ = 'Copyright 2021, 3Liz'
+__license__ = 'GPL version 3'
+__email__ = 'info@3liz.org'
+
+import json
+
+from typing import Union
+
+from qgis.core import Qgis
+from qgis.server import QgsServerApi
+from qgis.utils import pluginMetadata, server_active_plugins
+
+from lizmap.server.core import to_bool
+
+
+class LizmapApi(QgsServerApi):
+
+    def name(self):
+        return "Lizmap end point"
+
+    def rootPath(self):
+        return "/lizmap/server.json"
+
+    def executeRequest(self, request_context):
+        response = request_context.response()
+        response.setHeader('Content-Type', 'application/json')
+
+        plugins = dict()
+        for plugin in server_active_plugins:
+            plugins[plugin] = dict()
+            plugins[plugin]['version'] = pluginMetadata(plugin, 'version')
+
+        qgis_version_split = Qgis.QGIS_VERSION.split('-')
+
+        services_available = []
+        services = ('WMS', 'WFS', 'WCS', 'WMTS', 'ATLAS', 'CADASTRE', 'EXPRESSION', 'LIZMAP')
+        for service in services:
+            if self.serverIface().serviceRegistry().getService(service):
+                services_available.append(service)
+
+        data = {
+            'qgis_server': {
+                'metadata': {
+                    'version': qgis_version_split[0],  # 3.16.0
+                    'name': qgis_version_split[1],  # Hannover
+                    'version_int': Qgis.QGIS_VERSION_INT,  # 31600
+                },
+                'support_custom_headers': self.support_custom_headers(),
+                'services': services_available,
+                'plugins': plugins,
+            },
+        }
+        response.write(json.dumps(data))
+
+    def support_custom_headers(self) -> Union[None, bool]:
+        """ Check if this QGIS Server supports custom headers.
+
+         Returns None if the check is not requested with the GET parameter CHECK_CUSTOM_HEADERS
+
+         If requested, returns boolean if X-Check-Custom-Headers is found in headers.
+         """
+        handler = self.serverIface().requestHandler()
+
+        params = handler.parameterMap()
+        if not to_bool(params.get('CHECK_CUSTOM_HEADERS')):
+            return None
+
+        headers = handler.requestHeaders()
+        return headers.get('X-Check-Custom-Headers') is not None

--- a/lizmap/server/lizmap_server.py
+++ b/lizmap/server/lizmap_server.py
@@ -2,11 +2,15 @@ __copyright__ = 'Copyright 2021, 3Liz'
 __license__ = 'GPL version 3'
 __email__ = 'info@3liz.org'
 
+import os
+
+from qgis.core import Qgis
 from qgis.server import QgsServerInterface
 
 from lizmap.server.expression_service import ExpressionService
 from lizmap.server.get_feature_info import GetFeatureInfoFilter
 from lizmap.server.lizmap_accesscontrol import LizmapAccessControlFilter
+from lizmap.server.lizmap_api import LizmapApi
 from lizmap.server.lizmap_filter import LizmapFilter
 from lizmap.server.lizmap_service import LizmapService
 from lizmap.server.logger import Logger
@@ -21,16 +25,35 @@ class LizmapServer:
         self.logger = Logger()
         self.logger.info('Init server')
 
-        reg = server_iface.serviceRegistry()
+        service_registry = server_iface.serviceRegistry()
+
+        # Register API
+        if Qgis.QGIS_VERSION_INT < 31000:
+            self.logger.warning(
+                'Not possible to register the API needed for Lizmap Web Client ≥ 3.6. '
+                'QGIS Server/Desktop must be 3.10 minimum.')
+        else:
+            variable = 'QGIS_SERVER_LIZMAP_REVEAL_SETTINGS'
+            if not os.environ.get(variable, '').lower() in ('1', 'yes', 'y', 'true'):
+                self.logger.warning(
+                    'The environment variable {} must be enabled to have Lizmap Web Client ≥ 3.6. '
+                    'You must be ensure that this API is protected in your webserver, by IP address for '
+                    'instance, allowing only the Lizmap PHP application.'.format(variable)
+                )
+            else:
+                lizmap_api = LizmapApi(self.server_iface)
+                service_registry.registerApi(lizmap_api)
+
+        # Register service
         try:
-            reg.registerService(ExpressionService())
+            service_registry.registerService(ExpressionService())
         except Exception as e:
             self.logger.critical('Error loading service "expression" : {}'.format(e))
             raise
         self.logger.info('Service "expression" loaded')
 
         try:
-            reg.registerService(LizmapService(self.server_iface))
+            service_registry.registerService(LizmapService(self.server_iface))
         except Exception as e:
             self.logger.critical('Error loading service "lizmap" : {}'.format(e))
             raise

--- a/test/server/test_lizmap_api.py
+++ b/test/server/test_lizmap_api.py
@@ -1,0 +1,17 @@
+import json
+
+__copyright__ = 'Copyright 2021, 3Liz'
+__license__ = 'GPL version 3'
+__email__ = 'info@3liz.org'
+
+
+def test_lizmap_api(client):
+    """Test the Lizmap API for server settings"""
+    qs = "/lizmap/server.json"
+    rv = client.get(qs)
+    assert rv.status_code == 200
+
+    assert rv.headers.get('Content-Type', '').find('application/json') == 0
+
+    json_content = json.loads(rv.content.decode('utf-8'))
+    assert 'qgis_server' in json_content


### PR DESCRIPTION
<!---
PUT "dev" branch for any new features or next Lizmap version
PUT "master" for bug fix
-->

* **Funded by**: 3Liz
* **Description**: 
  * No need to have a MAP with a project. A single URL `lizmap.json` for now.

![Capture d’écran de 2021-03-10 16-59-18](https://user-images.githubusercontent.com/1609292/110612865-e3ad6f00-8190-11eb-960f-904a142b8367.png)

Need to forbid this URL IMHO from the Lizmap Web Client side.
And add warning about this URL when someone is exposing QGIS Server on the internet, maybe even disable this request by default without an environment variable ?
