### PR TITLE
Get feature info

### DIFF
--- a/lizmap/forms/base_edition_dialog.py
+++ b/lizmap/forms/base_edition_dialog.py
@@ -18,7 +18,7 @@ from lizmap.definitions.definitions import (
     LwcVersions,
 )
 from lizmap.qgis_plugin_tools.tools.i18n import tr
-from lizmap.qt_style_sheets import NEW_FEATURE
+from lizmap.qt_style_sheets import NEW_FEATURE_CSS
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'
@@ -138,7 +138,7 @@ class BaseEditionDialog(QDialog):
         for lwc_version, items in self.lwc_versions.items():
             if found:
                 for item in items:
-                    item.setStyleSheet(NEW_FEATURE)
+                    item.setStyleSheet(NEW_FEATURE_CSS)
 
             else:
                 for item in items:
@@ -156,9 +156,9 @@ class BaseEditionDialog(QDialog):
                     if version == lwc_version:
                         label = layer_config.get('label')
                         if label:
-                            label.setStyleSheet(NEW_FEATURE)
+                            label.setStyleSheet(NEW_FEATURE_CSS)
                         if layer_config['type'] == InputType.CheckBox:
-                            layer_config.get('widget').setStyleSheet(NEW_FEATURE)
+                            layer_config.get('widget').setStyleSheet(NEW_FEATURE_CSS)
             else:
                 for layer_config in self.config.layer_config.values():
                     version = layer_config.get('version')

--- a/lizmap/forms/dataviz_edition.py
+++ b/lizmap/forms/dataviz_edition.py
@@ -23,7 +23,7 @@ from lizmap.forms.base_edition_dialog import BaseEditionDialog
 from lizmap.forms.trace_dataviz_edition import TraceDatavizEditionDialog
 from lizmap.qgis_plugin_tools.tools.i18n import tr
 from lizmap.qgis_plugin_tools.tools.resources import load_ui
-from lizmap.qt_style_sheets import NEW_FEATURE
+from lizmap.qt_style_sheets import NEW_FEATURE_CSS
 
 __copyright__ = 'Copyright 2020, 3Liz'
 __license__ = 'GPL version 3'
@@ -253,7 +253,7 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
 
         if version in [LwcVersions.Lizmap_3_1, LwcVersions.Lizmap_3_2, LwcVersions.Lizmap_3_3]:
             if self.traces.rowCount() >= 2:
-                self.add_trace.setStyleSheet(NEW_FEATURE)
+                self.add_trace.setStyleSheet(NEW_FEATURE_CSS)
             else:
                 self.add_trace.setStyleSheet('')
         else:

--- a/lizmap/forms/table_manager.py
+++ b/lizmap/forms/table_manager.py
@@ -16,7 +16,7 @@ from lizmap.definitions.dataviz import AggregationType, GraphType
 from lizmap.definitions.definitions import LwcVersions
 from lizmap.qgis_plugin_tools.tools.i18n import tr
 from lizmap.qgis_plugin_tools.tools.resources import plugin_name
-from lizmap.qt_style_sheets import NEW_FEATURE
+from lizmap.qt_style_sheets import NEW_FEATURE_CSS
 
 LOGGER = logging.getLogger(plugin_name())
 
@@ -103,7 +103,7 @@ class TableManager:
                     if version == lwc_version:
                         label = general_config.get('label')
                         if label:
-                            label.setStyleSheet(NEW_FEATURE)
+                            label.setStyleSheet(NEW_FEATURE_CSS)
             else:
                 for general_config in self.definitions.general_config.values():
                     version = general_config.get('version')

--- a/lizmap/lizmap_api/config.py
+++ b/lizmap/lizmap_api/config.py
@@ -267,7 +267,7 @@ class LizmapConfig:
         },
         'popupSource': {
             'wType': 'list', 'type': 'string', 'default': 'auto',
-            'list': ["auto", "lizmap", "qgis"]
+            'list': ["auto", "lizmap", "qgis", "form", ]
         },
         'popupTemplate': {
             'wType': 'text', 'type': 'string', 'default': ''

--- a/lizmap/qt_style_sheets.py
+++ b/lizmap/qt_style_sheets.py
@@ -1,4 +1,6 @@
-NEW_FEATURE = 'background-color:rgb(170, 255, 255);'
+# Both colors MUST be synchronized
+NEW_FEATURE_COLOR = '#aaffff'
+NEW_FEATURE_CSS = 'background-color:rgb(170, 255, 255);'
 
 STYLESHEET = (
     '''

--- a/lizmap/resources/ui/ui_lizmap.ui
+++ b/lizmap/resources/ui/ui_lizmap.ui
@@ -1480,6 +1480,11 @@ border-radius: 0px;</string>
                                <string>qgis</string>
                               </property>
                              </item>
+                             <item>
+                              <property name="text">
+                               <string>form</string>
+                              </property>
+                             </item>
                             </widget>
                            </item>
                            <item>

--- a/lizmap/server/get_feature_info.py
+++ b/lizmap/server/get_feature_info.py
@@ -1,0 +1,162 @@
+__copyright__ = "Copyright 2021, 3Liz"
+__license__ = "GPL version 3"
+__email__ = "info@3liz.org"
+
+import json
+import xml.etree.ElementTree as ET
+
+from collections import namedtuple
+from pathlib import Path
+from typing import Generator, Tuple
+
+from qgis.core import (
+    Qgis,
+    QgsDistanceArea,
+    QgsEditFormConfig,
+    QgsExpression,
+    QgsExpressionContext,
+    QgsExpressionContextUtils,
+    QgsMessageLog,
+)
+from qgis.server import QgsConfigCache, QgsServerFilter
+
+from lizmap.server.core import find_vector_layer
+from lizmap.tooltip import Tooltip
+
+"""
+QGIS Server filter for the GetFeatureInfo according to CFG config.
+"""
+
+
+class GetFeatureInfoFilter(QgsServerFilter):
+
+    @classmethod
+    def parse_xml(cls, string: str) -> Generator[Tuple[str, str], None, None]:
+        """ Generator for layer and feature found in the XML GetFeatureInfo. """
+        root = ET.fromstring(string)
+        for layer in root:
+            for feature in layer:
+                yield layer.attrib['name'], int(feature.attrib['id'])
+
+    @classmethod
+    def append_maptip(cls, string: str, layer_name: str, feature_id: int, maptip: str) -> str:
+        """ Edit the XML GetFeatureInfo by adding a maptip for a given layer and feature ID. """
+        root = ET.fromstring(string)
+        for layer in root:
+            if layer.attrib['name'] != layer_name:
+                continue
+
+            for feature in layer:
+                if int(feature.attrib['id']) != feature_id:
+                    continue
+
+                item = feature.find("Attribute[@name='maptip']")
+                if item is not None:
+                    item.attrib['value'] = maptip
+                else:
+                    item = ET.Element('Attribute')
+                    item.attrib['name'] = "maptip"
+                    item.attrib['value'] = maptip
+                    feature.append(item)
+
+        xml_lines = ET.tostring(root, encoding='utf8', method='xml').decode("utf-8").split('\n')
+        xml_string = '\n'.join(xml_lines[1:])
+        return xml_string.strip()
+
+    def responseComplete(self):
+        """ Intercept the GetFeatureInfo and add the form maptip if needed. """
+        request = self.serverInterface().requestHandler()
+        # request: QgsRequestHandler
+        params = request.parameterMap()
+
+        if params.get('SERVICE', '').upper() != 'WMS':
+            return
+
+        if params.get('REQUEST', '').upper() != 'GETFEATUREINFO':
+            return
+
+        if params.get('INFO_FORMAT', '').upper() != 'TEXT/XML':
+            # Better to log something
+            return
+
+        project_path = Path(self.serverInterface().configFilePath())
+        if not project_path.exists():
+            # QGIS Project path does not exist as a file
+            return
+
+        config_path = Path(self.serverInterface().configFilePath() + '.cfg')
+        if not config_path.exists():
+            return
+
+        with open(config_path, 'r', encoding='utf-8') as cfg_file:
+            cfg = json.loads(cfg_file.read())
+
+        project = QgsConfigCache.instance().project(str(project_path))
+        relation_manager = project.relationManager()
+
+        xml = request.body().data().decode("utf-8")
+
+        output = []
+        Result = namedtuple('Result', ['layer', 'feature', 'expression'])
+
+        for layer_name, feature in self.parse_xml(xml):
+            layer = find_vector_layer(layer_name, project)
+
+            layer_config = cfg.get('layers').get(layer_name)
+            if layer_config.get('popup') not in ['True', True]:
+                continue
+
+            if layer_config.get('popupSource') != 'form':
+                continue
+
+            config = layer.editFormConfig()
+            if config.layout() != QgsEditFormConfig.TabLayout:
+                QgsMessageLog.logMessage(
+                    'The CFG is requesting a form popup, but the layer is not a form drag&drop layout',
+                    'lizmap',
+                    Qgis.Warning
+                )
+                continue
+
+            root = config.invisibleRootContainer()
+
+            # Need to eval the html_content
+            html_content = Tooltip.create_popup_node_item_from_form(layer, root, 0, [], '', relation_manager)
+            html_content = Tooltip.create_popup(html_content)
+
+            # Maybe we can avoid the CSS on all features ?
+            html_content += Tooltip.css()
+
+            output.append(Result(layer, feature, html_content))
+
+        if not output:
+            return
+
+        QgsMessageLog.logMessage(
+            "Replacing the maptip from QGIS by the drag and drop expression for {} features on {}".format(
+                len(output), ','.join([result.layer.name() for result in output])),
+            'lizmap',
+            Qgis.Info
+        )
+
+        # Let's evaluate each expression popup
+        exp_context = QgsExpressionContext()
+        exp_context.appendScope(QgsExpressionContextUtils.globalScope())
+        exp_context.appendScope(QgsExpressionContextUtils.projectScope(project))
+
+        for result in output:
+            distance_area = QgsDistanceArea()
+            distance_area.setSourceCrs(result.layer.crs(), project.transformContext())
+            distance_area.setEllipsoid(project.ellipsoid())
+            exp_context.appendScope(QgsExpressionContextUtils.layerScope(result.layer))
+
+            feature = result.layer.getFeature(int(result.feature))
+            exp_context.setFeature(feature)
+            exp_context.setFields(feature.fields())
+
+            value = QgsExpression.replaceExpressionText(result.expression, exp_context, distance_area)
+            xml = self.append_maptip(xml, result.layer.name(), feature.id(), value)
+
+        request.clear()
+        request.setResponseHeader('Content-Type', 'text/xml')
+        request.appendBody(bytes(xml, 'utf-8'))

--- a/lizmap/server/lizmap_server.py
+++ b/lizmap/server/lizmap_server.py
@@ -7,6 +7,7 @@ import os
 from qgis.server import QgsServerInterface
 
 from .expression_service import ExpressionService
+from .get_feature_info import GetFeatureInfoFilter
 from .lizmap_accesscontrol import LizmapAccessControlFilter
 from .lizmap_filter import LizmapFilter
 from .lizmap_service import LizmapService
@@ -47,3 +48,5 @@ class LizmapServer:
         except Exception as e:
             self.logger.critical('Error loading access control : {}'.format(e))
             raise
+
+        server_iface.registerFilter(GetFeatureInfoFilter(self.server_iface), 150)

--- a/test/server/data/get_feature_info.qgs
+++ b/test/server/data/get_feature_info.qgs
@@ -1,10 +1,9 @@
-<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
 <qgis projectname="" version="3.10.14-A Coruña">
-  <homePath path=""/>
+  <homePath path=""></homePath>
   <title></title>
-  <autotransaction active="0"/>
-  <evaluateDefaultValues active="0"/>
-  <trust active="0"/>
+  <autotransaction active="0"></autotransaction>
+  <evaluateDefaultValues active="0"></evaluateDefaultValues>
+  <trust active="0"></trust>
   <projectCrs>
     <spatialrefsys>
       <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
@@ -19,26 +18,31 @@
     </spatialrefsys>
   </projectCrs>
   <layer-tree-group>
-    <customproperties/>
-    <layer-tree-layer name="default_popup" checked="Qt::Checked" legend_exp="" id="france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3" providerKey="ogr" source="./france_parts/france_parts.shp" expanded="1">
-      <customproperties/>
+    <customproperties></customproperties>
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3" legend_exp="" name="default_popup" providerKey="ogr" source="./france_parts/france_parts.shp">
+      <customproperties></customproperties>
     </layer-tree-layer>
-    <layer-tree-layer name="qgis_popup" checked="Qt::Checked" legend_exp="" id="default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1" providerKey="ogr" source="./france_parts/france_parts.shp" expanded="1">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="qgis_popup_a6f4c4e3_79bc_4443_aab6_7e44ef9fe24b" legend_exp="" name="qgis_form" providerKey="ogr" source="./france_parts/france_parts.shp">
+      <customproperties></customproperties>
+    </layer-tree-layer>
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1" legend_exp="" name="qgis_popup" providerKey="ogr" source="./france_parts/france_parts.shp">
+      <customproperties></customproperties>
     </layer-tree-layer>
     <custom-order enabled="0">
       <item>france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3</item>
       <item>default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1</item>
+      <item>qgis_popup_a6f4c4e3_79bc_4443_aab6_7e44ef9fe24b</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings intersection-snapping="0" tolerance="12" type="1" enabled="0" unit="1" mode="2">
+  <snapping-settings enabled="0" intersection-snapping="0" mode="2" tolerance="12" type="1" unit="1">
     <individual-layer-settings>
-      <layer-setting tolerance="12" type="1" enabled="0" id="france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3" units="1"/>
-      <layer-setting tolerance="12" type="1" enabled="0" id="default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1" units="1"/>
+      <layer-setting enabled="0" id="qgis_popup_a6f4c4e3_79bc_4443_aab6_7e44ef9fe24b" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting enabled="0" id="france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting enabled="0" id="default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1" tolerance="12" type="1" units="1"></layer-setting>
     </individual-layer-settings>
   </snapping-settings>
-  <relations/>
-  <mapcanvas name="theMapCanvas" annotationsVisible="1">
+  <relations></relations>
+  <mapcanvas annotationsVisible="1" name="theMapCanvas">
     <units>degrees</units>
     <extent>
       <xmin>-5.33889081436202328</xmin>
@@ -61,25 +65,30 @@
       </spatialrefsys>
     </destinationsrs>
     <rendermaptile>0</rendermaptile>
-    <expressionContextScope/>
+    <expressionContextScope></expressionContextScope>
   </mapcanvas>
-  <projectModels/>
+  <projectModels></projectModels>
   <legend updateDrawingOrder="true">
-    <legendlayer open="true" name="default_popup" checked="Qt::Checked" drawingOrder="-1" showFeatureCount="0">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="default_popup" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer open="true" name="qgis_popup" checked="Qt::Checked" drawingOrder="-1" showFeatureCount="0">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="qgis_form" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="qgis_popup_a6f4c4e3_79bc_4443_aab6_7e44ef9fe24b" visible="1"></legendlayerfile>
+      </filegroup>
+    </legendlayer>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="qgis_popup" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
   </legend>
-  <mapViewDocks/>
-  <mapViewDocks3D/>
+  <mapViewDocks></mapViewDocks>
+  <mapViewDocks3D></mapViewDocks3D>
   <projectlayers>
-    <maplayer autoRefreshEnabled="0" simplifyAlgorithm="0" geometry="Polygon" labelsEnabled="0" type="vector" refreshOnNotifyEnabled="0" simplifyLocal="1" wkbType="MultiPolygon" simplifyMaxScale="1" simplifyDrawingTol="1" maxScale="0" styleCategories="AllStyleCategories" simplifyDrawingHints="1" refreshOnNotifyMessage="" autoRefreshTime="0" minScale="1e+08" hasScaleBasedVisibilityFlag="0" readOnly="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" maxScale="0" minScale="1e+08" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" type="vector" wkbType="MultiPolygon">
       <extent>
         <xmin>-5.1326269186972695</xmin>
         <ymin>46.2791909857754149</ymin>
@@ -121,7 +130,7 @@
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
@@ -138,7 +147,7 @@
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial miny="0" maxx="0" maxy="0" minx="0" dimensions="2" minz="0" crs="" maxz="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -148,78 +157,78 @@
         </extent>
       </resourceMetadata>
       <provider encoding="ISO-8859-1">ogr</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <legend type="default-vector"></legend>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="défaut">
-        <map-layer-style name="défaut"/>
+        <map-layer-style name="défaut"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 type="singleSymbol" forceraster="0" symbollevels="0" enableorderby="0">
+      <renderer-v2 enableorderby="0" forceraster="0" symbollevels="0" type="singleSymbol">
         <symbols>
-          <symbol clip_to_extent="1" force_rhr="0" type="fill" name="0" alpha="1">
-            <layer locked="0" enabled="1" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="229,182,54,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="35,35,35,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.26" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="solid" k="style"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="fill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="229,182,54,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="35,35,35,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.26"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
       <customproperties>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <property key="embeddedWidgets/count" value="0"></property>
+        <property key="variableNames"></property>
+        <property key="variableValues"></property>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory maxScaleDenominator="1e+08" barWidth="5" height="15" penWidth="0" minScaleDenominator="0" lineSizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" sizeScale="3x:0,0,0,0,0,0" backgroundAlpha="255" penColor="#000000" backgroundColor="#ffffff" sizeType="MM" minimumSize="0" enabled="0" penAlpha="255" scaleBasedVisibility="0" scaleDependency="Area" diagramOrientation="Up" width="15" rotationOffset="270" labelPlacementMethod="XHeight" opacity="1">
-          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" width="15">
+          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+          <attribute color="#000000" field="" label=""></attribute>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings zIndex="0" dist="0" placement="1" showAll="1" priority="0" linePlacementFlags="18" obstacle="0">
+      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="1" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
-        <activeChecks/>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks></activeChecks>
         <checkConfiguration type="Map">
-          <Option type="Map" name="QgsGeometryGapCheck">
-            <Option type="double" name="allowedGapsBuffer" value="0"/>
-            <Option type="bool" name="allowedGapsEnabled" value="false"/>
-            <Option type="QString" name="allowedGapsLayer" value=""/>
+          <Option name="QgsGeometryGapCheck" type="Map">
+            <Option name="allowedGapsBuffer" type="double" value="0"></Option>
+            <Option name="allowedGapsEnabled" type="bool" value="false"></Option>
+            <Option name="allowedGapsLayer" type="QString" value=""></Option>
           </Option>
         </checkConfiguration>
       </geometryOptions>
@@ -227,555 +236,555 @@
         <field name="OBJECTID">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="VertexCou">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ISO">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NAME_0">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NAME_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="VARNAME_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NL_NAME_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="HASC_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="TYPE_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ENGTYPE_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="VALIDFR_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="VALIDTO_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="REMARKS_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Region">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="RegionVar">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ProvNumber">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NEV_Countr">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="FIRST_FIPS">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="FIRST_HASC">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="FIPS_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="gadm_level">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="CheckMe">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Region_Cod">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Region_C_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ScaleRank">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Region_C_2">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Region_C_3">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Country_Pr">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="DataRank">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Abbrev">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Postal">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Area_sqkm">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="sameAsCity">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ADM0_A3">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="MAP_COLOR">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="LabelRank">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Shape_Leng">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Shape_Area">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="OBJECTID" name="" index="0"/>
-        <alias field="VertexCou" name="" index="1"/>
-        <alias field="ISO" name="" index="2"/>
-        <alias field="NAME_0" name="" index="3"/>
-        <alias field="NAME_1" name="" index="4"/>
-        <alias field="VARNAME_1" name="" index="5"/>
-        <alias field="NL_NAME_1" name="" index="6"/>
-        <alias field="HASC_1" name="" index="7"/>
-        <alias field="TYPE_1" name="" index="8"/>
-        <alias field="ENGTYPE_1" name="" index="9"/>
-        <alias field="VALIDFR_1" name="" index="10"/>
-        <alias field="VALIDTO_1" name="" index="11"/>
-        <alias field="REMARKS_1" name="" index="12"/>
-        <alias field="Region" name="" index="13"/>
-        <alias field="RegionVar" name="" index="14"/>
-        <alias field="ProvNumber" name="" index="15"/>
-        <alias field="NEV_Countr" name="" index="16"/>
-        <alias field="FIRST_FIPS" name="" index="17"/>
-        <alias field="FIRST_HASC" name="" index="18"/>
-        <alias field="FIPS_1" name="" index="19"/>
-        <alias field="gadm_level" name="" index="20"/>
-        <alias field="CheckMe" name="" index="21"/>
-        <alias field="Region_Cod" name="" index="22"/>
-        <alias field="Region_C_1" name="" index="23"/>
-        <alias field="ScaleRank" name="" index="24"/>
-        <alias field="Region_C_2" name="" index="25"/>
-        <alias field="Region_C_3" name="" index="26"/>
-        <alias field="Country_Pr" name="" index="27"/>
-        <alias field="DataRank" name="" index="28"/>
-        <alias field="Abbrev" name="" index="29"/>
-        <alias field="Postal" name="" index="30"/>
-        <alias field="Area_sqkm" name="" index="31"/>
-        <alias field="sameAsCity" name="" index="32"/>
-        <alias field="ADM0_A3" name="" index="33"/>
-        <alias field="MAP_COLOR" name="" index="34"/>
-        <alias field="LabelRank" name="" index="35"/>
-        <alias field="Shape_Leng" name="" index="36"/>
-        <alias field="Shape_Area" name="" index="37"/>
+        <alias field="OBJECTID" index="0" name=""></alias>
+        <alias field="VertexCou" index="1" name=""></alias>
+        <alias field="ISO" index="2" name=""></alias>
+        <alias field="NAME_0" index="3" name=""></alias>
+        <alias field="NAME_1" index="4" name=""></alias>
+        <alias field="VARNAME_1" index="5" name=""></alias>
+        <alias field="NL_NAME_1" index="6" name=""></alias>
+        <alias field="HASC_1" index="7" name=""></alias>
+        <alias field="TYPE_1" index="8" name=""></alias>
+        <alias field="ENGTYPE_1" index="9" name=""></alias>
+        <alias field="VALIDFR_1" index="10" name=""></alias>
+        <alias field="VALIDTO_1" index="11" name=""></alias>
+        <alias field="REMARKS_1" index="12" name=""></alias>
+        <alias field="Region" index="13" name=""></alias>
+        <alias field="RegionVar" index="14" name=""></alias>
+        <alias field="ProvNumber" index="15" name=""></alias>
+        <alias field="NEV_Countr" index="16" name=""></alias>
+        <alias field="FIRST_FIPS" index="17" name=""></alias>
+        <alias field="FIRST_HASC" index="18" name=""></alias>
+        <alias field="FIPS_1" index="19" name=""></alias>
+        <alias field="gadm_level" index="20" name=""></alias>
+        <alias field="CheckMe" index="21" name=""></alias>
+        <alias field="Region_Cod" index="22" name=""></alias>
+        <alias field="Region_C_1" index="23" name=""></alias>
+        <alias field="ScaleRank" index="24" name=""></alias>
+        <alias field="Region_C_2" index="25" name=""></alias>
+        <alias field="Region_C_3" index="26" name=""></alias>
+        <alias field="Country_Pr" index="27" name=""></alias>
+        <alias field="DataRank" index="28" name=""></alias>
+        <alias field="Abbrev" index="29" name=""></alias>
+        <alias field="Postal" index="30" name=""></alias>
+        <alias field="Area_sqkm" index="31" name=""></alias>
+        <alias field="sameAsCity" index="32" name=""></alias>
+        <alias field="ADM0_A3" index="33" name=""></alias>
+        <alias field="MAP_COLOR" index="34" name=""></alias>
+        <alias field="LabelRank" index="35" name=""></alias>
+        <alias field="Shape_Leng" index="36" name=""></alias>
+        <alias field="Shape_Area" index="37" name=""></alias>
       </aliases>
       <excludeAttributesWMS>
-        <attribute>Country_Pr</attribute>
-        <attribute>TYPE_1</attribute>
-        <attribute>VertexCou</attribute>
-        <attribute>Region_C_1</attribute>
-        <attribute>FIRST_HASC</attribute>
-        <attribute>CheckMe</attribute>
-        <attribute>NAME_1</attribute>
-        <attribute>sameAsCity</attribute>
-        <attribute>MAP_COLOR</attribute>
-        <attribute>FIPS_1</attribute>
-        <attribute>gadm_level</attribute>
-        <attribute>HASC_1</attribute>
-        <attribute>Area_sqkm</attribute>
-        <attribute>FIRST_FIPS</attribute>
-        <attribute>ISO</attribute>
-        <attribute>Region_Cod</attribute>
-        <attribute>VALIDTO_1</attribute>
-        <attribute>DataRank</attribute>
         <attribute>Abbrev</attribute>
-        <attribute>ADM0_A3</attribute>
+        <attribute>NAME_1</attribute>
         <attribute>Region_C_2</attribute>
+        <attribute>Country_Pr</attribute>
+        <attribute>CheckMe</attribute>
         <attribute>NL_NAME_1</attribute>
-        <attribute>LabelRank</attribute>
+        <attribute>VertexCou</attribute>
+        <attribute>VALIDTO_1</attribute>
+        <attribute>FIRST_FIPS</attribute>
+        <attribute>FIRST_HASC</attribute>
+        <attribute>ADM0_A3</attribute>
+        <attribute>TYPE_1</attribute>
+        <attribute>DataRank</attribute>
+        <attribute>Area_sqkm</attribute>
+        <attribute>FIPS_1</attribute>
+        <attribute>sameAsCity</attribute>
         <attribute>ENGTYPE_1</attribute>
+        <attribute>VALIDFR_1</attribute>
+        <attribute>Region_Cod</attribute>
+        <attribute>ProvNumber</attribute>
+        <attribute>ISO</attribute>
         <attribute>REMARKS_1</attribute>
+        <attribute>gadm_level</attribute>
         <attribute>Region_C_3</attribute>
-        <attribute>NEV_Countr</attribute>
         <attribute>Postal</attribute>
         <attribute>RegionVar</attribute>
-        <attribute>VALIDFR_1</attribute>
-        <attribute>ProvNumber</attribute>
+        <attribute>LabelRank</attribute>
+        <attribute>MAP_COLOR</attribute>
+        <attribute>HASC_1</attribute>
         <attribute>ScaleRank</attribute>
+        <attribute>Region_C_1</attribute>
+        <attribute>NEV_Countr</attribute>
       </excludeAttributesWMS>
       <excludeAttributesWFS>
-        <attribute>Country_Pr</attribute>
-        <attribute>TYPE_1</attribute>
-        <attribute>VertexCou</attribute>
-        <attribute>Region_C_1</attribute>
-        <attribute>FIRST_HASC</attribute>
-        <attribute>CheckMe</attribute>
-        <attribute>NAME_1</attribute>
-        <attribute>sameAsCity</attribute>
-        <attribute>MAP_COLOR</attribute>
-        <attribute>FIPS_1</attribute>
-        <attribute>gadm_level</attribute>
-        <attribute>HASC_1</attribute>
-        <attribute>Area_sqkm</attribute>
-        <attribute>FIRST_FIPS</attribute>
-        <attribute>ISO</attribute>
-        <attribute>Region_Cod</attribute>
-        <attribute>VALIDTO_1</attribute>
-        <attribute>DataRank</attribute>
         <attribute>Abbrev</attribute>
-        <attribute>ADM0_A3</attribute>
+        <attribute>NAME_1</attribute>
         <attribute>Region_C_2</attribute>
+        <attribute>Country_Pr</attribute>
+        <attribute>CheckMe</attribute>
         <attribute>NL_NAME_1</attribute>
-        <attribute>LabelRank</attribute>
+        <attribute>VertexCou</attribute>
+        <attribute>VALIDTO_1</attribute>
+        <attribute>FIRST_FIPS</attribute>
+        <attribute>FIRST_HASC</attribute>
+        <attribute>ADM0_A3</attribute>
+        <attribute>TYPE_1</attribute>
+        <attribute>DataRank</attribute>
+        <attribute>Area_sqkm</attribute>
+        <attribute>FIPS_1</attribute>
+        <attribute>sameAsCity</attribute>
         <attribute>ENGTYPE_1</attribute>
+        <attribute>VALIDFR_1</attribute>
+        <attribute>Region_Cod</attribute>
+        <attribute>ProvNumber</attribute>
+        <attribute>ISO</attribute>
         <attribute>REMARKS_1</attribute>
+        <attribute>gadm_level</attribute>
         <attribute>Region_C_3</attribute>
-        <attribute>NEV_Countr</attribute>
         <attribute>Postal</attribute>
         <attribute>RegionVar</attribute>
-        <attribute>VALIDFR_1</attribute>
-        <attribute>ProvNumber</attribute>
+        <attribute>LabelRank</attribute>
+        <attribute>MAP_COLOR</attribute>
+        <attribute>HASC_1</attribute>
         <attribute>ScaleRank</attribute>
+        <attribute>Region_C_1</attribute>
+        <attribute>NEV_Countr</attribute>
       </excludeAttributesWFS>
       <defaults>
-        <default field="OBJECTID" expression="" applyOnUpdate="0"/>
-        <default field="VertexCou" expression="" applyOnUpdate="0"/>
-        <default field="ISO" expression="" applyOnUpdate="0"/>
-        <default field="NAME_0" expression="" applyOnUpdate="0"/>
-        <default field="NAME_1" expression="" applyOnUpdate="0"/>
-        <default field="VARNAME_1" expression="" applyOnUpdate="0"/>
-        <default field="NL_NAME_1" expression="" applyOnUpdate="0"/>
-        <default field="HASC_1" expression="" applyOnUpdate="0"/>
-        <default field="TYPE_1" expression="" applyOnUpdate="0"/>
-        <default field="ENGTYPE_1" expression="" applyOnUpdate="0"/>
-        <default field="VALIDFR_1" expression="" applyOnUpdate="0"/>
-        <default field="VALIDTO_1" expression="" applyOnUpdate="0"/>
-        <default field="REMARKS_1" expression="" applyOnUpdate="0"/>
-        <default field="Region" expression="" applyOnUpdate="0"/>
-        <default field="RegionVar" expression="" applyOnUpdate="0"/>
-        <default field="ProvNumber" expression="" applyOnUpdate="0"/>
-        <default field="NEV_Countr" expression="" applyOnUpdate="0"/>
-        <default field="FIRST_FIPS" expression="" applyOnUpdate="0"/>
-        <default field="FIRST_HASC" expression="" applyOnUpdate="0"/>
-        <default field="FIPS_1" expression="" applyOnUpdate="0"/>
-        <default field="gadm_level" expression="" applyOnUpdate="0"/>
-        <default field="CheckMe" expression="" applyOnUpdate="0"/>
-        <default field="Region_Cod" expression="" applyOnUpdate="0"/>
-        <default field="Region_C_1" expression="" applyOnUpdate="0"/>
-        <default field="ScaleRank" expression="" applyOnUpdate="0"/>
-        <default field="Region_C_2" expression="" applyOnUpdate="0"/>
-        <default field="Region_C_3" expression="" applyOnUpdate="0"/>
-        <default field="Country_Pr" expression="" applyOnUpdate="0"/>
-        <default field="DataRank" expression="" applyOnUpdate="0"/>
-        <default field="Abbrev" expression="" applyOnUpdate="0"/>
-        <default field="Postal" expression="" applyOnUpdate="0"/>
-        <default field="Area_sqkm" expression="" applyOnUpdate="0"/>
-        <default field="sameAsCity" expression="" applyOnUpdate="0"/>
-        <default field="ADM0_A3" expression="" applyOnUpdate="0"/>
-        <default field="MAP_COLOR" expression="" applyOnUpdate="0"/>
-        <default field="LabelRank" expression="" applyOnUpdate="0"/>
-        <default field="Shape_Leng" expression="" applyOnUpdate="0"/>
-        <default field="Shape_Area" expression="" applyOnUpdate="0"/>
+        <default applyOnUpdate="0" expression="" field="OBJECTID"></default>
+        <default applyOnUpdate="0" expression="" field="VertexCou"></default>
+        <default applyOnUpdate="0" expression="" field="ISO"></default>
+        <default applyOnUpdate="0" expression="" field="NAME_0"></default>
+        <default applyOnUpdate="0" expression="" field="NAME_1"></default>
+        <default applyOnUpdate="0" expression="" field="VARNAME_1"></default>
+        <default applyOnUpdate="0" expression="" field="NL_NAME_1"></default>
+        <default applyOnUpdate="0" expression="" field="HASC_1"></default>
+        <default applyOnUpdate="0" expression="" field="TYPE_1"></default>
+        <default applyOnUpdate="0" expression="" field="ENGTYPE_1"></default>
+        <default applyOnUpdate="0" expression="" field="VALIDFR_1"></default>
+        <default applyOnUpdate="0" expression="" field="VALIDTO_1"></default>
+        <default applyOnUpdate="0" expression="" field="REMARKS_1"></default>
+        <default applyOnUpdate="0" expression="" field="Region"></default>
+        <default applyOnUpdate="0" expression="" field="RegionVar"></default>
+        <default applyOnUpdate="0" expression="" field="ProvNumber"></default>
+        <default applyOnUpdate="0" expression="" field="NEV_Countr"></default>
+        <default applyOnUpdate="0" expression="" field="FIRST_FIPS"></default>
+        <default applyOnUpdate="0" expression="" field="FIRST_HASC"></default>
+        <default applyOnUpdate="0" expression="" field="FIPS_1"></default>
+        <default applyOnUpdate="0" expression="" field="gadm_level"></default>
+        <default applyOnUpdate="0" expression="" field="CheckMe"></default>
+        <default applyOnUpdate="0" expression="" field="Region_Cod"></default>
+        <default applyOnUpdate="0" expression="" field="Region_C_1"></default>
+        <default applyOnUpdate="0" expression="" field="ScaleRank"></default>
+        <default applyOnUpdate="0" expression="" field="Region_C_2"></default>
+        <default applyOnUpdate="0" expression="" field="Region_C_3"></default>
+        <default applyOnUpdate="0" expression="" field="Country_Pr"></default>
+        <default applyOnUpdate="0" expression="" field="DataRank"></default>
+        <default applyOnUpdate="0" expression="" field="Abbrev"></default>
+        <default applyOnUpdate="0" expression="" field="Postal"></default>
+        <default applyOnUpdate="0" expression="" field="Area_sqkm"></default>
+        <default applyOnUpdate="0" expression="" field="sameAsCity"></default>
+        <default applyOnUpdate="0" expression="" field="ADM0_A3"></default>
+        <default applyOnUpdate="0" expression="" field="MAP_COLOR"></default>
+        <default applyOnUpdate="0" expression="" field="LabelRank"></default>
+        <default applyOnUpdate="0" expression="" field="Shape_Leng"></default>
+        <default applyOnUpdate="0" expression="" field="Shape_Area"></default>
       </defaults>
       <constraints>
-        <constraint field="OBJECTID" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="VertexCou" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="ISO" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="NAME_0" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="NAME_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="VARNAME_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="NL_NAME_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="HASC_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="TYPE_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="ENGTYPE_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="VALIDFR_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="VALIDTO_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="REMARKS_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Region" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="RegionVar" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="ProvNumber" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="NEV_Countr" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="FIRST_FIPS" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="FIRST_HASC" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="FIPS_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="gadm_level" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="CheckMe" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Region_Cod" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Region_C_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="ScaleRank" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Region_C_2" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Region_C_3" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Country_Pr" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="DataRank" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Abbrev" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Postal" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Area_sqkm" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="sameAsCity" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="ADM0_A3" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="MAP_COLOR" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="LabelRank" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Shape_Leng" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Shape_Area" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint constraints="0" exp_strength="0" field="OBJECTID" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="VertexCou" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ISO" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NAME_0" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NAME_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="VARNAME_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NL_NAME_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="HASC_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="TYPE_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ENGTYPE_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="VALIDFR_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="VALIDTO_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="REMARKS_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="RegionVar" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ProvNumber" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NEV_Countr" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="FIRST_FIPS" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="FIRST_HASC" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="FIPS_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="gadm_level" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="CheckMe" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region_Cod" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region_C_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ScaleRank" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region_C_2" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region_C_3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Country_Pr" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="DataRank" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Abbrev" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Postal" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Area_sqkm" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="sameAsCity" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ADM0_A3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="MAP_COLOR" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="LabelRank" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Shape_Leng" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Shape_Area" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="OBJECTID" exp="" desc=""/>
-        <constraint field="VertexCou" exp="" desc=""/>
-        <constraint field="ISO" exp="" desc=""/>
-        <constraint field="NAME_0" exp="" desc=""/>
-        <constraint field="NAME_1" exp="" desc=""/>
-        <constraint field="VARNAME_1" exp="" desc=""/>
-        <constraint field="NL_NAME_1" exp="" desc=""/>
-        <constraint field="HASC_1" exp="" desc=""/>
-        <constraint field="TYPE_1" exp="" desc=""/>
-        <constraint field="ENGTYPE_1" exp="" desc=""/>
-        <constraint field="VALIDFR_1" exp="" desc=""/>
-        <constraint field="VALIDTO_1" exp="" desc=""/>
-        <constraint field="REMARKS_1" exp="" desc=""/>
-        <constraint field="Region" exp="" desc=""/>
-        <constraint field="RegionVar" exp="" desc=""/>
-        <constraint field="ProvNumber" exp="" desc=""/>
-        <constraint field="NEV_Countr" exp="" desc=""/>
-        <constraint field="FIRST_FIPS" exp="" desc=""/>
-        <constraint field="FIRST_HASC" exp="" desc=""/>
-        <constraint field="FIPS_1" exp="" desc=""/>
-        <constraint field="gadm_level" exp="" desc=""/>
-        <constraint field="CheckMe" exp="" desc=""/>
-        <constraint field="Region_Cod" exp="" desc=""/>
-        <constraint field="Region_C_1" exp="" desc=""/>
-        <constraint field="ScaleRank" exp="" desc=""/>
-        <constraint field="Region_C_2" exp="" desc=""/>
-        <constraint field="Region_C_3" exp="" desc=""/>
-        <constraint field="Country_Pr" exp="" desc=""/>
-        <constraint field="DataRank" exp="" desc=""/>
-        <constraint field="Abbrev" exp="" desc=""/>
-        <constraint field="Postal" exp="" desc=""/>
-        <constraint field="Area_sqkm" exp="" desc=""/>
-        <constraint field="sameAsCity" exp="" desc=""/>
-        <constraint field="ADM0_A3" exp="" desc=""/>
-        <constraint field="MAP_COLOR" exp="" desc=""/>
-        <constraint field="LabelRank" exp="" desc=""/>
-        <constraint field="Shape_Leng" exp="" desc=""/>
-        <constraint field="Shape_Area" exp="" desc=""/>
+        <constraint desc="" exp="" field="OBJECTID"></constraint>
+        <constraint desc="" exp="" field="VertexCou"></constraint>
+        <constraint desc="" exp="" field="ISO"></constraint>
+        <constraint desc="" exp="" field="NAME_0"></constraint>
+        <constraint desc="" exp="" field="NAME_1"></constraint>
+        <constraint desc="" exp="" field="VARNAME_1"></constraint>
+        <constraint desc="" exp="" field="NL_NAME_1"></constraint>
+        <constraint desc="" exp="" field="HASC_1"></constraint>
+        <constraint desc="" exp="" field="TYPE_1"></constraint>
+        <constraint desc="" exp="" field="ENGTYPE_1"></constraint>
+        <constraint desc="" exp="" field="VALIDFR_1"></constraint>
+        <constraint desc="" exp="" field="VALIDTO_1"></constraint>
+        <constraint desc="" exp="" field="REMARKS_1"></constraint>
+        <constraint desc="" exp="" field="Region"></constraint>
+        <constraint desc="" exp="" field="RegionVar"></constraint>
+        <constraint desc="" exp="" field="ProvNumber"></constraint>
+        <constraint desc="" exp="" field="NEV_Countr"></constraint>
+        <constraint desc="" exp="" field="FIRST_FIPS"></constraint>
+        <constraint desc="" exp="" field="FIRST_HASC"></constraint>
+        <constraint desc="" exp="" field="FIPS_1"></constraint>
+        <constraint desc="" exp="" field="gadm_level"></constraint>
+        <constraint desc="" exp="" field="CheckMe"></constraint>
+        <constraint desc="" exp="" field="Region_Cod"></constraint>
+        <constraint desc="" exp="" field="Region_C_1"></constraint>
+        <constraint desc="" exp="" field="ScaleRank"></constraint>
+        <constraint desc="" exp="" field="Region_C_2"></constraint>
+        <constraint desc="" exp="" field="Region_C_3"></constraint>
+        <constraint desc="" exp="" field="Country_Pr"></constraint>
+        <constraint desc="" exp="" field="DataRank"></constraint>
+        <constraint desc="" exp="" field="Abbrev"></constraint>
+        <constraint desc="" exp="" field="Postal"></constraint>
+        <constraint desc="" exp="" field="Area_sqkm"></constraint>
+        <constraint desc="" exp="" field="sameAsCity"></constraint>
+        <constraint desc="" exp="" field="ADM0_A3"></constraint>
+        <constraint desc="" exp="" field="MAP_COLOR"></constraint>
+        <constraint desc="" exp="" field="LabelRank"></constraint>
+        <constraint desc="" exp="" field="Shape_Leng"></constraint>
+        <constraint desc="" exp="" field="Shape_Area"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" name="OBJECTID" width="-1" hidden="0"/>
-          <column type="field" name="VertexCou" width="-1" hidden="0"/>
-          <column type="field" name="ISO" width="-1" hidden="0"/>
-          <column type="field" name="NAME_0" width="-1" hidden="0"/>
-          <column type="field" name="NAME_1" width="-1" hidden="0"/>
-          <column type="field" name="VARNAME_1" width="-1" hidden="0"/>
-          <column type="field" name="NL_NAME_1" width="-1" hidden="0"/>
-          <column type="field" name="HASC_1" width="-1" hidden="0"/>
-          <column type="field" name="TYPE_1" width="-1" hidden="0"/>
-          <column type="field" name="ENGTYPE_1" width="-1" hidden="0"/>
-          <column type="field" name="VALIDFR_1" width="-1" hidden="0"/>
-          <column type="field" name="VALIDTO_1" width="-1" hidden="0"/>
-          <column type="field" name="REMARKS_1" width="-1" hidden="0"/>
-          <column type="field" name="Region" width="-1" hidden="0"/>
-          <column type="field" name="RegionVar" width="-1" hidden="0"/>
-          <column type="field" name="ProvNumber" width="-1" hidden="0"/>
-          <column type="field" name="NEV_Countr" width="-1" hidden="0"/>
-          <column type="field" name="FIRST_FIPS" width="-1" hidden="0"/>
-          <column type="field" name="FIRST_HASC" width="-1" hidden="0"/>
-          <column type="field" name="FIPS_1" width="-1" hidden="0"/>
-          <column type="field" name="gadm_level" width="-1" hidden="0"/>
-          <column type="field" name="CheckMe" width="-1" hidden="0"/>
-          <column type="field" name="Region_Cod" width="-1" hidden="0"/>
-          <column type="field" name="Region_C_1" width="-1" hidden="0"/>
-          <column type="field" name="ScaleRank" width="-1" hidden="0"/>
-          <column type="field" name="Region_C_2" width="-1" hidden="0"/>
-          <column type="field" name="Region_C_3" width="-1" hidden="0"/>
-          <column type="field" name="Country_Pr" width="-1" hidden="0"/>
-          <column type="field" name="DataRank" width="-1" hidden="0"/>
-          <column type="field" name="Abbrev" width="-1" hidden="0"/>
-          <column type="field" name="Postal" width="-1" hidden="0"/>
-          <column type="field" name="Area_sqkm" width="-1" hidden="0"/>
-          <column type="field" name="sameAsCity" width="-1" hidden="0"/>
-          <column type="field" name="ADM0_A3" width="-1" hidden="0"/>
-          <column type="field" name="MAP_COLOR" width="-1" hidden="0"/>
-          <column type="field" name="LabelRank" width="-1" hidden="0"/>
-          <column type="field" name="Shape_Leng" width="-1" hidden="0"/>
-          <column type="field" name="Shape_Area" width="-1" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
+          <column hidden="0" name="OBJECTID" type="field" width="-1"></column>
+          <column hidden="0" name="VertexCou" type="field" width="-1"></column>
+          <column hidden="0" name="ISO" type="field" width="-1"></column>
+          <column hidden="0" name="NAME_0" type="field" width="-1"></column>
+          <column hidden="0" name="NAME_1" type="field" width="-1"></column>
+          <column hidden="0" name="VARNAME_1" type="field" width="-1"></column>
+          <column hidden="0" name="NL_NAME_1" type="field" width="-1"></column>
+          <column hidden="0" name="HASC_1" type="field" width="-1"></column>
+          <column hidden="0" name="TYPE_1" type="field" width="-1"></column>
+          <column hidden="0" name="ENGTYPE_1" type="field" width="-1"></column>
+          <column hidden="0" name="VALIDFR_1" type="field" width="-1"></column>
+          <column hidden="0" name="VALIDTO_1" type="field" width="-1"></column>
+          <column hidden="0" name="REMARKS_1" type="field" width="-1"></column>
+          <column hidden="0" name="Region" type="field" width="-1"></column>
+          <column hidden="0" name="RegionVar" type="field" width="-1"></column>
+          <column hidden="0" name="ProvNumber" type="field" width="-1"></column>
+          <column hidden="0" name="NEV_Countr" type="field" width="-1"></column>
+          <column hidden="0" name="FIRST_FIPS" type="field" width="-1"></column>
+          <column hidden="0" name="FIRST_HASC" type="field" width="-1"></column>
+          <column hidden="0" name="FIPS_1" type="field" width="-1"></column>
+          <column hidden="0" name="gadm_level" type="field" width="-1"></column>
+          <column hidden="0" name="CheckMe" type="field" width="-1"></column>
+          <column hidden="0" name="Region_Cod" type="field" width="-1"></column>
+          <column hidden="0" name="Region_C_1" type="field" width="-1"></column>
+          <column hidden="0" name="ScaleRank" type="field" width="-1"></column>
+          <column hidden="0" name="Region_C_2" type="field" width="-1"></column>
+          <column hidden="0" name="Region_C_3" type="field" width="-1"></column>
+          <column hidden="0" name="Country_Pr" type="field" width="-1"></column>
+          <column hidden="0" name="DataRank" type="field" width="-1"></column>
+          <column hidden="0" name="Abbrev" type="field" width="-1"></column>
+          <column hidden="0" name="Postal" type="field" width="-1"></column>
+          <column hidden="0" name="Area_sqkm" type="field" width="-1"></column>
+          <column hidden="0" name="sameAsCity" type="field" width="-1"></column>
+          <column hidden="0" name="ADM0_A3" type="field" width="-1"></column>
+          <column hidden="0" name="MAP_COLOR" type="field" width="-1"></column>
+          <column hidden="0" name="LabelRank" type="field" width="-1"></column>
+          <column hidden="0" name="Shape_Leng" type="field" width="-1"></column>
+          <column hidden="0" name="Shape_Area" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 Les formulaires QGIS peuvent avoir une fonction Python qui sera appelée à l'ouverture du formulaire.
 
@@ -790,94 +799,94 @@ def my_form_open(dialog, layer, feature):
     geom = feature.geometry()
     control = dialog.findChild(QWidget, "MyLineEdit")
 
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field name="ADM0_A3" editable="1"/>
-        <field name="Abbrev" editable="1"/>
-        <field name="Area_sqkm" editable="1"/>
-        <field name="CheckMe" editable="1"/>
-        <field name="Country_Pr" editable="1"/>
-        <field name="DataRank" editable="1"/>
-        <field name="ENGTYPE_1" editable="1"/>
-        <field name="FIPS_1" editable="1"/>
-        <field name="FIRST_FIPS" editable="1"/>
-        <field name="FIRST_HASC" editable="1"/>
-        <field name="HASC_1" editable="1"/>
-        <field name="ISO" editable="1"/>
-        <field name="LabelRank" editable="1"/>
-        <field name="MAP_COLOR" editable="1"/>
-        <field name="NAME_0" editable="1"/>
-        <field name="NAME_1" editable="1"/>
-        <field name="NEV_Countr" editable="1"/>
-        <field name="NL_NAME_1" editable="1"/>
-        <field name="OBJECTID" editable="1"/>
-        <field name="Postal" editable="1"/>
-        <field name="ProvNumber" editable="1"/>
-        <field name="REMARKS_1" editable="1"/>
-        <field name="Region" editable="1"/>
-        <field name="RegionVar" editable="1"/>
-        <field name="Region_C_1" editable="1"/>
-        <field name="Region_C_2" editable="1"/>
-        <field name="Region_C_3" editable="1"/>
-        <field name="Region_Cod" editable="1"/>
-        <field name="ScaleRank" editable="1"/>
-        <field name="Shape_Area" editable="1"/>
-        <field name="Shape_Leng" editable="1"/>
-        <field name="TYPE_1" editable="1"/>
-        <field name="VALIDFR_1" editable="1"/>
-        <field name="VALIDTO_1" editable="1"/>
-        <field name="VARNAME_1" editable="1"/>
-        <field name="VertexCou" editable="1"/>
-        <field name="gadm_level" editable="1"/>
-        <field name="sameAsCity" editable="1"/>
+        <field editable="1" name="ADM0_A3"></field>
+        <field editable="1" name="Abbrev"></field>
+        <field editable="1" name="Area_sqkm"></field>
+        <field editable="1" name="CheckMe"></field>
+        <field editable="1" name="Country_Pr"></field>
+        <field editable="1" name="DataRank"></field>
+        <field editable="1" name="ENGTYPE_1"></field>
+        <field editable="1" name="FIPS_1"></field>
+        <field editable="1" name="FIRST_FIPS"></field>
+        <field editable="1" name="FIRST_HASC"></field>
+        <field editable="1" name="HASC_1"></field>
+        <field editable="1" name="ISO"></field>
+        <field editable="1" name="LabelRank"></field>
+        <field editable="1" name="MAP_COLOR"></field>
+        <field editable="1" name="NAME_0"></field>
+        <field editable="1" name="NAME_1"></field>
+        <field editable="1" name="NEV_Countr"></field>
+        <field editable="1" name="NL_NAME_1"></field>
+        <field editable="1" name="OBJECTID"></field>
+        <field editable="1" name="Postal"></field>
+        <field editable="1" name="ProvNumber"></field>
+        <field editable="1" name="REMARKS_1"></field>
+        <field editable="1" name="Region"></field>
+        <field editable="1" name="RegionVar"></field>
+        <field editable="1" name="Region_C_1"></field>
+        <field editable="1" name="Region_C_2"></field>
+        <field editable="1" name="Region_C_3"></field>
+        <field editable="1" name="Region_Cod"></field>
+        <field editable="1" name="ScaleRank"></field>
+        <field editable="1" name="Shape_Area"></field>
+        <field editable="1" name="Shape_Leng"></field>
+        <field editable="1" name="TYPE_1"></field>
+        <field editable="1" name="VALIDFR_1"></field>
+        <field editable="1" name="VALIDTO_1"></field>
+        <field editable="1" name="VARNAME_1"></field>
+        <field editable="1" name="VertexCou"></field>
+        <field editable="1" name="gadm_level"></field>
+        <field editable="1" name="sameAsCity"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="ADM0_A3"/>
-        <field labelOnTop="0" name="Abbrev"/>
-        <field labelOnTop="0" name="Area_sqkm"/>
-        <field labelOnTop="0" name="CheckMe"/>
-        <field labelOnTop="0" name="Country_Pr"/>
-        <field labelOnTop="0" name="DataRank"/>
-        <field labelOnTop="0" name="ENGTYPE_1"/>
-        <field labelOnTop="0" name="FIPS_1"/>
-        <field labelOnTop="0" name="FIRST_FIPS"/>
-        <field labelOnTop="0" name="FIRST_HASC"/>
-        <field labelOnTop="0" name="HASC_1"/>
-        <field labelOnTop="0" name="ISO"/>
-        <field labelOnTop="0" name="LabelRank"/>
-        <field labelOnTop="0" name="MAP_COLOR"/>
-        <field labelOnTop="0" name="NAME_0"/>
-        <field labelOnTop="0" name="NAME_1"/>
-        <field labelOnTop="0" name="NEV_Countr"/>
-        <field labelOnTop="0" name="NL_NAME_1"/>
-        <field labelOnTop="0" name="OBJECTID"/>
-        <field labelOnTop="0" name="Postal"/>
-        <field labelOnTop="0" name="ProvNumber"/>
-        <field labelOnTop="0" name="REMARKS_1"/>
-        <field labelOnTop="0" name="Region"/>
-        <field labelOnTop="0" name="RegionVar"/>
-        <field labelOnTop="0" name="Region_C_1"/>
-        <field labelOnTop="0" name="Region_C_2"/>
-        <field labelOnTop="0" name="Region_C_3"/>
-        <field labelOnTop="0" name="Region_Cod"/>
-        <field labelOnTop="0" name="ScaleRank"/>
-        <field labelOnTop="0" name="Shape_Area"/>
-        <field labelOnTop="0" name="Shape_Leng"/>
-        <field labelOnTop="0" name="TYPE_1"/>
-        <field labelOnTop="0" name="VALIDFR_1"/>
-        <field labelOnTop="0" name="VALIDTO_1"/>
-        <field labelOnTop="0" name="VARNAME_1"/>
-        <field labelOnTop="0" name="VertexCou"/>
-        <field labelOnTop="0" name="gadm_level"/>
-        <field labelOnTop="0" name="sameAsCity"/>
+        <field labelOnTop="0" name="ADM0_A3"></field>
+        <field labelOnTop="0" name="Abbrev"></field>
+        <field labelOnTop="0" name="Area_sqkm"></field>
+        <field labelOnTop="0" name="CheckMe"></field>
+        <field labelOnTop="0" name="Country_Pr"></field>
+        <field labelOnTop="0" name="DataRank"></field>
+        <field labelOnTop="0" name="ENGTYPE_1"></field>
+        <field labelOnTop="0" name="FIPS_1"></field>
+        <field labelOnTop="0" name="FIRST_FIPS"></field>
+        <field labelOnTop="0" name="FIRST_HASC"></field>
+        <field labelOnTop="0" name="HASC_1"></field>
+        <field labelOnTop="0" name="ISO"></field>
+        <field labelOnTop="0" name="LabelRank"></field>
+        <field labelOnTop="0" name="MAP_COLOR"></field>
+        <field labelOnTop="0" name="NAME_0"></field>
+        <field labelOnTop="0" name="NAME_1"></field>
+        <field labelOnTop="0" name="NEV_Countr"></field>
+        <field labelOnTop="0" name="NL_NAME_1"></field>
+        <field labelOnTop="0" name="OBJECTID"></field>
+        <field labelOnTop="0" name="Postal"></field>
+        <field labelOnTop="0" name="ProvNumber"></field>
+        <field labelOnTop="0" name="REMARKS_1"></field>
+        <field labelOnTop="0" name="Region"></field>
+        <field labelOnTop="0" name="RegionVar"></field>
+        <field labelOnTop="0" name="Region_C_1"></field>
+        <field labelOnTop="0" name="Region_C_2"></field>
+        <field labelOnTop="0" name="Region_C_3"></field>
+        <field labelOnTop="0" name="Region_Cod"></field>
+        <field labelOnTop="0" name="ScaleRank"></field>
+        <field labelOnTop="0" name="Shape_Area"></field>
+        <field labelOnTop="0" name="Shape_Leng"></field>
+        <field labelOnTop="0" name="TYPE_1"></field>
+        <field labelOnTop="0" name="VALIDFR_1"></field>
+        <field labelOnTop="0" name="VALIDTO_1"></field>
+        <field labelOnTop="0" name="VARNAME_1"></field>
+        <field labelOnTop="0" name="VertexCou"></field>
+        <field labelOnTop="0" name="gadm_level"></field>
+        <field labelOnTop="0" name="sameAsCity"></field>
       </labelOnTop>
-      <widgets/>
+      <widgets></widgets>
       <previewExpression>"NAME_0"</previewExpression>
-      <mapTip>&lt;p>[% "NAME_0" %]&lt;/p></mapTip>
+      <mapTip>&lt;p&gt;[% "NAME_0" %]&lt;/p&gt;</mapTip>
     </maplayer>
-    <maplayer autoRefreshEnabled="0" simplifyAlgorithm="0" geometry="Polygon" labelsEnabled="0" type="vector" refreshOnNotifyEnabled="0" simplifyLocal="1" wkbType="MultiPolygon" simplifyMaxScale="1" simplifyDrawingTol="1" maxScale="0" styleCategories="AllStyleCategories" simplifyDrawingHints="1" refreshOnNotifyMessage="" autoRefreshTime="0" minScale="1e+08" hasScaleBasedVisibilityFlag="0" readOnly="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" maxScale="0" minScale="1e+08" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" type="vector" wkbType="MultiPolygon">
       <extent>
         <xmin>-5.1326269186972695</xmin>
         <ymin>46.2791909857754149</ymin>
@@ -919,7 +928,7 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
@@ -936,7 +945,7 @@ def my_form_open(dialog, layer, feature):
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial miny="0" maxx="0" maxy="0" minx="0" dimensions="2" minz="0" crs="" maxz="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -946,127 +955,127 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="ISO-8859-1">ogr</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <legend type="default-vector"/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <legend type="default-vector"></legend>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="défaut">
-        <map-layer-style name="défaut"/>
+        <map-layer-style name="défaut"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
+      <auxiliaryLayer></auxiliaryLayer>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 type="singleSymbol" forceraster="0" symbollevels="0" enableorderby="0">
+      <renderer-v2 enableorderby="0" forceraster="0" symbollevels="0" type="singleSymbol">
         <symbols>
-          <symbol clip_to_extent="1" force_rhr="0" type="fill" name="0" alpha="1">
-            <layer locked="0" enabled="1" class="LinePatternFill" pass="0">
-              <prop v="135" k="angle"/>
-              <prop v="55,126,184,255" k="color"/>
-              <prop v="2" k="distance"/>
-              <prop v="3x:0,0,0,0,0,0" k="distance_map_unit_scale"/>
-              <prop v="MM" k="distance_unit"/>
-              <prop v="0.26" k="line_width"/>
-              <prop v="3x:0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-              <prop v="MM" k="outline_width_unit"/>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="fill">
+            <layer class="LinePatternFill" enabled="1" locked="0" pass="0">
+              <prop k="angle" v="135"></prop>
+              <prop k="color" v="55,126,184,255"></prop>
+              <prop k="distance" v="9"></prop>
+              <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_unit" v="MM"></prop>
+              <prop k="line_width" v="0.26"></prop>
+              <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <symbol clip_to_extent="1" force_rhr="0" type="line" name="@0@0" alpha="1">
-                <layer locked="0" enabled="1" class="SimpleLine" pass="0">
-                  <prop v="square" k="capstyle"/>
-                  <prop v="5;2" k="customdash"/>
-                  <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-                  <prop v="MM" k="customdash_unit"/>
-                  <prop v="0" k="draw_inside_polygon"/>
-                  <prop v="bevel" k="joinstyle"/>
-                  <prop v="0,0,0,255" k="line_color"/>
-                  <prop v="solid" k="line_style"/>
-                  <prop v="0.3" k="line_width"/>
-                  <prop v="MM" k="line_width_unit"/>
-                  <prop v="0" k="offset"/>
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-                  <prop v="MM" k="offset_unit"/>
-                  <prop v="0" k="ring_filter"/>
-                  <prop v="0" k="use_custom_dash"/>
-                  <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="@0@0" type="line">
+                <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+                  <prop k="capstyle" v="square"></prop>
+                  <prop k="customdash" v="5;2"></prop>
+                  <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="customdash_unit" v="MM"></prop>
+                  <prop k="draw_inside_polygon" v="0"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="line_color" v="0,0,0,255"></prop>
+                  <prop k="line_style" v="solid"></prop>
+                  <prop k="line_width" v="0.3"></prop>
+                  <prop k="line_width_unit" v="MM"></prop>
+                  <prop k="offset" v="0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="ring_filter" v="0"></prop>
+                  <prop k="use_custom_dash" v="0"></prop>
+                  <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option type="QString" name="name" value=""/>
-                      <Option name="properties"/>
-                      <Option type="QString" name="type" value="collection"/>
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </layer>
-            <layer locked="0" enabled="1" class="SimpleFill" pass="0">
-              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-              <prop v="0,0,0,255" k="color"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0.46" k="outline_width"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="no" k="style"/>
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="0,0,0,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="0,0,0,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.46"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="no"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
-                  <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
       <customproperties>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <property key="embeddedWidgets/count" value="0"></property>
+        <property key="variableNames"></property>
+        <property key="variableValues"></property>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory maxScaleDenominator="1e+08" barWidth="5" height="15" penWidth="0" minScaleDenominator="0" lineSizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" sizeScale="3x:0,0,0,0,0,0" backgroundAlpha="255" penColor="#000000" backgroundColor="#ffffff" sizeType="MM" minimumSize="0" enabled="0" penAlpha="255" scaleBasedVisibility="0" scaleDependency="Area" diagramOrientation="Up" width="15" rotationOffset="270" labelPlacementMethod="XHeight" opacity="1">
-          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" width="15">
+          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+          <attribute color="#000000" field="" label=""></attribute>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings zIndex="0" dist="0" placement="1" showAll="1" priority="0" linePlacementFlags="18" obstacle="0">
+      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="1" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option type="QString" name="name" value=""/>
-            <Option name="properties"/>
-            <Option type="QString" name="type" value="collection"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
-        <activeChecks/>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks></activeChecks>
         <checkConfiguration type="Map">
-          <Option type="Map" name="QgsGeometryGapCheck">
-            <Option type="double" name="allowedGapsBuffer" value="0"/>
-            <Option type="bool" name="allowedGapsEnabled" value="false"/>
-            <Option type="QString" name="allowedGapsLayer" value=""/>
+          <Option name="QgsGeometryGapCheck" type="Map">
+            <Option name="allowedGapsBuffer" type="double" value="0"></Option>
+            <Option name="allowedGapsEnabled" type="bool" value="false"></Option>
+            <Option name="allowedGapsLayer" type="QString" value=""></Option>
           </Option>
         </checkConfiguration>
       </geometryOptions>
@@ -1074,555 +1083,555 @@ def my_form_open(dialog, layer, feature):
         <field name="OBJECTID">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="VertexCou">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ISO">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NAME_0">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NAME_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="VARNAME_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NL_NAME_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="HASC_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="TYPE_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ENGTYPE_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="VALIDFR_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="VALIDTO_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="REMARKS_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Region">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="RegionVar">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ProvNumber">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="NEV_Countr">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="FIRST_FIPS">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="FIRST_HASC">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="FIPS_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="gadm_level">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="CheckMe">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Region_Cod">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Region_C_1">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ScaleRank">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Region_C_2">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Region_C_3">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Country_Pr">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="DataRank">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Abbrev">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Postal">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Area_sqkm">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="sameAsCity">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="ADM0_A3">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="MAP_COLOR">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="LabelRank">
           <editWidget type="Range">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Shape_Leng">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field name="Shape_Area">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="OBJECTID" name="" index="0"/>
-        <alias field="VertexCou" name="" index="1"/>
-        <alias field="ISO" name="" index="2"/>
-        <alias field="NAME_0" name="" index="3"/>
-        <alias field="NAME_1" name="" index="4"/>
-        <alias field="VARNAME_1" name="" index="5"/>
-        <alias field="NL_NAME_1" name="" index="6"/>
-        <alias field="HASC_1" name="" index="7"/>
-        <alias field="TYPE_1" name="" index="8"/>
-        <alias field="ENGTYPE_1" name="" index="9"/>
-        <alias field="VALIDFR_1" name="" index="10"/>
-        <alias field="VALIDTO_1" name="" index="11"/>
-        <alias field="REMARKS_1" name="" index="12"/>
-        <alias field="Region" name="" index="13"/>
-        <alias field="RegionVar" name="" index="14"/>
-        <alias field="ProvNumber" name="" index="15"/>
-        <alias field="NEV_Countr" name="" index="16"/>
-        <alias field="FIRST_FIPS" name="" index="17"/>
-        <alias field="FIRST_HASC" name="" index="18"/>
-        <alias field="FIPS_1" name="" index="19"/>
-        <alias field="gadm_level" name="" index="20"/>
-        <alias field="CheckMe" name="" index="21"/>
-        <alias field="Region_Cod" name="" index="22"/>
-        <alias field="Region_C_1" name="" index="23"/>
-        <alias field="ScaleRank" name="" index="24"/>
-        <alias field="Region_C_2" name="" index="25"/>
-        <alias field="Region_C_3" name="" index="26"/>
-        <alias field="Country_Pr" name="" index="27"/>
-        <alias field="DataRank" name="" index="28"/>
-        <alias field="Abbrev" name="" index="29"/>
-        <alias field="Postal" name="" index="30"/>
-        <alias field="Area_sqkm" name="" index="31"/>
-        <alias field="sameAsCity" name="" index="32"/>
-        <alias field="ADM0_A3" name="" index="33"/>
-        <alias field="MAP_COLOR" name="" index="34"/>
-        <alias field="LabelRank" name="" index="35"/>
-        <alias field="Shape_Leng" name="" index="36"/>
-        <alias field="Shape_Area" name="" index="37"/>
+        <alias field="OBJECTID" index="0" name=""></alias>
+        <alias field="VertexCou" index="1" name=""></alias>
+        <alias field="ISO" index="2" name=""></alias>
+        <alias field="NAME_0" index="3" name=""></alias>
+        <alias field="NAME_1" index="4" name=""></alias>
+        <alias field="VARNAME_1" index="5" name=""></alias>
+        <alias field="NL_NAME_1" index="6" name=""></alias>
+        <alias field="HASC_1" index="7" name=""></alias>
+        <alias field="TYPE_1" index="8" name=""></alias>
+        <alias field="ENGTYPE_1" index="9" name=""></alias>
+        <alias field="VALIDFR_1" index="10" name=""></alias>
+        <alias field="VALIDTO_1" index="11" name=""></alias>
+        <alias field="REMARKS_1" index="12" name=""></alias>
+        <alias field="Region" index="13" name=""></alias>
+        <alias field="RegionVar" index="14" name=""></alias>
+        <alias field="ProvNumber" index="15" name=""></alias>
+        <alias field="NEV_Countr" index="16" name=""></alias>
+        <alias field="FIRST_FIPS" index="17" name=""></alias>
+        <alias field="FIRST_HASC" index="18" name=""></alias>
+        <alias field="FIPS_1" index="19" name=""></alias>
+        <alias field="gadm_level" index="20" name=""></alias>
+        <alias field="CheckMe" index="21" name=""></alias>
+        <alias field="Region_Cod" index="22" name=""></alias>
+        <alias field="Region_C_1" index="23" name=""></alias>
+        <alias field="ScaleRank" index="24" name=""></alias>
+        <alias field="Region_C_2" index="25" name=""></alias>
+        <alias field="Region_C_3" index="26" name=""></alias>
+        <alias field="Country_Pr" index="27" name=""></alias>
+        <alias field="DataRank" index="28" name=""></alias>
+        <alias field="Abbrev" index="29" name=""></alias>
+        <alias field="Postal" index="30" name=""></alias>
+        <alias field="Area_sqkm" index="31" name=""></alias>
+        <alias field="sameAsCity" index="32" name=""></alias>
+        <alias field="ADM0_A3" index="33" name=""></alias>
+        <alias field="MAP_COLOR" index="34" name=""></alias>
+        <alias field="LabelRank" index="35" name=""></alias>
+        <alias field="Shape_Leng" index="36" name=""></alias>
+        <alias field="Shape_Area" index="37" name=""></alias>
       </aliases>
       <excludeAttributesWMS>
-        <attribute>Country_Pr</attribute>
-        <attribute>TYPE_1</attribute>
-        <attribute>VertexCou</attribute>
-        <attribute>Region_C_1</attribute>
-        <attribute>FIRST_HASC</attribute>
-        <attribute>CheckMe</attribute>
-        <attribute>NAME_1</attribute>
-        <attribute>sameAsCity</attribute>
-        <attribute>MAP_COLOR</attribute>
-        <attribute>FIPS_1</attribute>
-        <attribute>gadm_level</attribute>
-        <attribute>HASC_1</attribute>
-        <attribute>Area_sqkm</attribute>
-        <attribute>FIRST_FIPS</attribute>
-        <attribute>ISO</attribute>
-        <attribute>Region_Cod</attribute>
-        <attribute>VALIDTO_1</attribute>
-        <attribute>DataRank</attribute>
         <attribute>Abbrev</attribute>
-        <attribute>ADM0_A3</attribute>
+        <attribute>NAME_1</attribute>
         <attribute>Region_C_2</attribute>
+        <attribute>Country_Pr</attribute>
+        <attribute>CheckMe</attribute>
         <attribute>NL_NAME_1</attribute>
-        <attribute>LabelRank</attribute>
+        <attribute>VertexCou</attribute>
+        <attribute>VALIDTO_1</attribute>
+        <attribute>FIRST_FIPS</attribute>
+        <attribute>FIRST_HASC</attribute>
+        <attribute>ADM0_A3</attribute>
+        <attribute>TYPE_1</attribute>
+        <attribute>DataRank</attribute>
+        <attribute>Area_sqkm</attribute>
+        <attribute>FIPS_1</attribute>
+        <attribute>sameAsCity</attribute>
         <attribute>ENGTYPE_1</attribute>
+        <attribute>VALIDFR_1</attribute>
+        <attribute>Region_Cod</attribute>
+        <attribute>ProvNumber</attribute>
+        <attribute>ISO</attribute>
         <attribute>REMARKS_1</attribute>
+        <attribute>gadm_level</attribute>
         <attribute>Region_C_3</attribute>
-        <attribute>NEV_Countr</attribute>
         <attribute>Postal</attribute>
         <attribute>RegionVar</attribute>
-        <attribute>VALIDFR_1</attribute>
-        <attribute>ProvNumber</attribute>
+        <attribute>LabelRank</attribute>
+        <attribute>MAP_COLOR</attribute>
+        <attribute>HASC_1</attribute>
         <attribute>ScaleRank</attribute>
+        <attribute>Region_C_1</attribute>
+        <attribute>NEV_Countr</attribute>
       </excludeAttributesWMS>
       <excludeAttributesWFS>
-        <attribute>Country_Pr</attribute>
-        <attribute>TYPE_1</attribute>
-        <attribute>VertexCou</attribute>
-        <attribute>Region_C_1</attribute>
-        <attribute>FIRST_HASC</attribute>
-        <attribute>CheckMe</attribute>
-        <attribute>NAME_1</attribute>
-        <attribute>sameAsCity</attribute>
-        <attribute>MAP_COLOR</attribute>
-        <attribute>FIPS_1</attribute>
-        <attribute>gadm_level</attribute>
-        <attribute>HASC_1</attribute>
-        <attribute>Area_sqkm</attribute>
-        <attribute>FIRST_FIPS</attribute>
-        <attribute>ISO</attribute>
-        <attribute>Region_Cod</attribute>
-        <attribute>VALIDTO_1</attribute>
-        <attribute>DataRank</attribute>
         <attribute>Abbrev</attribute>
-        <attribute>ADM0_A3</attribute>
+        <attribute>NAME_1</attribute>
         <attribute>Region_C_2</attribute>
+        <attribute>Country_Pr</attribute>
+        <attribute>CheckMe</attribute>
         <attribute>NL_NAME_1</attribute>
-        <attribute>LabelRank</attribute>
+        <attribute>VertexCou</attribute>
+        <attribute>VALIDTO_1</attribute>
+        <attribute>FIRST_FIPS</attribute>
+        <attribute>FIRST_HASC</attribute>
+        <attribute>ADM0_A3</attribute>
+        <attribute>TYPE_1</attribute>
+        <attribute>DataRank</attribute>
+        <attribute>Area_sqkm</attribute>
+        <attribute>FIPS_1</attribute>
+        <attribute>sameAsCity</attribute>
         <attribute>ENGTYPE_1</attribute>
+        <attribute>VALIDFR_1</attribute>
+        <attribute>Region_Cod</attribute>
+        <attribute>ProvNumber</attribute>
+        <attribute>ISO</attribute>
         <attribute>REMARKS_1</attribute>
+        <attribute>gadm_level</attribute>
         <attribute>Region_C_3</attribute>
-        <attribute>NEV_Countr</attribute>
         <attribute>Postal</attribute>
         <attribute>RegionVar</attribute>
-        <attribute>VALIDFR_1</attribute>
-        <attribute>ProvNumber</attribute>
+        <attribute>LabelRank</attribute>
+        <attribute>MAP_COLOR</attribute>
+        <attribute>HASC_1</attribute>
         <attribute>ScaleRank</attribute>
+        <attribute>Region_C_1</attribute>
+        <attribute>NEV_Countr</attribute>
       </excludeAttributesWFS>
       <defaults>
-        <default field="OBJECTID" expression="" applyOnUpdate="0"/>
-        <default field="VertexCou" expression="" applyOnUpdate="0"/>
-        <default field="ISO" expression="" applyOnUpdate="0"/>
-        <default field="NAME_0" expression="" applyOnUpdate="0"/>
-        <default field="NAME_1" expression="" applyOnUpdate="0"/>
-        <default field="VARNAME_1" expression="" applyOnUpdate="0"/>
-        <default field="NL_NAME_1" expression="" applyOnUpdate="0"/>
-        <default field="HASC_1" expression="" applyOnUpdate="0"/>
-        <default field="TYPE_1" expression="" applyOnUpdate="0"/>
-        <default field="ENGTYPE_1" expression="" applyOnUpdate="0"/>
-        <default field="VALIDFR_1" expression="" applyOnUpdate="0"/>
-        <default field="VALIDTO_1" expression="" applyOnUpdate="0"/>
-        <default field="REMARKS_1" expression="" applyOnUpdate="0"/>
-        <default field="Region" expression="" applyOnUpdate="0"/>
-        <default field="RegionVar" expression="" applyOnUpdate="0"/>
-        <default field="ProvNumber" expression="" applyOnUpdate="0"/>
-        <default field="NEV_Countr" expression="" applyOnUpdate="0"/>
-        <default field="FIRST_FIPS" expression="" applyOnUpdate="0"/>
-        <default field="FIRST_HASC" expression="" applyOnUpdate="0"/>
-        <default field="FIPS_1" expression="" applyOnUpdate="0"/>
-        <default field="gadm_level" expression="" applyOnUpdate="0"/>
-        <default field="CheckMe" expression="" applyOnUpdate="0"/>
-        <default field="Region_Cod" expression="" applyOnUpdate="0"/>
-        <default field="Region_C_1" expression="" applyOnUpdate="0"/>
-        <default field="ScaleRank" expression="" applyOnUpdate="0"/>
-        <default field="Region_C_2" expression="" applyOnUpdate="0"/>
-        <default field="Region_C_3" expression="" applyOnUpdate="0"/>
-        <default field="Country_Pr" expression="" applyOnUpdate="0"/>
-        <default field="DataRank" expression="" applyOnUpdate="0"/>
-        <default field="Abbrev" expression="" applyOnUpdate="0"/>
-        <default field="Postal" expression="" applyOnUpdate="0"/>
-        <default field="Area_sqkm" expression="" applyOnUpdate="0"/>
-        <default field="sameAsCity" expression="" applyOnUpdate="0"/>
-        <default field="ADM0_A3" expression="" applyOnUpdate="0"/>
-        <default field="MAP_COLOR" expression="" applyOnUpdate="0"/>
-        <default field="LabelRank" expression="" applyOnUpdate="0"/>
-        <default field="Shape_Leng" expression="" applyOnUpdate="0"/>
-        <default field="Shape_Area" expression="" applyOnUpdate="0"/>
+        <default applyOnUpdate="0" expression="" field="OBJECTID"></default>
+        <default applyOnUpdate="0" expression="" field="VertexCou"></default>
+        <default applyOnUpdate="0" expression="" field="ISO"></default>
+        <default applyOnUpdate="0" expression="" field="NAME_0"></default>
+        <default applyOnUpdate="0" expression="" field="NAME_1"></default>
+        <default applyOnUpdate="0" expression="" field="VARNAME_1"></default>
+        <default applyOnUpdate="0" expression="" field="NL_NAME_1"></default>
+        <default applyOnUpdate="0" expression="" field="HASC_1"></default>
+        <default applyOnUpdate="0" expression="" field="TYPE_1"></default>
+        <default applyOnUpdate="0" expression="" field="ENGTYPE_1"></default>
+        <default applyOnUpdate="0" expression="" field="VALIDFR_1"></default>
+        <default applyOnUpdate="0" expression="" field="VALIDTO_1"></default>
+        <default applyOnUpdate="0" expression="" field="REMARKS_1"></default>
+        <default applyOnUpdate="0" expression="" field="Region"></default>
+        <default applyOnUpdate="0" expression="" field="RegionVar"></default>
+        <default applyOnUpdate="0" expression="" field="ProvNumber"></default>
+        <default applyOnUpdate="0" expression="" field="NEV_Countr"></default>
+        <default applyOnUpdate="0" expression="" field="FIRST_FIPS"></default>
+        <default applyOnUpdate="0" expression="" field="FIRST_HASC"></default>
+        <default applyOnUpdate="0" expression="" field="FIPS_1"></default>
+        <default applyOnUpdate="0" expression="" field="gadm_level"></default>
+        <default applyOnUpdate="0" expression="" field="CheckMe"></default>
+        <default applyOnUpdate="0" expression="" field="Region_Cod"></default>
+        <default applyOnUpdate="0" expression="" field="Region_C_1"></default>
+        <default applyOnUpdate="0" expression="" field="ScaleRank"></default>
+        <default applyOnUpdate="0" expression="" field="Region_C_2"></default>
+        <default applyOnUpdate="0" expression="" field="Region_C_3"></default>
+        <default applyOnUpdate="0" expression="" field="Country_Pr"></default>
+        <default applyOnUpdate="0" expression="" field="DataRank"></default>
+        <default applyOnUpdate="0" expression="" field="Abbrev"></default>
+        <default applyOnUpdate="0" expression="" field="Postal"></default>
+        <default applyOnUpdate="0" expression="" field="Area_sqkm"></default>
+        <default applyOnUpdate="0" expression="" field="sameAsCity"></default>
+        <default applyOnUpdate="0" expression="" field="ADM0_A3"></default>
+        <default applyOnUpdate="0" expression="" field="MAP_COLOR"></default>
+        <default applyOnUpdate="0" expression="" field="LabelRank"></default>
+        <default applyOnUpdate="0" expression="" field="Shape_Leng"></default>
+        <default applyOnUpdate="0" expression="" field="Shape_Area"></default>
       </defaults>
       <constraints>
-        <constraint field="OBJECTID" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="VertexCou" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="ISO" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="NAME_0" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="NAME_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="VARNAME_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="NL_NAME_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="HASC_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="TYPE_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="ENGTYPE_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="VALIDFR_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="VALIDTO_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="REMARKS_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Region" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="RegionVar" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="ProvNumber" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="NEV_Countr" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="FIRST_FIPS" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="FIRST_HASC" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="FIPS_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="gadm_level" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="CheckMe" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Region_Cod" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Region_C_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="ScaleRank" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Region_C_2" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Region_C_3" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Country_Pr" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="DataRank" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Abbrev" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Postal" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Area_sqkm" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="sameAsCity" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="ADM0_A3" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="MAP_COLOR" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="LabelRank" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Shape_Leng" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
-        <constraint field="Shape_Area" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint constraints="0" exp_strength="0" field="OBJECTID" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="VertexCou" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ISO" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NAME_0" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NAME_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="VARNAME_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NL_NAME_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="HASC_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="TYPE_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ENGTYPE_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="VALIDFR_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="VALIDTO_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="REMARKS_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="RegionVar" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ProvNumber" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NEV_Countr" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="FIRST_FIPS" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="FIRST_HASC" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="FIPS_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="gadm_level" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="CheckMe" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region_Cod" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region_C_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ScaleRank" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region_C_2" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region_C_3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Country_Pr" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="DataRank" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Abbrev" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Postal" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Area_sqkm" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="sameAsCity" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ADM0_A3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="MAP_COLOR" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="LabelRank" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Shape_Leng" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Shape_Area" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint field="OBJECTID" exp="" desc=""/>
-        <constraint field="VertexCou" exp="" desc=""/>
-        <constraint field="ISO" exp="" desc=""/>
-        <constraint field="NAME_0" exp="" desc=""/>
-        <constraint field="NAME_1" exp="" desc=""/>
-        <constraint field="VARNAME_1" exp="" desc=""/>
-        <constraint field="NL_NAME_1" exp="" desc=""/>
-        <constraint field="HASC_1" exp="" desc=""/>
-        <constraint field="TYPE_1" exp="" desc=""/>
-        <constraint field="ENGTYPE_1" exp="" desc=""/>
-        <constraint field="VALIDFR_1" exp="" desc=""/>
-        <constraint field="VALIDTO_1" exp="" desc=""/>
-        <constraint field="REMARKS_1" exp="" desc=""/>
-        <constraint field="Region" exp="" desc=""/>
-        <constraint field="RegionVar" exp="" desc=""/>
-        <constraint field="ProvNumber" exp="" desc=""/>
-        <constraint field="NEV_Countr" exp="" desc=""/>
-        <constraint field="FIRST_FIPS" exp="" desc=""/>
-        <constraint field="FIRST_HASC" exp="" desc=""/>
-        <constraint field="FIPS_1" exp="" desc=""/>
-        <constraint field="gadm_level" exp="" desc=""/>
-        <constraint field="CheckMe" exp="" desc=""/>
-        <constraint field="Region_Cod" exp="" desc=""/>
-        <constraint field="Region_C_1" exp="" desc=""/>
-        <constraint field="ScaleRank" exp="" desc=""/>
-        <constraint field="Region_C_2" exp="" desc=""/>
-        <constraint field="Region_C_3" exp="" desc=""/>
-        <constraint field="Country_Pr" exp="" desc=""/>
-        <constraint field="DataRank" exp="" desc=""/>
-        <constraint field="Abbrev" exp="" desc=""/>
-        <constraint field="Postal" exp="" desc=""/>
-        <constraint field="Area_sqkm" exp="" desc=""/>
-        <constraint field="sameAsCity" exp="" desc=""/>
-        <constraint field="ADM0_A3" exp="" desc=""/>
-        <constraint field="MAP_COLOR" exp="" desc=""/>
-        <constraint field="LabelRank" exp="" desc=""/>
-        <constraint field="Shape_Leng" exp="" desc=""/>
-        <constraint field="Shape_Area" exp="" desc=""/>
+        <constraint desc="" exp="" field="OBJECTID"></constraint>
+        <constraint desc="" exp="" field="VertexCou"></constraint>
+        <constraint desc="" exp="" field="ISO"></constraint>
+        <constraint desc="" exp="" field="NAME_0"></constraint>
+        <constraint desc="" exp="" field="NAME_1"></constraint>
+        <constraint desc="" exp="" field="VARNAME_1"></constraint>
+        <constraint desc="" exp="" field="NL_NAME_1"></constraint>
+        <constraint desc="" exp="" field="HASC_1"></constraint>
+        <constraint desc="" exp="" field="TYPE_1"></constraint>
+        <constraint desc="" exp="" field="ENGTYPE_1"></constraint>
+        <constraint desc="" exp="" field="VALIDFR_1"></constraint>
+        <constraint desc="" exp="" field="VALIDTO_1"></constraint>
+        <constraint desc="" exp="" field="REMARKS_1"></constraint>
+        <constraint desc="" exp="" field="Region"></constraint>
+        <constraint desc="" exp="" field="RegionVar"></constraint>
+        <constraint desc="" exp="" field="ProvNumber"></constraint>
+        <constraint desc="" exp="" field="NEV_Countr"></constraint>
+        <constraint desc="" exp="" field="FIRST_FIPS"></constraint>
+        <constraint desc="" exp="" field="FIRST_HASC"></constraint>
+        <constraint desc="" exp="" field="FIPS_1"></constraint>
+        <constraint desc="" exp="" field="gadm_level"></constraint>
+        <constraint desc="" exp="" field="CheckMe"></constraint>
+        <constraint desc="" exp="" field="Region_Cod"></constraint>
+        <constraint desc="" exp="" field="Region_C_1"></constraint>
+        <constraint desc="" exp="" field="ScaleRank"></constraint>
+        <constraint desc="" exp="" field="Region_C_2"></constraint>
+        <constraint desc="" exp="" field="Region_C_3"></constraint>
+        <constraint desc="" exp="" field="Country_Pr"></constraint>
+        <constraint desc="" exp="" field="DataRank"></constraint>
+        <constraint desc="" exp="" field="Abbrev"></constraint>
+        <constraint desc="" exp="" field="Postal"></constraint>
+        <constraint desc="" exp="" field="Area_sqkm"></constraint>
+        <constraint desc="" exp="" field="sameAsCity"></constraint>
+        <constraint desc="" exp="" field="ADM0_A3"></constraint>
+        <constraint desc="" exp="" field="MAP_COLOR"></constraint>
+        <constraint desc="" exp="" field="LabelRank"></constraint>
+        <constraint desc="" exp="" field="Shape_Leng"></constraint>
+        <constraint desc="" exp="" field="Shape_Area"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" name="OBJECTID" width="-1" hidden="0"/>
-          <column type="field" name="VertexCou" width="-1" hidden="0"/>
-          <column type="field" name="ISO" width="-1" hidden="0"/>
-          <column type="field" name="NAME_0" width="-1" hidden="0"/>
-          <column type="field" name="NAME_1" width="-1" hidden="0"/>
-          <column type="field" name="VARNAME_1" width="-1" hidden="0"/>
-          <column type="field" name="NL_NAME_1" width="-1" hidden="0"/>
-          <column type="field" name="HASC_1" width="-1" hidden="0"/>
-          <column type="field" name="TYPE_1" width="-1" hidden="0"/>
-          <column type="field" name="ENGTYPE_1" width="-1" hidden="0"/>
-          <column type="field" name="VALIDFR_1" width="-1" hidden="0"/>
-          <column type="field" name="VALIDTO_1" width="-1" hidden="0"/>
-          <column type="field" name="REMARKS_1" width="-1" hidden="0"/>
-          <column type="field" name="Region" width="-1" hidden="0"/>
-          <column type="field" name="RegionVar" width="-1" hidden="0"/>
-          <column type="field" name="ProvNumber" width="-1" hidden="0"/>
-          <column type="field" name="NEV_Countr" width="-1" hidden="0"/>
-          <column type="field" name="FIRST_FIPS" width="-1" hidden="0"/>
-          <column type="field" name="FIRST_HASC" width="-1" hidden="0"/>
-          <column type="field" name="FIPS_1" width="-1" hidden="0"/>
-          <column type="field" name="gadm_level" width="-1" hidden="0"/>
-          <column type="field" name="CheckMe" width="-1" hidden="0"/>
-          <column type="field" name="Region_Cod" width="-1" hidden="0"/>
-          <column type="field" name="Region_C_1" width="-1" hidden="0"/>
-          <column type="field" name="ScaleRank" width="-1" hidden="0"/>
-          <column type="field" name="Region_C_2" width="-1" hidden="0"/>
-          <column type="field" name="Region_C_3" width="-1" hidden="0"/>
-          <column type="field" name="Country_Pr" width="-1" hidden="0"/>
-          <column type="field" name="DataRank" width="-1" hidden="0"/>
-          <column type="field" name="Abbrev" width="-1" hidden="0"/>
-          <column type="field" name="Postal" width="-1" hidden="0"/>
-          <column type="field" name="Area_sqkm" width="-1" hidden="0"/>
-          <column type="field" name="sameAsCity" width="-1" hidden="0"/>
-          <column type="field" name="ADM0_A3" width="-1" hidden="0"/>
-          <column type="field" name="MAP_COLOR" width="-1" hidden="0"/>
-          <column type="field" name="LabelRank" width="-1" hidden="0"/>
-          <column type="field" name="Shape_Leng" width="-1" hidden="0"/>
-          <column type="field" name="Shape_Area" width="-1" hidden="0"/>
-          <column type="actions" width="-1" hidden="1"/>
+          <column hidden="0" name="OBJECTID" type="field" width="-1"></column>
+          <column hidden="0" name="VertexCou" type="field" width="-1"></column>
+          <column hidden="0" name="ISO" type="field" width="-1"></column>
+          <column hidden="0" name="NAME_0" type="field" width="-1"></column>
+          <column hidden="0" name="NAME_1" type="field" width="-1"></column>
+          <column hidden="0" name="VARNAME_1" type="field" width="-1"></column>
+          <column hidden="0" name="NL_NAME_1" type="field" width="-1"></column>
+          <column hidden="0" name="HASC_1" type="field" width="-1"></column>
+          <column hidden="0" name="TYPE_1" type="field" width="-1"></column>
+          <column hidden="0" name="ENGTYPE_1" type="field" width="-1"></column>
+          <column hidden="0" name="VALIDFR_1" type="field" width="-1"></column>
+          <column hidden="0" name="VALIDTO_1" type="field" width="-1"></column>
+          <column hidden="0" name="REMARKS_1" type="field" width="-1"></column>
+          <column hidden="0" name="Region" type="field" width="-1"></column>
+          <column hidden="0" name="RegionVar" type="field" width="-1"></column>
+          <column hidden="0" name="ProvNumber" type="field" width="-1"></column>
+          <column hidden="0" name="NEV_Countr" type="field" width="-1"></column>
+          <column hidden="0" name="FIRST_FIPS" type="field" width="-1"></column>
+          <column hidden="0" name="FIRST_HASC" type="field" width="-1"></column>
+          <column hidden="0" name="FIPS_1" type="field" width="-1"></column>
+          <column hidden="0" name="gadm_level" type="field" width="-1"></column>
+          <column hidden="0" name="CheckMe" type="field" width="-1"></column>
+          <column hidden="0" name="Region_Cod" type="field" width="-1"></column>
+          <column hidden="0" name="Region_C_1" type="field" width="-1"></column>
+          <column hidden="0" name="ScaleRank" type="field" width="-1"></column>
+          <column hidden="0" name="Region_C_2" type="field" width="-1"></column>
+          <column hidden="0" name="Region_C_3" type="field" width="-1"></column>
+          <column hidden="0" name="Country_Pr" type="field" width="-1"></column>
+          <column hidden="0" name="DataRank" type="field" width="-1"></column>
+          <column hidden="0" name="Abbrev" type="field" width="-1"></column>
+          <column hidden="0" name="Postal" type="field" width="-1"></column>
+          <column hidden="0" name="Area_sqkm" type="field" width="-1"></column>
+          <column hidden="0" name="sameAsCity" type="field" width="-1"></column>
+          <column hidden="0" name="ADM0_A3" type="field" width="-1"></column>
+          <column hidden="0" name="MAP_COLOR" type="field" width="-1"></column>
+          <column hidden="0" name="LabelRank" type="field" width="-1"></column>
+          <column hidden="0" name="Shape_Leng" type="field" width="-1"></column>
+          <column hidden="0" name="Shape_Area" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 Les formulaires QGIS peuvent avoir une fonction Python qui sera appelée à l'ouverture du formulaire.
 
@@ -1637,97 +1646,1025 @@ def my_form_open(dialog, layer, feature):
     geom = feature.geometry()
     control = dialog.findChild(QWidget, "MyLineEdit")
 
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field name="ADM0_A3" editable="1"/>
-        <field name="Abbrev" editable="1"/>
-        <field name="Area_sqkm" editable="1"/>
-        <field name="CheckMe" editable="1"/>
-        <field name="Country_Pr" editable="1"/>
-        <field name="DataRank" editable="1"/>
-        <field name="ENGTYPE_1" editable="1"/>
-        <field name="FIPS_1" editable="1"/>
-        <field name="FIRST_FIPS" editable="1"/>
-        <field name="FIRST_HASC" editable="1"/>
-        <field name="HASC_1" editable="1"/>
-        <field name="ISO" editable="1"/>
-        <field name="LabelRank" editable="1"/>
-        <field name="MAP_COLOR" editable="1"/>
-        <field name="NAME_0" editable="1"/>
-        <field name="NAME_1" editable="1"/>
-        <field name="NEV_Countr" editable="1"/>
-        <field name="NL_NAME_1" editable="1"/>
-        <field name="OBJECTID" editable="1"/>
-        <field name="Postal" editable="1"/>
-        <field name="ProvNumber" editable="1"/>
-        <field name="REMARKS_1" editable="1"/>
-        <field name="Region" editable="1"/>
-        <field name="RegionVar" editable="1"/>
-        <field name="Region_C_1" editable="1"/>
-        <field name="Region_C_2" editable="1"/>
-        <field name="Region_C_3" editable="1"/>
-        <field name="Region_Cod" editable="1"/>
-        <field name="ScaleRank" editable="1"/>
-        <field name="Shape_Area" editable="1"/>
-        <field name="Shape_Leng" editable="1"/>
-        <field name="TYPE_1" editable="1"/>
-        <field name="VALIDFR_1" editable="1"/>
-        <field name="VALIDTO_1" editable="1"/>
-        <field name="VARNAME_1" editable="1"/>
-        <field name="VertexCou" editable="1"/>
-        <field name="gadm_level" editable="1"/>
-        <field name="sameAsCity" editable="1"/>
+        <field editable="1" name="ADM0_A3"></field>
+        <field editable="1" name="Abbrev"></field>
+        <field editable="1" name="Area_sqkm"></field>
+        <field editable="1" name="CheckMe"></field>
+        <field editable="1" name="Country_Pr"></field>
+        <field editable="1" name="DataRank"></field>
+        <field editable="1" name="ENGTYPE_1"></field>
+        <field editable="1" name="FIPS_1"></field>
+        <field editable="1" name="FIRST_FIPS"></field>
+        <field editable="1" name="FIRST_HASC"></field>
+        <field editable="1" name="HASC_1"></field>
+        <field editable="1" name="ISO"></field>
+        <field editable="1" name="LabelRank"></field>
+        <field editable="1" name="MAP_COLOR"></field>
+        <field editable="1" name="NAME_0"></field>
+        <field editable="1" name="NAME_1"></field>
+        <field editable="1" name="NEV_Countr"></field>
+        <field editable="1" name="NL_NAME_1"></field>
+        <field editable="1" name="OBJECTID"></field>
+        <field editable="1" name="Postal"></field>
+        <field editable="1" name="ProvNumber"></field>
+        <field editable="1" name="REMARKS_1"></field>
+        <field editable="1" name="Region"></field>
+        <field editable="1" name="RegionVar"></field>
+        <field editable="1" name="Region_C_1"></field>
+        <field editable="1" name="Region_C_2"></field>
+        <field editable="1" name="Region_C_3"></field>
+        <field editable="1" name="Region_Cod"></field>
+        <field editable="1" name="ScaleRank"></field>
+        <field editable="1" name="Shape_Area"></field>
+        <field editable="1" name="Shape_Leng"></field>
+        <field editable="1" name="TYPE_1"></field>
+        <field editable="1" name="VALIDFR_1"></field>
+        <field editable="1" name="VALIDTO_1"></field>
+        <field editable="1" name="VARNAME_1"></field>
+        <field editable="1" name="VertexCou"></field>
+        <field editable="1" name="gadm_level"></field>
+        <field editable="1" name="sameAsCity"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="ADM0_A3"/>
-        <field labelOnTop="0" name="Abbrev"/>
-        <field labelOnTop="0" name="Area_sqkm"/>
-        <field labelOnTop="0" name="CheckMe"/>
-        <field labelOnTop="0" name="Country_Pr"/>
-        <field labelOnTop="0" name="DataRank"/>
-        <field labelOnTop="0" name="ENGTYPE_1"/>
-        <field labelOnTop="0" name="FIPS_1"/>
-        <field labelOnTop="0" name="FIRST_FIPS"/>
-        <field labelOnTop="0" name="FIRST_HASC"/>
-        <field labelOnTop="0" name="HASC_1"/>
-        <field labelOnTop="0" name="ISO"/>
-        <field labelOnTop="0" name="LabelRank"/>
-        <field labelOnTop="0" name="MAP_COLOR"/>
-        <field labelOnTop="0" name="NAME_0"/>
-        <field labelOnTop="0" name="NAME_1"/>
-        <field labelOnTop="0" name="NEV_Countr"/>
-        <field labelOnTop="0" name="NL_NAME_1"/>
-        <field labelOnTop="0" name="OBJECTID"/>
-        <field labelOnTop="0" name="Postal"/>
-        <field labelOnTop="0" name="ProvNumber"/>
-        <field labelOnTop="0" name="REMARKS_1"/>
-        <field labelOnTop="0" name="Region"/>
-        <field labelOnTop="0" name="RegionVar"/>
-        <field labelOnTop="0" name="Region_C_1"/>
-        <field labelOnTop="0" name="Region_C_2"/>
-        <field labelOnTop="0" name="Region_C_3"/>
-        <field labelOnTop="0" name="Region_Cod"/>
-        <field labelOnTop="0" name="ScaleRank"/>
-        <field labelOnTop="0" name="Shape_Area"/>
-        <field labelOnTop="0" name="Shape_Leng"/>
-        <field labelOnTop="0" name="TYPE_1"/>
-        <field labelOnTop="0" name="VALIDFR_1"/>
-        <field labelOnTop="0" name="VALIDTO_1"/>
-        <field labelOnTop="0" name="VARNAME_1"/>
-        <field labelOnTop="0" name="VertexCou"/>
-        <field labelOnTop="0" name="gadm_level"/>
-        <field labelOnTop="0" name="sameAsCity"/>
+        <field labelOnTop="0" name="ADM0_A3"></field>
+        <field labelOnTop="0" name="Abbrev"></field>
+        <field labelOnTop="0" name="Area_sqkm"></field>
+        <field labelOnTop="0" name="CheckMe"></field>
+        <field labelOnTop="0" name="Country_Pr"></field>
+        <field labelOnTop="0" name="DataRank"></field>
+        <field labelOnTop="0" name="ENGTYPE_1"></field>
+        <field labelOnTop="0" name="FIPS_1"></field>
+        <field labelOnTop="0" name="FIRST_FIPS"></field>
+        <field labelOnTop="0" name="FIRST_HASC"></field>
+        <field labelOnTop="0" name="HASC_1"></field>
+        <field labelOnTop="0" name="ISO"></field>
+        <field labelOnTop="0" name="LabelRank"></field>
+        <field labelOnTop="0" name="MAP_COLOR"></field>
+        <field labelOnTop="0" name="NAME_0"></field>
+        <field labelOnTop="0" name="NAME_1"></field>
+        <field labelOnTop="0" name="NEV_Countr"></field>
+        <field labelOnTop="0" name="NL_NAME_1"></field>
+        <field labelOnTop="0" name="OBJECTID"></field>
+        <field labelOnTop="0" name="Postal"></field>
+        <field labelOnTop="0" name="ProvNumber"></field>
+        <field labelOnTop="0" name="REMARKS_1"></field>
+        <field labelOnTop="0" name="Region"></field>
+        <field labelOnTop="0" name="RegionVar"></field>
+        <field labelOnTop="0" name="Region_C_1"></field>
+        <field labelOnTop="0" name="Region_C_2"></field>
+        <field labelOnTop="0" name="Region_C_3"></field>
+        <field labelOnTop="0" name="Region_Cod"></field>
+        <field labelOnTop="0" name="ScaleRank"></field>
+        <field labelOnTop="0" name="Shape_Area"></field>
+        <field labelOnTop="0" name="Shape_Leng"></field>
+        <field labelOnTop="0" name="TYPE_1"></field>
+        <field labelOnTop="0" name="VALIDFR_1"></field>
+        <field labelOnTop="0" name="VALIDTO_1"></field>
+        <field labelOnTop="0" name="VARNAME_1"></field>
+        <field labelOnTop="0" name="VertexCou"></field>
+        <field labelOnTop="0" name="gadm_level"></field>
+        <field labelOnTop="0" name="sameAsCity"></field>
       </labelOnTop>
-      <widgets/>
+      <widgets></widgets>
       <previewExpression>"NAME_0"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" maxScale="0" minScale="1e+08" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" type="vector" wkbType="MultiPolygon">
+      <extent>
+        <xmin>-5.1326269186972695</xmin>
+        <ymin>46.2791909857754149</ymin>
+        <xmax>3.11792890789286048</xmax>
+        <ymax>49.72647410719434902</ymax>
+      </extent>
+      <id>qgis_popup_a6f4c4e3_79bc_4443_aab6_7e44ef9fe24b</id>
+      <datasource>./france_parts/france_parts.shp</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>qgis_form</layername>
+      <srs>
+        <spatialrefsys>
+          <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+          <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+          <srsid>3452</srsid>
+          <srid>4326</srid>
+          <authid>EPSG:4326</authid>
+          <description>WGS 84</description>
+          <projectionacronym>longlat</projectionacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+          <geographicflag>true</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type>dataset</type>
+        <title></title>
+        <abstract></abstract>
+        <contact>
+          <name></name>
+          <organization></organization>
+          <position></position>
+          <voice></voice>
+          <fax></fax>
+          <email></email>
+          <role></role>
+        </contact>
+        <links></links>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <wkt></wkt>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
+          <temporal>
+            <period>
+              <start></start>
+              <end></end>
+            </period>
+          </temporal>
+        </extent>
+      </resourceMetadata>
+      <provider encoding="ISO-8859-1">ogr</provider>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <legend type="default-vector"></legend>
+      <expressionfields></expressionfields>
+      <map-layer-style-manager current="défaut">
+        <map-layer-style name="défaut"></map-layer-style>
+      </map-layer-style-manager>
+      <auxiliaryLayer></auxiliaryLayer>
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 enableorderby="0" forceraster="0" symbollevels="0" type="singleSymbol">
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="fill">
+            <layer class="LinePatternFill" enabled="1" locked="0" pass="0">
+              <prop k="angle" v="45"></prop>
+              <prop k="color" v="255,55,55,255"></prop>
+              <prop k="distance" v="9"></prop>
+              <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="distance_unit" v="MM"></prop>
+              <prop k="line_width" v="0.26"></prop>
+              <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="line_width_unit" v="MM"></prop>
+              <prop k="offset" v="0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="@0@0" type="line">
+                <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+                  <prop k="capstyle" v="square"></prop>
+                  <prop k="customdash" v="5;2"></prop>
+                  <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="customdash_unit" v="MM"></prop>
+                  <prop k="draw_inside_polygon" v="0"></prop>
+                  <prop k="joinstyle" v="bevel"></prop>
+                  <prop k="line_color" v="255,55,55,255"></prop>
+                  <prop k="line_style" v="solid"></prop>
+                  <prop k="line_width" v="0.3"></prop>
+                  <prop k="line_width_unit" v="MM"></prop>
+                  <prop k="offset" v="0"></prop>
+                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <prop k="offset_unit" v="MM"></prop>
+                  <prop k="ring_filter" v="0"></prop>
+                  <prop k="use_custom_dash" v="0"></prop>
+                  <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" type="QString" value=""></Option>
+                      <Option name="properties"></Option>
+                      <Option name="type" type="QString" value="collection"></Option>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </layer>
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="color" v="255,55,55,255"></prop>
+              <prop k="joinstyle" v="bevel"></prop>
+              <prop k="offset" v="0,0"></prop>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
+              <prop k="offset_unit" v="MM"></prop>
+              <prop k="outline_color" v="0,0,0,255"></prop>
+              <prop k="outline_style" v="solid"></prop>
+              <prop k="outline_width" v="0.46"></prop>
+              <prop k="outline_width_unit" v="MM"></prop>
+              <prop k="style" v="no"></prop>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation></rotation>
+        <sizescale></sizescale>
+      </renderer-v2>
+      <customproperties>
+        <property key="embeddedWidgets/count" value="0"></property>
+        <property key="variableNames"></property>
+        <property key="variableValues"></property>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" width="15">
+          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+          <attribute color="#000000" field="" label=""></attribute>
+        </DiagramCategory>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="1" priority="0" showAll="1" zIndex="0">
+        <properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </properties>
+      </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks></activeChecks>
+        <checkConfiguration type="Map">
+          <Option name="QgsGeometryGapCheck" type="Map">
+            <Option name="allowedGapsBuffer" type="double" value="0"></Option>
+            <Option name="allowedGapsEnabled" type="bool" value="false"></Option>
+            <Option name="allowedGapsLayer" type="QString" value=""></Option>
+          </Option>
+        </checkConfiguration>
+      </geometryOptions>
+      <fieldConfiguration>
+        <field name="OBJECTID">
+          <editWidget type="Range">
+            <config>
+              <Option type="Map">
+                <Option name="AllowNull" type="bool" value="true"></Option>
+                <Option name="Max" type="int" value="2147483647"></Option>
+                <Option name="Min" type="int" value="-2147483648"></Option>
+                <Option name="Precision" type="int" value="0"></Option>
+                <Option name="Step" type="int" value="1"></Option>
+                <Option name="Style" type="QString" value="SpinBox"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="VertexCou">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ISO">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="NAME_0">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="NAME_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="VARNAME_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="NL_NAME_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="HASC_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="TYPE_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ENGTYPE_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="VALIDFR_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="VALIDTO_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="REMARKS_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="RegionVar">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ProvNumber">
+          <editWidget type="Range">
+            <config>
+              <Option type="Map">
+                <Option name="AllowNull" type="bool" value="true"></Option>
+                <Option name="Max" type="int" value="2147483647"></Option>
+                <Option name="Min" type="int" value="-2147483648"></Option>
+                <Option name="Precision" type="int" value="0"></Option>
+                <Option name="Step" type="int" value="1"></Option>
+                <Option name="Style" type="QString" value="SpinBox"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="NEV_Countr">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="FIRST_FIPS">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="FIRST_HASC">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="FIPS_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="gadm_level">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="CheckMe">
+          <editWidget type="Range">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region_Cod">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region_C_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ScaleRank">
+          <editWidget type="Range">
+            <config>
+              <Option type="Map">
+                <Option name="AllowNull" type="bool" value="true"></Option>
+                <Option name="Max" type="int" value="2147483647"></Option>
+                <Option name="Min" type="int" value="-2147483648"></Option>
+                <Option name="Precision" type="int" value="0"></Option>
+                <Option name="Step" type="int" value="1"></Option>
+                <Option name="Style" type="QString" value="SpinBox"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region_C_2">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region_C_3">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Country_Pr">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="DataRank">
+          <editWidget type="Range">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Abbrev">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Postal">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Area_sqkm">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="sameAsCity">
+          <editWidget type="Range">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ADM0_A3">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="MAP_COLOR">
+          <editWidget type="Range">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="LabelRank">
+          <editWidget type="Range">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Shape_Leng">
+          <editWidget type="TextEdit">
+            <config>
+              <Option></Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Shape_Area">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="OBJECTID" index="0" name=""></alias>
+        <alias field="VertexCou" index="1" name=""></alias>
+        <alias field="ISO" index="2" name=""></alias>
+        <alias field="NAME_0" index="3" name=""></alias>
+        <alias field="NAME_1" index="4" name=""></alias>
+        <alias field="VARNAME_1" index="5" name=""></alias>
+        <alias field="NL_NAME_1" index="6" name=""></alias>
+        <alias field="HASC_1" index="7" name=""></alias>
+        <alias field="TYPE_1" index="8" name=""></alias>
+        <alias field="ENGTYPE_1" index="9" name=""></alias>
+        <alias field="VALIDFR_1" index="10" name=""></alias>
+        <alias field="VALIDTO_1" index="11" name=""></alias>
+        <alias field="REMARKS_1" index="12" name=""></alias>
+        <alias field="Region" index="13" name=""></alias>
+        <alias field="RegionVar" index="14" name=""></alias>
+        <alias field="ProvNumber" index="15" name=""></alias>
+        <alias field="NEV_Countr" index="16" name=""></alias>
+        <alias field="FIRST_FIPS" index="17" name=""></alias>
+        <alias field="FIRST_HASC" index="18" name=""></alias>
+        <alias field="FIPS_1" index="19" name=""></alias>
+        <alias field="gadm_level" index="20" name=""></alias>
+        <alias field="CheckMe" index="21" name=""></alias>
+        <alias field="Region_Cod" index="22" name=""></alias>
+        <alias field="Region_C_1" index="23" name=""></alias>
+        <alias field="ScaleRank" index="24" name=""></alias>
+        <alias field="Region_C_2" index="25" name=""></alias>
+        <alias field="Region_C_3" index="26" name=""></alias>
+        <alias field="Country_Pr" index="27" name=""></alias>
+        <alias field="DataRank" index="28" name=""></alias>
+        <alias field="Abbrev" index="29" name=""></alias>
+        <alias field="Postal" index="30" name=""></alias>
+        <alias field="Area_sqkm" index="31" name=""></alias>
+        <alias field="sameAsCity" index="32" name=""></alias>
+        <alias field="ADM0_A3" index="33" name=""></alias>
+        <alias field="MAP_COLOR" index="34" name=""></alias>
+        <alias field="LabelRank" index="35" name=""></alias>
+        <alias field="Shape_Leng" index="36" name=""></alias>
+        <alias field="Shape_Area" index="37" name=""></alias>
+      </aliases>
+      <excludeAttributesWMS>
+        <attribute>Abbrev</attribute>
+        <attribute>NAME_1</attribute>
+        <attribute>Region_C_2</attribute>
+        <attribute>Country_Pr</attribute>
+        <attribute>CheckMe</attribute>
+        <attribute>NL_NAME_1</attribute>
+        <attribute>VertexCou</attribute>
+        <attribute>VALIDTO_1</attribute>
+        <attribute>FIRST_FIPS</attribute>
+        <attribute>FIRST_HASC</attribute>
+        <attribute>ADM0_A3</attribute>
+        <attribute>TYPE_1</attribute>
+        <attribute>DataRank</attribute>
+        <attribute>Area_sqkm</attribute>
+        <attribute>FIPS_1</attribute>
+        <attribute>sameAsCity</attribute>
+        <attribute>ENGTYPE_1</attribute>
+        <attribute>VALIDFR_1</attribute>
+        <attribute>Region_Cod</attribute>
+        <attribute>ProvNumber</attribute>
+        <attribute>ISO</attribute>
+        <attribute>REMARKS_1</attribute>
+        <attribute>gadm_level</attribute>
+        <attribute>Region_C_3</attribute>
+        <attribute>Postal</attribute>
+        <attribute>RegionVar</attribute>
+        <attribute>LabelRank</attribute>
+        <attribute>MAP_COLOR</attribute>
+        <attribute>HASC_1</attribute>
+        <attribute>ScaleRank</attribute>
+        <attribute>Region_C_1</attribute>
+        <attribute>NEV_Countr</attribute>
+      </excludeAttributesWMS>
+      <excludeAttributesWFS>
+        <attribute>Abbrev</attribute>
+        <attribute>NAME_1</attribute>
+        <attribute>Region_C_2</attribute>
+        <attribute>Country_Pr</attribute>
+        <attribute>CheckMe</attribute>
+        <attribute>NL_NAME_1</attribute>
+        <attribute>VertexCou</attribute>
+        <attribute>VALIDTO_1</attribute>
+        <attribute>FIRST_FIPS</attribute>
+        <attribute>FIRST_HASC</attribute>
+        <attribute>ADM0_A3</attribute>
+        <attribute>TYPE_1</attribute>
+        <attribute>DataRank</attribute>
+        <attribute>Area_sqkm</attribute>
+        <attribute>FIPS_1</attribute>
+        <attribute>sameAsCity</attribute>
+        <attribute>ENGTYPE_1</attribute>
+        <attribute>VALIDFR_1</attribute>
+        <attribute>Region_Cod</attribute>
+        <attribute>ProvNumber</attribute>
+        <attribute>ISO</attribute>
+        <attribute>REMARKS_1</attribute>
+        <attribute>gadm_level</attribute>
+        <attribute>Region_C_3</attribute>
+        <attribute>Postal</attribute>
+        <attribute>RegionVar</attribute>
+        <attribute>LabelRank</attribute>
+        <attribute>MAP_COLOR</attribute>
+        <attribute>HASC_1</attribute>
+        <attribute>ScaleRank</attribute>
+        <attribute>Region_C_1</attribute>
+        <attribute>NEV_Countr</attribute>
+      </excludeAttributesWFS>
+      <defaults>
+        <default applyOnUpdate="0" expression="" field="OBJECTID"></default>
+        <default applyOnUpdate="0" expression="" field="VertexCou"></default>
+        <default applyOnUpdate="0" expression="" field="ISO"></default>
+        <default applyOnUpdate="0" expression="" field="NAME_0"></default>
+        <default applyOnUpdate="0" expression="" field="NAME_1"></default>
+        <default applyOnUpdate="0" expression="" field="VARNAME_1"></default>
+        <default applyOnUpdate="0" expression="" field="NL_NAME_1"></default>
+        <default applyOnUpdate="0" expression="" field="HASC_1"></default>
+        <default applyOnUpdate="0" expression="" field="TYPE_1"></default>
+        <default applyOnUpdate="0" expression="" field="ENGTYPE_1"></default>
+        <default applyOnUpdate="0" expression="" field="VALIDFR_1"></default>
+        <default applyOnUpdate="0" expression="" field="VALIDTO_1"></default>
+        <default applyOnUpdate="0" expression="" field="REMARKS_1"></default>
+        <default applyOnUpdate="0" expression="" field="Region"></default>
+        <default applyOnUpdate="0" expression="" field="RegionVar"></default>
+        <default applyOnUpdate="0" expression="" field="ProvNumber"></default>
+        <default applyOnUpdate="0" expression="" field="NEV_Countr"></default>
+        <default applyOnUpdate="0" expression="" field="FIRST_FIPS"></default>
+        <default applyOnUpdate="0" expression="" field="FIRST_HASC"></default>
+        <default applyOnUpdate="0" expression="" field="FIPS_1"></default>
+        <default applyOnUpdate="0" expression="" field="gadm_level"></default>
+        <default applyOnUpdate="0" expression="" field="CheckMe"></default>
+        <default applyOnUpdate="0" expression="" field="Region_Cod"></default>
+        <default applyOnUpdate="0" expression="" field="Region_C_1"></default>
+        <default applyOnUpdate="0" expression="" field="ScaleRank"></default>
+        <default applyOnUpdate="0" expression="" field="Region_C_2"></default>
+        <default applyOnUpdate="0" expression="" field="Region_C_3"></default>
+        <default applyOnUpdate="0" expression="" field="Country_Pr"></default>
+        <default applyOnUpdate="0" expression="" field="DataRank"></default>
+        <default applyOnUpdate="0" expression="" field="Abbrev"></default>
+        <default applyOnUpdate="0" expression="" field="Postal"></default>
+        <default applyOnUpdate="0" expression="" field="Area_sqkm"></default>
+        <default applyOnUpdate="0" expression="" field="sameAsCity"></default>
+        <default applyOnUpdate="0" expression="" field="ADM0_A3"></default>
+        <default applyOnUpdate="0" expression="" field="MAP_COLOR"></default>
+        <default applyOnUpdate="0" expression="" field="LabelRank"></default>
+        <default applyOnUpdate="0" expression="" field="Shape_Leng"></default>
+        <default applyOnUpdate="0" expression="" field="Shape_Area"></default>
+      </defaults>
+      <constraints>
+        <constraint constraints="0" exp_strength="0" field="OBJECTID" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="VertexCou" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ISO" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NAME_0" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NAME_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="VARNAME_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NL_NAME_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="HASC_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="TYPE_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ENGTYPE_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="VALIDFR_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="VALIDTO_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="REMARKS_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="RegionVar" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ProvNumber" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="NEV_Countr" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="FIRST_FIPS" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="FIRST_HASC" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="FIPS_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="gadm_level" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="CheckMe" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region_Cod" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region_C_1" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ScaleRank" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region_C_2" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Region_C_3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Country_Pr" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="DataRank" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Abbrev" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Postal" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Area_sqkm" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="sameAsCity" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="ADM0_A3" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="MAP_COLOR" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="LabelRank" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Shape_Leng" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="Shape_Area" notnull_strength="0" unique_strength="0"></constraint>
+      </constraints>
+      <constraintExpressions>
+        <constraint desc="" exp="" field="OBJECTID"></constraint>
+        <constraint desc="" exp="" field="VertexCou"></constraint>
+        <constraint desc="" exp="" field="ISO"></constraint>
+        <constraint desc="" exp="" field="NAME_0"></constraint>
+        <constraint desc="" exp="" field="NAME_1"></constraint>
+        <constraint desc="" exp="" field="VARNAME_1"></constraint>
+        <constraint desc="" exp="" field="NL_NAME_1"></constraint>
+        <constraint desc="" exp="" field="HASC_1"></constraint>
+        <constraint desc="" exp="" field="TYPE_1"></constraint>
+        <constraint desc="" exp="" field="ENGTYPE_1"></constraint>
+        <constraint desc="" exp="" field="VALIDFR_1"></constraint>
+        <constraint desc="" exp="" field="VALIDTO_1"></constraint>
+        <constraint desc="" exp="" field="REMARKS_1"></constraint>
+        <constraint desc="" exp="" field="Region"></constraint>
+        <constraint desc="" exp="" field="RegionVar"></constraint>
+        <constraint desc="" exp="" field="ProvNumber"></constraint>
+        <constraint desc="" exp="" field="NEV_Countr"></constraint>
+        <constraint desc="" exp="" field="FIRST_FIPS"></constraint>
+        <constraint desc="" exp="" field="FIRST_HASC"></constraint>
+        <constraint desc="" exp="" field="FIPS_1"></constraint>
+        <constraint desc="" exp="" field="gadm_level"></constraint>
+        <constraint desc="" exp="" field="CheckMe"></constraint>
+        <constraint desc="" exp="" field="Region_Cod"></constraint>
+        <constraint desc="" exp="" field="Region_C_1"></constraint>
+        <constraint desc="" exp="" field="ScaleRank"></constraint>
+        <constraint desc="" exp="" field="Region_C_2"></constraint>
+        <constraint desc="" exp="" field="Region_C_3"></constraint>
+        <constraint desc="" exp="" field="Country_Pr"></constraint>
+        <constraint desc="" exp="" field="DataRank"></constraint>
+        <constraint desc="" exp="" field="Abbrev"></constraint>
+        <constraint desc="" exp="" field="Postal"></constraint>
+        <constraint desc="" exp="" field="Area_sqkm"></constraint>
+        <constraint desc="" exp="" field="sameAsCity"></constraint>
+        <constraint desc="" exp="" field="ADM0_A3"></constraint>
+        <constraint desc="" exp="" field="MAP_COLOR"></constraint>
+        <constraint desc="" exp="" field="LabelRank"></constraint>
+        <constraint desc="" exp="" field="Shape_Leng"></constraint>
+        <constraint desc="" exp="" field="Shape_Area"></constraint>
+      </constraintExpressions>
+      <expressionfields></expressionfields>
+      <attributeactions>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+        <columns>
+          <column hidden="0" name="OBJECTID" type="field" width="-1"></column>
+          <column hidden="0" name="VertexCou" type="field" width="-1"></column>
+          <column hidden="0" name="ISO" type="field" width="-1"></column>
+          <column hidden="0" name="NAME_0" type="field" width="-1"></column>
+          <column hidden="0" name="NAME_1" type="field" width="-1"></column>
+          <column hidden="0" name="VARNAME_1" type="field" width="-1"></column>
+          <column hidden="0" name="NL_NAME_1" type="field" width="-1"></column>
+          <column hidden="0" name="HASC_1" type="field" width="-1"></column>
+          <column hidden="0" name="TYPE_1" type="field" width="-1"></column>
+          <column hidden="0" name="ENGTYPE_1" type="field" width="-1"></column>
+          <column hidden="0" name="VALIDFR_1" type="field" width="-1"></column>
+          <column hidden="0" name="VALIDTO_1" type="field" width="-1"></column>
+          <column hidden="0" name="REMARKS_1" type="field" width="-1"></column>
+          <column hidden="0" name="Region" type="field" width="-1"></column>
+          <column hidden="0" name="RegionVar" type="field" width="-1"></column>
+          <column hidden="0" name="ProvNumber" type="field" width="-1"></column>
+          <column hidden="0" name="NEV_Countr" type="field" width="-1"></column>
+          <column hidden="0" name="FIRST_FIPS" type="field" width="-1"></column>
+          <column hidden="0" name="FIRST_HASC" type="field" width="-1"></column>
+          <column hidden="0" name="FIPS_1" type="field" width="-1"></column>
+          <column hidden="0" name="gadm_level" type="field" width="-1"></column>
+          <column hidden="0" name="CheckMe" type="field" width="-1"></column>
+          <column hidden="0" name="Region_Cod" type="field" width="-1"></column>
+          <column hidden="0" name="Region_C_1" type="field" width="-1"></column>
+          <column hidden="0" name="ScaleRank" type="field" width="-1"></column>
+          <column hidden="0" name="Region_C_2" type="field" width="-1"></column>
+          <column hidden="0" name="Region_C_3" type="field" width="-1"></column>
+          <column hidden="0" name="Country_Pr" type="field" width="-1"></column>
+          <column hidden="0" name="DataRank" type="field" width="-1"></column>
+          <column hidden="0" name="Abbrev" type="field" width="-1"></column>
+          <column hidden="0" name="Postal" type="field" width="-1"></column>
+          <column hidden="0" name="Area_sqkm" type="field" width="-1"></column>
+          <column hidden="0" name="sameAsCity" type="field" width="-1"></column>
+          <column hidden="0" name="ADM0_A3" type="field" width="-1"></column>
+          <column hidden="0" name="MAP_COLOR" type="field" width="-1"></column>
+          <column hidden="0" name="LabelRank" type="field" width="-1"></column>
+          <column hidden="0" name="Shape_Leng" type="field" width="-1"></column>
+          <column hidden="0" name="Shape_Area" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
+        </columns>
+      </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
+      </conditionalstyles>
+      <storedexpressions></storedexpressions>
+      <editform tolerant="1"></editform>
+      <editforminit></editforminit>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode># -*- coding: utf-8 -*-
+"""
+Les formulaires QGIS peuvent avoir une fonction Python qui sera appelée à l'ouverture du formulaire.
+
+Utilisez cette fonction pour ajouter plus de fonctionnalités à vos formulaires.
+
+Entrez le nom de la fonction dans le champ "Fonction d'initialisation Python".
+Voici un exemple à suivre:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+
+</editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>tablayout</editorlayout>
+      <attributeEditorForm>
+        <attributeEditorContainer columnCount="1" groupBox="0" name="Home" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <attributeEditorField index="3" name="NAME_0" showLabel="1"></attributeEditorField>
+        </attributeEditorContainer>
+      </attributeEditorForm>
+      <editable>
+        <field editable="1" name="ADM0_A3"></field>
+        <field editable="1" name="Abbrev"></field>
+        <field editable="1" name="Area_sqkm"></field>
+        <field editable="1" name="CheckMe"></field>
+        <field editable="1" name="Country_Pr"></field>
+        <field editable="1" name="DataRank"></field>
+        <field editable="1" name="ENGTYPE_1"></field>
+        <field editable="1" name="FIPS_1"></field>
+        <field editable="1" name="FIRST_FIPS"></field>
+        <field editable="1" name="FIRST_HASC"></field>
+        <field editable="1" name="HASC_1"></field>
+        <field editable="1" name="ISO"></field>
+        <field editable="1" name="LabelRank"></field>
+        <field editable="1" name="MAP_COLOR"></field>
+        <field editable="1" name="NAME_0"></field>
+        <field editable="1" name="NAME_1"></field>
+        <field editable="1" name="NEV_Countr"></field>
+        <field editable="1" name="NL_NAME_1"></field>
+        <field editable="1" name="OBJECTID"></field>
+        <field editable="1" name="Postal"></field>
+        <field editable="1" name="ProvNumber"></field>
+        <field editable="1" name="REMARKS_1"></field>
+        <field editable="1" name="Region"></field>
+        <field editable="1" name="RegionVar"></field>
+        <field editable="1" name="Region_C_1"></field>
+        <field editable="1" name="Region_C_2"></field>
+        <field editable="1" name="Region_C_3"></field>
+        <field editable="1" name="Region_Cod"></field>
+        <field editable="1" name="ScaleRank"></field>
+        <field editable="1" name="Shape_Area"></field>
+        <field editable="1" name="Shape_Leng"></field>
+        <field editable="1" name="TYPE_1"></field>
+        <field editable="1" name="VALIDFR_1"></field>
+        <field editable="1" name="VALIDTO_1"></field>
+        <field editable="1" name="VARNAME_1"></field>
+        <field editable="1" name="VertexCou"></field>
+        <field editable="1" name="gadm_level"></field>
+        <field editable="1" name="sameAsCity"></field>
+      </editable>
+      <labelOnTop>
+        <field labelOnTop="0" name="ADM0_A3"></field>
+        <field labelOnTop="0" name="Abbrev"></field>
+        <field labelOnTop="0" name="Area_sqkm"></field>
+        <field labelOnTop="0" name="CheckMe"></field>
+        <field labelOnTop="0" name="Country_Pr"></field>
+        <field labelOnTop="0" name="DataRank"></field>
+        <field labelOnTop="0" name="ENGTYPE_1"></field>
+        <field labelOnTop="0" name="FIPS_1"></field>
+        <field labelOnTop="0" name="FIRST_FIPS"></field>
+        <field labelOnTop="0" name="FIRST_HASC"></field>
+        <field labelOnTop="0" name="HASC_1"></field>
+        <field labelOnTop="0" name="ISO"></field>
+        <field labelOnTop="0" name="LabelRank"></field>
+        <field labelOnTop="0" name="MAP_COLOR"></field>
+        <field labelOnTop="0" name="NAME_0"></field>
+        <field labelOnTop="0" name="NAME_1"></field>
+        <field labelOnTop="0" name="NEV_Countr"></field>
+        <field labelOnTop="0" name="NL_NAME_1"></field>
+        <field labelOnTop="0" name="OBJECTID"></field>
+        <field labelOnTop="0" name="Postal"></field>
+        <field labelOnTop="0" name="ProvNumber"></field>
+        <field labelOnTop="0" name="REMARKS_1"></field>
+        <field labelOnTop="0" name="Region"></field>
+        <field labelOnTop="0" name="RegionVar"></field>
+        <field labelOnTop="0" name="Region_C_1"></field>
+        <field labelOnTop="0" name="Region_C_2"></field>
+        <field labelOnTop="0" name="Region_C_3"></field>
+        <field labelOnTop="0" name="Region_Cod"></field>
+        <field labelOnTop="0" name="ScaleRank"></field>
+        <field labelOnTop="0" name="Shape_Area"></field>
+        <field labelOnTop="0" name="Shape_Leng"></field>
+        <field labelOnTop="0" name="TYPE_1"></field>
+        <field labelOnTop="0" name="VALIDFR_1"></field>
+        <field labelOnTop="0" name="VALIDTO_1"></field>
+        <field labelOnTop="0" name="VARNAME_1"></field>
+        <field labelOnTop="0" name="VertexCou"></field>
+        <field labelOnTop="0" name="gadm_level"></field>
+        <field labelOnTop="0" name="sameAsCity"></field>
+      </labelOnTop>
+      <widgets></widgets>
+      <previewExpression>"NAME_0"</previewExpression>
+      <mapTip>&lt;p&gt;[% "NAME_0" %]&lt;/p&gt;</mapTip>
+    </maplayer>
   </projectlayers>
   <layerorder>
-    <layer id="france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3"/>
-    <layer id="default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1"/>
+    <layer id="france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3"></layer>
+    <layer id="default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1"></layer>
+    <layer id="qgis_popup_a6f4c4e3_79bc_4443_aab6_7e44ef9fe24b"></layer>
   </layerorder>
   <properties>
     <DefaultStyles>
@@ -1784,13 +2721,13 @@ def my_form_open(dialog, layer, feature):
     <SpatialRefSys>
       <ProjectionsEnabled type="int">1</ProjectionsEnabled>
     </SpatialRefSys>
-    <WCSLayers type="QStringList"/>
+    <WCSLayers type="QStringList"></WCSLayers>
     <WCSUrl type="QString"></WCSUrl>
-    <WFSLayers type="QStringList"/>
+    <WFSLayers type="QStringList"></WFSLayers>
     <WFSTLayers>
-      <Delete type="QStringList"/>
-      <Insert type="QStringList"/>
-      <Update type="QStringList"/>
+      <Delete type="QStringList"></Delete>
+      <Insert type="QStringList"></Insert>
+      <Update type="QStringList"></Update>
     </WFSTLayers>
     <WFSUrl type="QString"></WFSUrl>
     <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
@@ -1824,29 +2761,29 @@ def my_form_open(dialog, layer, feature):
     <WMSUrl type="QString"></WMSUrl>
     <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
     <WMTSGrids>
-      <CRS type="QStringList"/>
-      <Config type="QStringList"/>
+      <CRS type="QStringList"></CRS>
+      <Config type="QStringList"></Config>
     </WMTSGrids>
     <WMTSJpegLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSJpegLayers>
     <WMTSLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSLayers>
     <WMTSMinScale type="int">5000</WMTSMinScale>
     <WMTSPngLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSPngLayers>
     <WMTSUrl type="QString"></WMTSUrl>
   </properties>
-  <visibility-presets/>
-  <transformContext/>
+  <visibility-presets></visibility-presets>
+  <transformContext></transformContext>
   <projectMetadata>
     <identifier></identifier>
     <parentidentifier></parentidentifier>
@@ -1863,14 +2800,14 @@ def my_form_open(dialog, layer, feature):
       <email></email>
       <role></role>
     </contact>
-    <links/>
+    <links></links>
     <author>Etienne Trimaille</author>
     <creation>2021-06-01T09:36:05</creation>
   </projectMetadata>
-  <Annotations/>
-  <Layouts/>
-  <Bookmarks/>
+  <Annotations></Annotations>
+  <Layouts></Layouts>
+  <Bookmarks></Bookmarks>
   <ProjectViewSettings UseProjectScales="0">
-    <Scales/>
+    <Scales></Scales>
   </ProjectViewSettings>
 </qgis>

--- a/test/server/data/get_feature_info.qgs
+++ b/test/server/data/get_feature_info.qgs
@@ -1,0 +1,1876 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis projectname="" version="3.10.14-A Coruña">
+  <homePath path=""/>
+  <title></title>
+  <autotransaction active="0"/>
+  <evaluateDefaultValues active="0"/>
+  <trust active="0"/>
+  <projectCrs>
+    <spatialrefsys>
+      <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+      <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+      <srsid>3452</srsid>
+      <srid>4326</srid>
+      <authid>EPSG:4326</authid>
+      <description>WGS 84</description>
+      <projectionacronym>longlat</projectionacronym>
+      <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+      <geographicflag>true</geographicflag>
+    </spatialrefsys>
+  </projectCrs>
+  <layer-tree-group>
+    <customproperties/>
+    <layer-tree-layer name="default_popup" checked="Qt::Checked" legend_exp="" id="france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3" providerKey="ogr" source="./france_parts/france_parts.shp" expanded="1">
+      <customproperties/>
+    </layer-tree-layer>
+    <layer-tree-layer name="qgis_popup" checked="Qt::Checked" legend_exp="" id="default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1" providerKey="ogr" source="./france_parts/france_parts.shp" expanded="1">
+      <customproperties/>
+    </layer-tree-layer>
+    <custom-order enabled="0">
+      <item>france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3</item>
+      <item>default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1</item>
+    </custom-order>
+  </layer-tree-group>
+  <snapping-settings intersection-snapping="0" tolerance="12" type="1" enabled="0" unit="1" mode="2">
+    <individual-layer-settings>
+      <layer-setting tolerance="12" type="1" enabled="0" id="france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3" units="1"/>
+      <layer-setting tolerance="12" type="1" enabled="0" id="default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1" units="1"/>
+    </individual-layer-settings>
+  </snapping-settings>
+  <relations/>
+  <mapcanvas name="theMapCanvas" annotationsVisible="1">
+    <units>degrees</units>
+    <extent>
+      <xmin>-5.33889081436202328</xmin>
+      <ymin>46.19300890773994439</ymin>
+      <xmax>3.32419280355761426</xmax>
+      <ymax>49.81265618522981953</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys>
+        <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+    <expressionContextScope/>
+  </mapcanvas>
+  <projectModels/>
+  <legend updateDrawingOrder="true">
+    <legendlayer open="true" name="default_popup" checked="Qt::Checked" drawingOrder="-1" showFeatureCount="0">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile layerid="france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3" visible="1" isInOverview="0"/>
+      </filegroup>
+    </legendlayer>
+    <legendlayer open="true" name="qgis_popup" checked="Qt::Checked" drawingOrder="-1" showFeatureCount="0">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile layerid="default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1" visible="1" isInOverview="0"/>
+      </filegroup>
+    </legendlayer>
+  </legend>
+  <mapViewDocks/>
+  <mapViewDocks3D/>
+  <projectlayers>
+    <maplayer autoRefreshEnabled="0" simplifyAlgorithm="0" geometry="Polygon" labelsEnabled="0" type="vector" refreshOnNotifyEnabled="0" simplifyLocal="1" wkbType="MultiPolygon" simplifyMaxScale="1" simplifyDrawingTol="1" maxScale="0" styleCategories="AllStyleCategories" simplifyDrawingHints="1" refreshOnNotifyMessage="" autoRefreshTime="0" minScale="1e+08" hasScaleBasedVisibilityFlag="0" readOnly="0">
+      <extent>
+        <xmin>-5.1326269186972695</xmin>
+        <ymin>46.2791909857754149</ymin>
+        <xmax>3.11792890789286048</xmax>
+        <ymax>49.72647410719434902</ymax>
+      </extent>
+      <id>default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1</id>
+      <datasource>./france_parts/france_parts.shp</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>qgis_popup</layername>
+      <srs>
+        <spatialrefsys>
+          <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+          <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+          <srsid>3452</srsid>
+          <srid>4326</srid>
+          <authid>EPSG:4326</authid>
+          <description>WGS 84</description>
+          <projectionacronym>longlat</projectionacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+          <geographicflag>true</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type>dataset</type>
+        <title></title>
+        <abstract></abstract>
+        <contact>
+          <name></name>
+          <organization></organization>
+          <position></position>
+          <voice></voice>
+          <fax></fax>
+          <email></email>
+          <role></role>
+        </contact>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <wkt></wkt>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent>
+          <spatial miny="0" maxx="0" maxy="0" minx="0" dimensions="2" minz="0" crs="" maxz="0"/>
+          <temporal>
+            <period>
+              <start></start>
+              <end></end>
+            </period>
+          </temporal>
+        </extent>
+      </resourceMetadata>
+      <provider encoding="ISO-8859-1">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <legend type="default-vector"/>
+      <expressionfields/>
+      <map-layer-style-manager current="défaut">
+        <map-layer-style name="défaut"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" forceraster="0" symbollevels="0" enableorderby="0">
+        <symbols>
+          <symbol clip_to_extent="1" force_rhr="0" type="fill" name="0" alpha="1">
+            <layer locked="0" enabled="1" class="SimpleFill" pass="0">
+              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+              <prop v="229,182,54,255" k="color"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0.26" k="outline_width"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="solid" k="style"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" name="name" value=""/>
+                  <Option name="properties"/>
+                  <Option type="QString" name="type" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
+      </renderer-v2>
+      <customproperties>
+        <property value="0" key="embeddedWidgets/count"/>
+        <property key="variableNames"/>
+        <property key="variableValues"/>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory maxScaleDenominator="1e+08" barWidth="5" height="15" penWidth="0" minScaleDenominator="0" lineSizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" sizeScale="3x:0,0,0,0,0,0" backgroundAlpha="255" penColor="#000000" backgroundColor="#ffffff" sizeType="MM" minimumSize="0" enabled="0" penAlpha="255" scaleBasedVisibility="0" scaleDependency="Area" diagramOrientation="Up" width="15" rotationOffset="270" labelPlacementMethod="XHeight" opacity="1">
+          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" label="" color="#000000"/>
+        </DiagramCategory>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings zIndex="0" dist="0" placement="1" showAll="1" priority="0" linePlacementFlags="18" obstacle="0">
+        <properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </properties>
+      </DiagramLayerSettings>
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+        <activeChecks/>
+        <checkConfiguration type="Map">
+          <Option type="Map" name="QgsGeometryGapCheck">
+            <Option type="double" name="allowedGapsBuffer" value="0"/>
+            <Option type="bool" name="allowedGapsEnabled" value="false"/>
+            <Option type="QString" name="allowedGapsLayer" value=""/>
+          </Option>
+        </checkConfiguration>
+      </geometryOptions>
+      <fieldConfiguration>
+        <field name="OBJECTID">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="VertexCou">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ISO">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="NAME_0">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="NAME_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="VARNAME_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="NL_NAME_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="HASC_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="TYPE_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ENGTYPE_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="VALIDFR_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="VALIDTO_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="REMARKS_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="RegionVar">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ProvNumber">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="NEV_Countr">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="FIRST_FIPS">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="FIRST_HASC">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="FIPS_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="gadm_level">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="CheckMe">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region_Cod">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region_C_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ScaleRank">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region_C_2">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region_C_3">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Country_Pr">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="DataRank">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Abbrev">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Postal">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Area_sqkm">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="sameAsCity">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ADM0_A3">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="MAP_COLOR">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="LabelRank">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Shape_Leng">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Shape_Area">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="OBJECTID" name="" index="0"/>
+        <alias field="VertexCou" name="" index="1"/>
+        <alias field="ISO" name="" index="2"/>
+        <alias field="NAME_0" name="" index="3"/>
+        <alias field="NAME_1" name="" index="4"/>
+        <alias field="VARNAME_1" name="" index="5"/>
+        <alias field="NL_NAME_1" name="" index="6"/>
+        <alias field="HASC_1" name="" index="7"/>
+        <alias field="TYPE_1" name="" index="8"/>
+        <alias field="ENGTYPE_1" name="" index="9"/>
+        <alias field="VALIDFR_1" name="" index="10"/>
+        <alias field="VALIDTO_1" name="" index="11"/>
+        <alias field="REMARKS_1" name="" index="12"/>
+        <alias field="Region" name="" index="13"/>
+        <alias field="RegionVar" name="" index="14"/>
+        <alias field="ProvNumber" name="" index="15"/>
+        <alias field="NEV_Countr" name="" index="16"/>
+        <alias field="FIRST_FIPS" name="" index="17"/>
+        <alias field="FIRST_HASC" name="" index="18"/>
+        <alias field="FIPS_1" name="" index="19"/>
+        <alias field="gadm_level" name="" index="20"/>
+        <alias field="CheckMe" name="" index="21"/>
+        <alias field="Region_Cod" name="" index="22"/>
+        <alias field="Region_C_1" name="" index="23"/>
+        <alias field="ScaleRank" name="" index="24"/>
+        <alias field="Region_C_2" name="" index="25"/>
+        <alias field="Region_C_3" name="" index="26"/>
+        <alias field="Country_Pr" name="" index="27"/>
+        <alias field="DataRank" name="" index="28"/>
+        <alias field="Abbrev" name="" index="29"/>
+        <alias field="Postal" name="" index="30"/>
+        <alias field="Area_sqkm" name="" index="31"/>
+        <alias field="sameAsCity" name="" index="32"/>
+        <alias field="ADM0_A3" name="" index="33"/>
+        <alias field="MAP_COLOR" name="" index="34"/>
+        <alias field="LabelRank" name="" index="35"/>
+        <alias field="Shape_Leng" name="" index="36"/>
+        <alias field="Shape_Area" name="" index="37"/>
+      </aliases>
+      <excludeAttributesWMS>
+        <attribute>Country_Pr</attribute>
+        <attribute>TYPE_1</attribute>
+        <attribute>VertexCou</attribute>
+        <attribute>Region_C_1</attribute>
+        <attribute>FIRST_HASC</attribute>
+        <attribute>CheckMe</attribute>
+        <attribute>NAME_1</attribute>
+        <attribute>sameAsCity</attribute>
+        <attribute>MAP_COLOR</attribute>
+        <attribute>FIPS_1</attribute>
+        <attribute>gadm_level</attribute>
+        <attribute>HASC_1</attribute>
+        <attribute>Area_sqkm</attribute>
+        <attribute>FIRST_FIPS</attribute>
+        <attribute>ISO</attribute>
+        <attribute>Region_Cod</attribute>
+        <attribute>VALIDTO_1</attribute>
+        <attribute>DataRank</attribute>
+        <attribute>Abbrev</attribute>
+        <attribute>ADM0_A3</attribute>
+        <attribute>Region_C_2</attribute>
+        <attribute>NL_NAME_1</attribute>
+        <attribute>LabelRank</attribute>
+        <attribute>ENGTYPE_1</attribute>
+        <attribute>REMARKS_1</attribute>
+        <attribute>Region_C_3</attribute>
+        <attribute>NEV_Countr</attribute>
+        <attribute>Postal</attribute>
+        <attribute>RegionVar</attribute>
+        <attribute>VALIDFR_1</attribute>
+        <attribute>ProvNumber</attribute>
+        <attribute>ScaleRank</attribute>
+      </excludeAttributesWMS>
+      <excludeAttributesWFS>
+        <attribute>Country_Pr</attribute>
+        <attribute>TYPE_1</attribute>
+        <attribute>VertexCou</attribute>
+        <attribute>Region_C_1</attribute>
+        <attribute>FIRST_HASC</attribute>
+        <attribute>CheckMe</attribute>
+        <attribute>NAME_1</attribute>
+        <attribute>sameAsCity</attribute>
+        <attribute>MAP_COLOR</attribute>
+        <attribute>FIPS_1</attribute>
+        <attribute>gadm_level</attribute>
+        <attribute>HASC_1</attribute>
+        <attribute>Area_sqkm</attribute>
+        <attribute>FIRST_FIPS</attribute>
+        <attribute>ISO</attribute>
+        <attribute>Region_Cod</attribute>
+        <attribute>VALIDTO_1</attribute>
+        <attribute>DataRank</attribute>
+        <attribute>Abbrev</attribute>
+        <attribute>ADM0_A3</attribute>
+        <attribute>Region_C_2</attribute>
+        <attribute>NL_NAME_1</attribute>
+        <attribute>LabelRank</attribute>
+        <attribute>ENGTYPE_1</attribute>
+        <attribute>REMARKS_1</attribute>
+        <attribute>Region_C_3</attribute>
+        <attribute>NEV_Countr</attribute>
+        <attribute>Postal</attribute>
+        <attribute>RegionVar</attribute>
+        <attribute>VALIDFR_1</attribute>
+        <attribute>ProvNumber</attribute>
+        <attribute>ScaleRank</attribute>
+      </excludeAttributesWFS>
+      <defaults>
+        <default field="OBJECTID" expression="" applyOnUpdate="0"/>
+        <default field="VertexCou" expression="" applyOnUpdate="0"/>
+        <default field="ISO" expression="" applyOnUpdate="0"/>
+        <default field="NAME_0" expression="" applyOnUpdate="0"/>
+        <default field="NAME_1" expression="" applyOnUpdate="0"/>
+        <default field="VARNAME_1" expression="" applyOnUpdate="0"/>
+        <default field="NL_NAME_1" expression="" applyOnUpdate="0"/>
+        <default field="HASC_1" expression="" applyOnUpdate="0"/>
+        <default field="TYPE_1" expression="" applyOnUpdate="0"/>
+        <default field="ENGTYPE_1" expression="" applyOnUpdate="0"/>
+        <default field="VALIDFR_1" expression="" applyOnUpdate="0"/>
+        <default field="VALIDTO_1" expression="" applyOnUpdate="0"/>
+        <default field="REMARKS_1" expression="" applyOnUpdate="0"/>
+        <default field="Region" expression="" applyOnUpdate="0"/>
+        <default field="RegionVar" expression="" applyOnUpdate="0"/>
+        <default field="ProvNumber" expression="" applyOnUpdate="0"/>
+        <default field="NEV_Countr" expression="" applyOnUpdate="0"/>
+        <default field="FIRST_FIPS" expression="" applyOnUpdate="0"/>
+        <default field="FIRST_HASC" expression="" applyOnUpdate="0"/>
+        <default field="FIPS_1" expression="" applyOnUpdate="0"/>
+        <default field="gadm_level" expression="" applyOnUpdate="0"/>
+        <default field="CheckMe" expression="" applyOnUpdate="0"/>
+        <default field="Region_Cod" expression="" applyOnUpdate="0"/>
+        <default field="Region_C_1" expression="" applyOnUpdate="0"/>
+        <default field="ScaleRank" expression="" applyOnUpdate="0"/>
+        <default field="Region_C_2" expression="" applyOnUpdate="0"/>
+        <default field="Region_C_3" expression="" applyOnUpdate="0"/>
+        <default field="Country_Pr" expression="" applyOnUpdate="0"/>
+        <default field="DataRank" expression="" applyOnUpdate="0"/>
+        <default field="Abbrev" expression="" applyOnUpdate="0"/>
+        <default field="Postal" expression="" applyOnUpdate="0"/>
+        <default field="Area_sqkm" expression="" applyOnUpdate="0"/>
+        <default field="sameAsCity" expression="" applyOnUpdate="0"/>
+        <default field="ADM0_A3" expression="" applyOnUpdate="0"/>
+        <default field="MAP_COLOR" expression="" applyOnUpdate="0"/>
+        <default field="LabelRank" expression="" applyOnUpdate="0"/>
+        <default field="Shape_Leng" expression="" applyOnUpdate="0"/>
+        <default field="Shape_Area" expression="" applyOnUpdate="0"/>
+      </defaults>
+      <constraints>
+        <constraint field="OBJECTID" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="VertexCou" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="ISO" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="NAME_0" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="NAME_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="VARNAME_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="NL_NAME_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="HASC_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="TYPE_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="ENGTYPE_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="VALIDFR_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="VALIDTO_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="REMARKS_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Region" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="RegionVar" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="ProvNumber" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="NEV_Countr" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="FIRST_FIPS" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="FIRST_HASC" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="FIPS_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="gadm_level" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="CheckMe" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Region_Cod" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Region_C_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="ScaleRank" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Region_C_2" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Region_C_3" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Country_Pr" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="DataRank" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Abbrev" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Postal" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Area_sqkm" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="sameAsCity" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="ADM0_A3" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="MAP_COLOR" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="LabelRank" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Shape_Leng" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Shape_Area" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint field="OBJECTID" exp="" desc=""/>
+        <constraint field="VertexCou" exp="" desc=""/>
+        <constraint field="ISO" exp="" desc=""/>
+        <constraint field="NAME_0" exp="" desc=""/>
+        <constraint field="NAME_1" exp="" desc=""/>
+        <constraint field="VARNAME_1" exp="" desc=""/>
+        <constraint field="NL_NAME_1" exp="" desc=""/>
+        <constraint field="HASC_1" exp="" desc=""/>
+        <constraint field="TYPE_1" exp="" desc=""/>
+        <constraint field="ENGTYPE_1" exp="" desc=""/>
+        <constraint field="VALIDFR_1" exp="" desc=""/>
+        <constraint field="VALIDTO_1" exp="" desc=""/>
+        <constraint field="REMARKS_1" exp="" desc=""/>
+        <constraint field="Region" exp="" desc=""/>
+        <constraint field="RegionVar" exp="" desc=""/>
+        <constraint field="ProvNumber" exp="" desc=""/>
+        <constraint field="NEV_Countr" exp="" desc=""/>
+        <constraint field="FIRST_FIPS" exp="" desc=""/>
+        <constraint field="FIRST_HASC" exp="" desc=""/>
+        <constraint field="FIPS_1" exp="" desc=""/>
+        <constraint field="gadm_level" exp="" desc=""/>
+        <constraint field="CheckMe" exp="" desc=""/>
+        <constraint field="Region_Cod" exp="" desc=""/>
+        <constraint field="Region_C_1" exp="" desc=""/>
+        <constraint field="ScaleRank" exp="" desc=""/>
+        <constraint field="Region_C_2" exp="" desc=""/>
+        <constraint field="Region_C_3" exp="" desc=""/>
+        <constraint field="Country_Pr" exp="" desc=""/>
+        <constraint field="DataRank" exp="" desc=""/>
+        <constraint field="Abbrev" exp="" desc=""/>
+        <constraint field="Postal" exp="" desc=""/>
+        <constraint field="Area_sqkm" exp="" desc=""/>
+        <constraint field="sameAsCity" exp="" desc=""/>
+        <constraint field="ADM0_A3" exp="" desc=""/>
+        <constraint field="MAP_COLOR" exp="" desc=""/>
+        <constraint field="LabelRank" exp="" desc=""/>
+        <constraint field="Shape_Leng" exp="" desc=""/>
+        <constraint field="Shape_Area" exp="" desc=""/>
+      </constraintExpressions>
+      <expressionfields/>
+      <attributeactions>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+      </attributeactions>
+      <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+        <columns>
+          <column type="field" name="OBJECTID" width="-1" hidden="0"/>
+          <column type="field" name="VertexCou" width="-1" hidden="0"/>
+          <column type="field" name="ISO" width="-1" hidden="0"/>
+          <column type="field" name="NAME_0" width="-1" hidden="0"/>
+          <column type="field" name="NAME_1" width="-1" hidden="0"/>
+          <column type="field" name="VARNAME_1" width="-1" hidden="0"/>
+          <column type="field" name="NL_NAME_1" width="-1" hidden="0"/>
+          <column type="field" name="HASC_1" width="-1" hidden="0"/>
+          <column type="field" name="TYPE_1" width="-1" hidden="0"/>
+          <column type="field" name="ENGTYPE_1" width="-1" hidden="0"/>
+          <column type="field" name="VALIDFR_1" width="-1" hidden="0"/>
+          <column type="field" name="VALIDTO_1" width="-1" hidden="0"/>
+          <column type="field" name="REMARKS_1" width="-1" hidden="0"/>
+          <column type="field" name="Region" width="-1" hidden="0"/>
+          <column type="field" name="RegionVar" width="-1" hidden="0"/>
+          <column type="field" name="ProvNumber" width="-1" hidden="0"/>
+          <column type="field" name="NEV_Countr" width="-1" hidden="0"/>
+          <column type="field" name="FIRST_FIPS" width="-1" hidden="0"/>
+          <column type="field" name="FIRST_HASC" width="-1" hidden="0"/>
+          <column type="field" name="FIPS_1" width="-1" hidden="0"/>
+          <column type="field" name="gadm_level" width="-1" hidden="0"/>
+          <column type="field" name="CheckMe" width="-1" hidden="0"/>
+          <column type="field" name="Region_Cod" width="-1" hidden="0"/>
+          <column type="field" name="Region_C_1" width="-1" hidden="0"/>
+          <column type="field" name="ScaleRank" width="-1" hidden="0"/>
+          <column type="field" name="Region_C_2" width="-1" hidden="0"/>
+          <column type="field" name="Region_C_3" width="-1" hidden="0"/>
+          <column type="field" name="Country_Pr" width="-1" hidden="0"/>
+          <column type="field" name="DataRank" width="-1" hidden="0"/>
+          <column type="field" name="Abbrev" width="-1" hidden="0"/>
+          <column type="field" name="Postal" width="-1" hidden="0"/>
+          <column type="field" name="Area_sqkm" width="-1" hidden="0"/>
+          <column type="field" name="sameAsCity" width="-1" hidden="0"/>
+          <column type="field" name="ADM0_A3" width="-1" hidden="0"/>
+          <column type="field" name="MAP_COLOR" width="-1" hidden="0"/>
+          <column type="field" name="LabelRank" width="-1" hidden="0"/>
+          <column type="field" name="Shape_Leng" width="-1" hidden="0"/>
+          <column type="field" name="Shape_Area" width="-1" hidden="0"/>
+          <column type="actions" width="-1" hidden="1"/>
+        </columns>
+      </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <storedexpressions/>
+      <editform tolerant="1"></editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+Les formulaires QGIS peuvent avoir une fonction Python qui sera appelée à l'ouverture du formulaire.
+
+Utilisez cette fonction pour ajouter plus de fonctionnalités à vos formulaires.
+
+Entrez le nom de la fonction dans le champ "Fonction d'initialisation Python".
+Voici un exemple à suivre:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+
+]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable>
+        <field name="ADM0_A3" editable="1"/>
+        <field name="Abbrev" editable="1"/>
+        <field name="Area_sqkm" editable="1"/>
+        <field name="CheckMe" editable="1"/>
+        <field name="Country_Pr" editable="1"/>
+        <field name="DataRank" editable="1"/>
+        <field name="ENGTYPE_1" editable="1"/>
+        <field name="FIPS_1" editable="1"/>
+        <field name="FIRST_FIPS" editable="1"/>
+        <field name="FIRST_HASC" editable="1"/>
+        <field name="HASC_1" editable="1"/>
+        <field name="ISO" editable="1"/>
+        <field name="LabelRank" editable="1"/>
+        <field name="MAP_COLOR" editable="1"/>
+        <field name="NAME_0" editable="1"/>
+        <field name="NAME_1" editable="1"/>
+        <field name="NEV_Countr" editable="1"/>
+        <field name="NL_NAME_1" editable="1"/>
+        <field name="OBJECTID" editable="1"/>
+        <field name="Postal" editable="1"/>
+        <field name="ProvNumber" editable="1"/>
+        <field name="REMARKS_1" editable="1"/>
+        <field name="Region" editable="1"/>
+        <field name="RegionVar" editable="1"/>
+        <field name="Region_C_1" editable="1"/>
+        <field name="Region_C_2" editable="1"/>
+        <field name="Region_C_3" editable="1"/>
+        <field name="Region_Cod" editable="1"/>
+        <field name="ScaleRank" editable="1"/>
+        <field name="Shape_Area" editable="1"/>
+        <field name="Shape_Leng" editable="1"/>
+        <field name="TYPE_1" editable="1"/>
+        <field name="VALIDFR_1" editable="1"/>
+        <field name="VALIDTO_1" editable="1"/>
+        <field name="VARNAME_1" editable="1"/>
+        <field name="VertexCou" editable="1"/>
+        <field name="gadm_level" editable="1"/>
+        <field name="sameAsCity" editable="1"/>
+      </editable>
+      <labelOnTop>
+        <field labelOnTop="0" name="ADM0_A3"/>
+        <field labelOnTop="0" name="Abbrev"/>
+        <field labelOnTop="0" name="Area_sqkm"/>
+        <field labelOnTop="0" name="CheckMe"/>
+        <field labelOnTop="0" name="Country_Pr"/>
+        <field labelOnTop="0" name="DataRank"/>
+        <field labelOnTop="0" name="ENGTYPE_1"/>
+        <field labelOnTop="0" name="FIPS_1"/>
+        <field labelOnTop="0" name="FIRST_FIPS"/>
+        <field labelOnTop="0" name="FIRST_HASC"/>
+        <field labelOnTop="0" name="HASC_1"/>
+        <field labelOnTop="0" name="ISO"/>
+        <field labelOnTop="0" name="LabelRank"/>
+        <field labelOnTop="0" name="MAP_COLOR"/>
+        <field labelOnTop="0" name="NAME_0"/>
+        <field labelOnTop="0" name="NAME_1"/>
+        <field labelOnTop="0" name="NEV_Countr"/>
+        <field labelOnTop="0" name="NL_NAME_1"/>
+        <field labelOnTop="0" name="OBJECTID"/>
+        <field labelOnTop="0" name="Postal"/>
+        <field labelOnTop="0" name="ProvNumber"/>
+        <field labelOnTop="0" name="REMARKS_1"/>
+        <field labelOnTop="0" name="Region"/>
+        <field labelOnTop="0" name="RegionVar"/>
+        <field labelOnTop="0" name="Region_C_1"/>
+        <field labelOnTop="0" name="Region_C_2"/>
+        <field labelOnTop="0" name="Region_C_3"/>
+        <field labelOnTop="0" name="Region_Cod"/>
+        <field labelOnTop="0" name="ScaleRank"/>
+        <field labelOnTop="0" name="Shape_Area"/>
+        <field labelOnTop="0" name="Shape_Leng"/>
+        <field labelOnTop="0" name="TYPE_1"/>
+        <field labelOnTop="0" name="VALIDFR_1"/>
+        <field labelOnTop="0" name="VALIDTO_1"/>
+        <field labelOnTop="0" name="VARNAME_1"/>
+        <field labelOnTop="0" name="VertexCou"/>
+        <field labelOnTop="0" name="gadm_level"/>
+        <field labelOnTop="0" name="sameAsCity"/>
+      </labelOnTop>
+      <widgets/>
+      <previewExpression>"NAME_0"</previewExpression>
+      <mapTip>&lt;p>[% "NAME_0" %]&lt;/p></mapTip>
+    </maplayer>
+    <maplayer autoRefreshEnabled="0" simplifyAlgorithm="0" geometry="Polygon" labelsEnabled="0" type="vector" refreshOnNotifyEnabled="0" simplifyLocal="1" wkbType="MultiPolygon" simplifyMaxScale="1" simplifyDrawingTol="1" maxScale="0" styleCategories="AllStyleCategories" simplifyDrawingHints="1" refreshOnNotifyMessage="" autoRefreshTime="0" minScale="1e+08" hasScaleBasedVisibilityFlag="0" readOnly="0">
+      <extent>
+        <xmin>-5.1326269186972695</xmin>
+        <ymin>46.2791909857754149</ymin>
+        <xmax>3.11792890789286048</xmax>
+        <ymax>49.72647410719434902</ymax>
+      </extent>
+      <id>france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3</id>
+      <datasource>./france_parts/france_parts.shp</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>default_popup</layername>
+      <srs>
+        <spatialrefsys>
+          <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+          <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+          <srsid>3452</srsid>
+          <srid>4326</srid>
+          <authid>EPSG:4326</authid>
+          <description>WGS 84</description>
+          <projectionacronym>longlat</projectionacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+          <geographicflag>true</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type>dataset</type>
+        <title></title>
+        <abstract></abstract>
+        <contact>
+          <name></name>
+          <organization></organization>
+          <position></position>
+          <voice></voice>
+          <fax></fax>
+          <email></email>
+          <role></role>
+        </contact>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <wkt></wkt>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent>
+          <spatial miny="0" maxx="0" maxy="0" minx="0" dimensions="2" minz="0" crs="" maxz="0"/>
+          <temporal>
+            <period>
+              <start></start>
+              <end></end>
+            </period>
+          </temporal>
+        </extent>
+      </resourceMetadata>
+      <provider encoding="ISO-8859-1">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <legend type="default-vector"/>
+      <expressionfields/>
+      <map-layer-style-manager current="défaut">
+        <map-layer-style name="défaut"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" forceraster="0" symbollevels="0" enableorderby="0">
+        <symbols>
+          <symbol clip_to_extent="1" force_rhr="0" type="fill" name="0" alpha="1">
+            <layer locked="0" enabled="1" class="LinePatternFill" pass="0">
+              <prop v="135" k="angle"/>
+              <prop v="55,126,184,255" k="color"/>
+              <prop v="2" k="distance"/>
+              <prop v="3x:0,0,0,0,0,0" k="distance_map_unit_scale"/>
+              <prop v="MM" k="distance_unit"/>
+              <prop v="0.26" k="line_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="line_width_map_unit_scale"/>
+              <prop v="MM" k="line_width_unit"/>
+              <prop v="0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" name="name" value=""/>
+                  <Option name="properties"/>
+                  <Option type="QString" name="type" value="collection"/>
+                </Option>
+              </data_defined_properties>
+              <symbol clip_to_extent="1" force_rhr="0" type="line" name="@0@0" alpha="1">
+                <layer locked="0" enabled="1" class="SimpleLine" pass="0">
+                  <prop v="square" k="capstyle"/>
+                  <prop v="5;2" k="customdash"/>
+                  <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+                  <prop v="MM" k="customdash_unit"/>
+                  <prop v="0" k="draw_inside_polygon"/>
+                  <prop v="bevel" k="joinstyle"/>
+                  <prop v="0,0,0,255" k="line_color"/>
+                  <prop v="solid" k="line_style"/>
+                  <prop v="0.3" k="line_width"/>
+                  <prop v="MM" k="line_width_unit"/>
+                  <prop v="0" k="offset"/>
+                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+                  <prop v="MM" k="offset_unit"/>
+                  <prop v="0" k="ring_filter"/>
+                  <prop v="0" k="use_custom_dash"/>
+                  <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option type="QString" name="name" value=""/>
+                      <Option name="properties"/>
+                      <Option type="QString" name="type" value="collection"/>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </layer>
+            <layer locked="0" enabled="1" class="SimpleFill" pass="0">
+              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+              <prop v="0,0,0,255" k="color"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="0,0,0,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0.46" k="outline_width"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="no" k="style"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" name="name" value=""/>
+                  <Option name="properties"/>
+                  <Option type="QString" name="type" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
+      </renderer-v2>
+      <customproperties>
+        <property value="0" key="embeddedWidgets/count"/>
+        <property key="variableNames"/>
+        <property key="variableValues"/>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory maxScaleDenominator="1e+08" barWidth="5" height="15" penWidth="0" minScaleDenominator="0" lineSizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" sizeScale="3x:0,0,0,0,0,0" backgroundAlpha="255" penColor="#000000" backgroundColor="#ffffff" sizeType="MM" minimumSize="0" enabled="0" penAlpha="255" scaleBasedVisibility="0" scaleDependency="Area" diagramOrientation="Up" width="15" rotationOffset="270" labelPlacementMethod="XHeight" opacity="1">
+          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" label="" color="#000000"/>
+        </DiagramCategory>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings zIndex="0" dist="0" placement="1" showAll="1" priority="0" linePlacementFlags="18" obstacle="0">
+        <properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </properties>
+      </DiagramLayerSettings>
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+        <activeChecks/>
+        <checkConfiguration type="Map">
+          <Option type="Map" name="QgsGeometryGapCheck">
+            <Option type="double" name="allowedGapsBuffer" value="0"/>
+            <Option type="bool" name="allowedGapsEnabled" value="false"/>
+            <Option type="QString" name="allowedGapsLayer" value=""/>
+          </Option>
+        </checkConfiguration>
+      </geometryOptions>
+      <fieldConfiguration>
+        <field name="OBJECTID">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="VertexCou">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ISO">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="NAME_0">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="NAME_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="VARNAME_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="NL_NAME_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="HASC_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="TYPE_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ENGTYPE_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="VALIDFR_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="VALIDTO_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="REMARKS_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="RegionVar">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ProvNumber">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="NEV_Countr">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="FIRST_FIPS">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="FIRST_HASC">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="FIPS_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="gadm_level">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="CheckMe">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region_Cod">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region_C_1">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ScaleRank">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region_C_2">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Region_C_3">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Country_Pr">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="DataRank">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Abbrev">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Postal">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Area_sqkm">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="sameAsCity">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ADM0_A3">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="MAP_COLOR">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="LabelRank">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Shape_Leng">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Shape_Area">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="OBJECTID" name="" index="0"/>
+        <alias field="VertexCou" name="" index="1"/>
+        <alias field="ISO" name="" index="2"/>
+        <alias field="NAME_0" name="" index="3"/>
+        <alias field="NAME_1" name="" index="4"/>
+        <alias field="VARNAME_1" name="" index="5"/>
+        <alias field="NL_NAME_1" name="" index="6"/>
+        <alias field="HASC_1" name="" index="7"/>
+        <alias field="TYPE_1" name="" index="8"/>
+        <alias field="ENGTYPE_1" name="" index="9"/>
+        <alias field="VALIDFR_1" name="" index="10"/>
+        <alias field="VALIDTO_1" name="" index="11"/>
+        <alias field="REMARKS_1" name="" index="12"/>
+        <alias field="Region" name="" index="13"/>
+        <alias field="RegionVar" name="" index="14"/>
+        <alias field="ProvNumber" name="" index="15"/>
+        <alias field="NEV_Countr" name="" index="16"/>
+        <alias field="FIRST_FIPS" name="" index="17"/>
+        <alias field="FIRST_HASC" name="" index="18"/>
+        <alias field="FIPS_1" name="" index="19"/>
+        <alias field="gadm_level" name="" index="20"/>
+        <alias field="CheckMe" name="" index="21"/>
+        <alias field="Region_Cod" name="" index="22"/>
+        <alias field="Region_C_1" name="" index="23"/>
+        <alias field="ScaleRank" name="" index="24"/>
+        <alias field="Region_C_2" name="" index="25"/>
+        <alias field="Region_C_3" name="" index="26"/>
+        <alias field="Country_Pr" name="" index="27"/>
+        <alias field="DataRank" name="" index="28"/>
+        <alias field="Abbrev" name="" index="29"/>
+        <alias field="Postal" name="" index="30"/>
+        <alias field="Area_sqkm" name="" index="31"/>
+        <alias field="sameAsCity" name="" index="32"/>
+        <alias field="ADM0_A3" name="" index="33"/>
+        <alias field="MAP_COLOR" name="" index="34"/>
+        <alias field="LabelRank" name="" index="35"/>
+        <alias field="Shape_Leng" name="" index="36"/>
+        <alias field="Shape_Area" name="" index="37"/>
+      </aliases>
+      <excludeAttributesWMS>
+        <attribute>Country_Pr</attribute>
+        <attribute>TYPE_1</attribute>
+        <attribute>VertexCou</attribute>
+        <attribute>Region_C_1</attribute>
+        <attribute>FIRST_HASC</attribute>
+        <attribute>CheckMe</attribute>
+        <attribute>NAME_1</attribute>
+        <attribute>sameAsCity</attribute>
+        <attribute>MAP_COLOR</attribute>
+        <attribute>FIPS_1</attribute>
+        <attribute>gadm_level</attribute>
+        <attribute>HASC_1</attribute>
+        <attribute>Area_sqkm</attribute>
+        <attribute>FIRST_FIPS</attribute>
+        <attribute>ISO</attribute>
+        <attribute>Region_Cod</attribute>
+        <attribute>VALIDTO_1</attribute>
+        <attribute>DataRank</attribute>
+        <attribute>Abbrev</attribute>
+        <attribute>ADM0_A3</attribute>
+        <attribute>Region_C_2</attribute>
+        <attribute>NL_NAME_1</attribute>
+        <attribute>LabelRank</attribute>
+        <attribute>ENGTYPE_1</attribute>
+        <attribute>REMARKS_1</attribute>
+        <attribute>Region_C_3</attribute>
+        <attribute>NEV_Countr</attribute>
+        <attribute>Postal</attribute>
+        <attribute>RegionVar</attribute>
+        <attribute>VALIDFR_1</attribute>
+        <attribute>ProvNumber</attribute>
+        <attribute>ScaleRank</attribute>
+      </excludeAttributesWMS>
+      <excludeAttributesWFS>
+        <attribute>Country_Pr</attribute>
+        <attribute>TYPE_1</attribute>
+        <attribute>VertexCou</attribute>
+        <attribute>Region_C_1</attribute>
+        <attribute>FIRST_HASC</attribute>
+        <attribute>CheckMe</attribute>
+        <attribute>NAME_1</attribute>
+        <attribute>sameAsCity</attribute>
+        <attribute>MAP_COLOR</attribute>
+        <attribute>FIPS_1</attribute>
+        <attribute>gadm_level</attribute>
+        <attribute>HASC_1</attribute>
+        <attribute>Area_sqkm</attribute>
+        <attribute>FIRST_FIPS</attribute>
+        <attribute>ISO</attribute>
+        <attribute>Region_Cod</attribute>
+        <attribute>VALIDTO_1</attribute>
+        <attribute>DataRank</attribute>
+        <attribute>Abbrev</attribute>
+        <attribute>ADM0_A3</attribute>
+        <attribute>Region_C_2</attribute>
+        <attribute>NL_NAME_1</attribute>
+        <attribute>LabelRank</attribute>
+        <attribute>ENGTYPE_1</attribute>
+        <attribute>REMARKS_1</attribute>
+        <attribute>Region_C_3</attribute>
+        <attribute>NEV_Countr</attribute>
+        <attribute>Postal</attribute>
+        <attribute>RegionVar</attribute>
+        <attribute>VALIDFR_1</attribute>
+        <attribute>ProvNumber</attribute>
+        <attribute>ScaleRank</attribute>
+      </excludeAttributesWFS>
+      <defaults>
+        <default field="OBJECTID" expression="" applyOnUpdate="0"/>
+        <default field="VertexCou" expression="" applyOnUpdate="0"/>
+        <default field="ISO" expression="" applyOnUpdate="0"/>
+        <default field="NAME_0" expression="" applyOnUpdate="0"/>
+        <default field="NAME_1" expression="" applyOnUpdate="0"/>
+        <default field="VARNAME_1" expression="" applyOnUpdate="0"/>
+        <default field="NL_NAME_1" expression="" applyOnUpdate="0"/>
+        <default field="HASC_1" expression="" applyOnUpdate="0"/>
+        <default field="TYPE_1" expression="" applyOnUpdate="0"/>
+        <default field="ENGTYPE_1" expression="" applyOnUpdate="0"/>
+        <default field="VALIDFR_1" expression="" applyOnUpdate="0"/>
+        <default field="VALIDTO_1" expression="" applyOnUpdate="0"/>
+        <default field="REMARKS_1" expression="" applyOnUpdate="0"/>
+        <default field="Region" expression="" applyOnUpdate="0"/>
+        <default field="RegionVar" expression="" applyOnUpdate="0"/>
+        <default field="ProvNumber" expression="" applyOnUpdate="0"/>
+        <default field="NEV_Countr" expression="" applyOnUpdate="0"/>
+        <default field="FIRST_FIPS" expression="" applyOnUpdate="0"/>
+        <default field="FIRST_HASC" expression="" applyOnUpdate="0"/>
+        <default field="FIPS_1" expression="" applyOnUpdate="0"/>
+        <default field="gadm_level" expression="" applyOnUpdate="0"/>
+        <default field="CheckMe" expression="" applyOnUpdate="0"/>
+        <default field="Region_Cod" expression="" applyOnUpdate="0"/>
+        <default field="Region_C_1" expression="" applyOnUpdate="0"/>
+        <default field="ScaleRank" expression="" applyOnUpdate="0"/>
+        <default field="Region_C_2" expression="" applyOnUpdate="0"/>
+        <default field="Region_C_3" expression="" applyOnUpdate="0"/>
+        <default field="Country_Pr" expression="" applyOnUpdate="0"/>
+        <default field="DataRank" expression="" applyOnUpdate="0"/>
+        <default field="Abbrev" expression="" applyOnUpdate="0"/>
+        <default field="Postal" expression="" applyOnUpdate="0"/>
+        <default field="Area_sqkm" expression="" applyOnUpdate="0"/>
+        <default field="sameAsCity" expression="" applyOnUpdate="0"/>
+        <default field="ADM0_A3" expression="" applyOnUpdate="0"/>
+        <default field="MAP_COLOR" expression="" applyOnUpdate="0"/>
+        <default field="LabelRank" expression="" applyOnUpdate="0"/>
+        <default field="Shape_Leng" expression="" applyOnUpdate="0"/>
+        <default field="Shape_Area" expression="" applyOnUpdate="0"/>
+      </defaults>
+      <constraints>
+        <constraint field="OBJECTID" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="VertexCou" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="ISO" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="NAME_0" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="NAME_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="VARNAME_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="NL_NAME_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="HASC_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="TYPE_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="ENGTYPE_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="VALIDFR_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="VALIDTO_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="REMARKS_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Region" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="RegionVar" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="ProvNumber" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="NEV_Countr" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="FIRST_FIPS" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="FIRST_HASC" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="FIPS_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="gadm_level" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="CheckMe" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Region_Cod" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Region_C_1" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="ScaleRank" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Region_C_2" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Region_C_3" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Country_Pr" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="DataRank" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Abbrev" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Postal" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Area_sqkm" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="sameAsCity" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="ADM0_A3" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="MAP_COLOR" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="LabelRank" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Shape_Leng" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+        <constraint field="Shape_Area" exp_strength="0" unique_strength="0" constraints="0" notnull_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint field="OBJECTID" exp="" desc=""/>
+        <constraint field="VertexCou" exp="" desc=""/>
+        <constraint field="ISO" exp="" desc=""/>
+        <constraint field="NAME_0" exp="" desc=""/>
+        <constraint field="NAME_1" exp="" desc=""/>
+        <constraint field="VARNAME_1" exp="" desc=""/>
+        <constraint field="NL_NAME_1" exp="" desc=""/>
+        <constraint field="HASC_1" exp="" desc=""/>
+        <constraint field="TYPE_1" exp="" desc=""/>
+        <constraint field="ENGTYPE_1" exp="" desc=""/>
+        <constraint field="VALIDFR_1" exp="" desc=""/>
+        <constraint field="VALIDTO_1" exp="" desc=""/>
+        <constraint field="REMARKS_1" exp="" desc=""/>
+        <constraint field="Region" exp="" desc=""/>
+        <constraint field="RegionVar" exp="" desc=""/>
+        <constraint field="ProvNumber" exp="" desc=""/>
+        <constraint field="NEV_Countr" exp="" desc=""/>
+        <constraint field="FIRST_FIPS" exp="" desc=""/>
+        <constraint field="FIRST_HASC" exp="" desc=""/>
+        <constraint field="FIPS_1" exp="" desc=""/>
+        <constraint field="gadm_level" exp="" desc=""/>
+        <constraint field="CheckMe" exp="" desc=""/>
+        <constraint field="Region_Cod" exp="" desc=""/>
+        <constraint field="Region_C_1" exp="" desc=""/>
+        <constraint field="ScaleRank" exp="" desc=""/>
+        <constraint field="Region_C_2" exp="" desc=""/>
+        <constraint field="Region_C_3" exp="" desc=""/>
+        <constraint field="Country_Pr" exp="" desc=""/>
+        <constraint field="DataRank" exp="" desc=""/>
+        <constraint field="Abbrev" exp="" desc=""/>
+        <constraint field="Postal" exp="" desc=""/>
+        <constraint field="Area_sqkm" exp="" desc=""/>
+        <constraint field="sameAsCity" exp="" desc=""/>
+        <constraint field="ADM0_A3" exp="" desc=""/>
+        <constraint field="MAP_COLOR" exp="" desc=""/>
+        <constraint field="LabelRank" exp="" desc=""/>
+        <constraint field="Shape_Leng" exp="" desc=""/>
+        <constraint field="Shape_Area" exp="" desc=""/>
+      </constraintExpressions>
+      <expressionfields/>
+      <attributeactions>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+      </attributeactions>
+      <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+        <columns>
+          <column type="field" name="OBJECTID" width="-1" hidden="0"/>
+          <column type="field" name="VertexCou" width="-1" hidden="0"/>
+          <column type="field" name="ISO" width="-1" hidden="0"/>
+          <column type="field" name="NAME_0" width="-1" hidden="0"/>
+          <column type="field" name="NAME_1" width="-1" hidden="0"/>
+          <column type="field" name="VARNAME_1" width="-1" hidden="0"/>
+          <column type="field" name="NL_NAME_1" width="-1" hidden="0"/>
+          <column type="field" name="HASC_1" width="-1" hidden="0"/>
+          <column type="field" name="TYPE_1" width="-1" hidden="0"/>
+          <column type="field" name="ENGTYPE_1" width="-1" hidden="0"/>
+          <column type="field" name="VALIDFR_1" width="-1" hidden="0"/>
+          <column type="field" name="VALIDTO_1" width="-1" hidden="0"/>
+          <column type="field" name="REMARKS_1" width="-1" hidden="0"/>
+          <column type="field" name="Region" width="-1" hidden="0"/>
+          <column type="field" name="RegionVar" width="-1" hidden="0"/>
+          <column type="field" name="ProvNumber" width="-1" hidden="0"/>
+          <column type="field" name="NEV_Countr" width="-1" hidden="0"/>
+          <column type="field" name="FIRST_FIPS" width="-1" hidden="0"/>
+          <column type="field" name="FIRST_HASC" width="-1" hidden="0"/>
+          <column type="field" name="FIPS_1" width="-1" hidden="0"/>
+          <column type="field" name="gadm_level" width="-1" hidden="0"/>
+          <column type="field" name="CheckMe" width="-1" hidden="0"/>
+          <column type="field" name="Region_Cod" width="-1" hidden="0"/>
+          <column type="field" name="Region_C_1" width="-1" hidden="0"/>
+          <column type="field" name="ScaleRank" width="-1" hidden="0"/>
+          <column type="field" name="Region_C_2" width="-1" hidden="0"/>
+          <column type="field" name="Region_C_3" width="-1" hidden="0"/>
+          <column type="field" name="Country_Pr" width="-1" hidden="0"/>
+          <column type="field" name="DataRank" width="-1" hidden="0"/>
+          <column type="field" name="Abbrev" width="-1" hidden="0"/>
+          <column type="field" name="Postal" width="-1" hidden="0"/>
+          <column type="field" name="Area_sqkm" width="-1" hidden="0"/>
+          <column type="field" name="sameAsCity" width="-1" hidden="0"/>
+          <column type="field" name="ADM0_A3" width="-1" hidden="0"/>
+          <column type="field" name="MAP_COLOR" width="-1" hidden="0"/>
+          <column type="field" name="LabelRank" width="-1" hidden="0"/>
+          <column type="field" name="Shape_Leng" width="-1" hidden="0"/>
+          <column type="field" name="Shape_Area" width="-1" hidden="0"/>
+          <column type="actions" width="-1" hidden="1"/>
+        </columns>
+      </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <storedexpressions/>
+      <editform tolerant="1"></editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+Les formulaires QGIS peuvent avoir une fonction Python qui sera appelée à l'ouverture du formulaire.
+
+Utilisez cette fonction pour ajouter plus de fonctionnalités à vos formulaires.
+
+Entrez le nom de la fonction dans le champ "Fonction d'initialisation Python".
+Voici un exemple à suivre:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+
+]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable>
+        <field name="ADM0_A3" editable="1"/>
+        <field name="Abbrev" editable="1"/>
+        <field name="Area_sqkm" editable="1"/>
+        <field name="CheckMe" editable="1"/>
+        <field name="Country_Pr" editable="1"/>
+        <field name="DataRank" editable="1"/>
+        <field name="ENGTYPE_1" editable="1"/>
+        <field name="FIPS_1" editable="1"/>
+        <field name="FIRST_FIPS" editable="1"/>
+        <field name="FIRST_HASC" editable="1"/>
+        <field name="HASC_1" editable="1"/>
+        <field name="ISO" editable="1"/>
+        <field name="LabelRank" editable="1"/>
+        <field name="MAP_COLOR" editable="1"/>
+        <field name="NAME_0" editable="1"/>
+        <field name="NAME_1" editable="1"/>
+        <field name="NEV_Countr" editable="1"/>
+        <field name="NL_NAME_1" editable="1"/>
+        <field name="OBJECTID" editable="1"/>
+        <field name="Postal" editable="1"/>
+        <field name="ProvNumber" editable="1"/>
+        <field name="REMARKS_1" editable="1"/>
+        <field name="Region" editable="1"/>
+        <field name="RegionVar" editable="1"/>
+        <field name="Region_C_1" editable="1"/>
+        <field name="Region_C_2" editable="1"/>
+        <field name="Region_C_3" editable="1"/>
+        <field name="Region_Cod" editable="1"/>
+        <field name="ScaleRank" editable="1"/>
+        <field name="Shape_Area" editable="1"/>
+        <field name="Shape_Leng" editable="1"/>
+        <field name="TYPE_1" editable="1"/>
+        <field name="VALIDFR_1" editable="1"/>
+        <field name="VALIDTO_1" editable="1"/>
+        <field name="VARNAME_1" editable="1"/>
+        <field name="VertexCou" editable="1"/>
+        <field name="gadm_level" editable="1"/>
+        <field name="sameAsCity" editable="1"/>
+      </editable>
+      <labelOnTop>
+        <field labelOnTop="0" name="ADM0_A3"/>
+        <field labelOnTop="0" name="Abbrev"/>
+        <field labelOnTop="0" name="Area_sqkm"/>
+        <field labelOnTop="0" name="CheckMe"/>
+        <field labelOnTop="0" name="Country_Pr"/>
+        <field labelOnTop="0" name="DataRank"/>
+        <field labelOnTop="0" name="ENGTYPE_1"/>
+        <field labelOnTop="0" name="FIPS_1"/>
+        <field labelOnTop="0" name="FIRST_FIPS"/>
+        <field labelOnTop="0" name="FIRST_HASC"/>
+        <field labelOnTop="0" name="HASC_1"/>
+        <field labelOnTop="0" name="ISO"/>
+        <field labelOnTop="0" name="LabelRank"/>
+        <field labelOnTop="0" name="MAP_COLOR"/>
+        <field labelOnTop="0" name="NAME_0"/>
+        <field labelOnTop="0" name="NAME_1"/>
+        <field labelOnTop="0" name="NEV_Countr"/>
+        <field labelOnTop="0" name="NL_NAME_1"/>
+        <field labelOnTop="0" name="OBJECTID"/>
+        <field labelOnTop="0" name="Postal"/>
+        <field labelOnTop="0" name="ProvNumber"/>
+        <field labelOnTop="0" name="REMARKS_1"/>
+        <field labelOnTop="0" name="Region"/>
+        <field labelOnTop="0" name="RegionVar"/>
+        <field labelOnTop="0" name="Region_C_1"/>
+        <field labelOnTop="0" name="Region_C_2"/>
+        <field labelOnTop="0" name="Region_C_3"/>
+        <field labelOnTop="0" name="Region_Cod"/>
+        <field labelOnTop="0" name="ScaleRank"/>
+        <field labelOnTop="0" name="Shape_Area"/>
+        <field labelOnTop="0" name="Shape_Leng"/>
+        <field labelOnTop="0" name="TYPE_1"/>
+        <field labelOnTop="0" name="VALIDFR_1"/>
+        <field labelOnTop="0" name="VALIDTO_1"/>
+        <field labelOnTop="0" name="VARNAME_1"/>
+        <field labelOnTop="0" name="VertexCou"/>
+        <field labelOnTop="0" name="gadm_level"/>
+        <field labelOnTop="0" name="sameAsCity"/>
+      </labelOnTop>
+      <widgets/>
+      <previewExpression>"NAME_0"</previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+  </projectlayers>
+  <layerorder>
+    <layer id="france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3"/>
+    <layer id="default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1"/>
+  </layerorder>
+  <properties>
+    <DefaultStyles>
+      <ColorRamp type="QString"></ColorRamp>
+      <Fill type="QString"></Fill>
+      <Line type="QString"></Line>
+      <Marker type="QString"></Marker>
+      <Opacity type="double">1</Opacity>
+      <RandomColors type="bool">true</RandomColors>
+    </DefaultStyles>
+    <Gui>
+      <CanvasColorBluePart type="int">127</CanvasColorBluePart>
+      <CanvasColorGreenPart type="int">127</CanvasColorGreenPart>
+      <CanvasColorRedPart type="int">127</CanvasColorRedPart>
+      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
+      <SelectionColorBluePart type="int">0</SelectionColorBluePart>
+      <SelectionColorGreenPart type="int">255</SelectionColorGreenPart>
+      <SelectionColorRedPart type="int">255</SelectionColorRedPart>
+    </Gui>
+    <Legend>
+      <filterByMap type="bool">false</filterByMap>
+    </Legend>
+    <Macros>
+      <pythonCode type="QString"></pythonCode>
+    </Macros>
+    <Measure>
+      <Ellipsoid type="QString">EPSG:7030</Ellipsoid>
+    </Measure>
+    <Measurement>
+      <AreaUnits type="QString">m2</AreaUnits>
+      <DistanceUnits type="QString">meters</DistanceUnits>
+    </Measurement>
+    <PAL>
+      <CandidatesLine type="int">50</CandidatesLine>
+      <CandidatesPoint type="int">16</CandidatesPoint>
+      <CandidatesPolygon type="int">30</CandidatesPolygon>
+      <DrawRectOnly type="bool">false</DrawRectOnly>
+      <DrawUnplaced type="bool">false</DrawUnplaced>
+      <SearchMethod type="int">0</SearchMethod>
+      <ShowingAllLabels type="bool">false</ShowingAllLabels>
+      <ShowingCandidates type="bool">false</ShowingCandidates>
+      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
+      <TextFormat type="int">0</TextFormat>
+      <UnplacedColor type="QString">255,0,0,255</UnplacedColor>
+    </PAL>
+    <Paths>
+      <Absolute type="bool">false</Absolute>
+    </Paths>
+    <PositionPrecision>
+      <Automatic type="bool">true</Automatic>
+      <DecimalPlaces type="int">2</DecimalPlaces>
+      <DegreeFormat type="QString">MU</DegreeFormat>
+    </PositionPrecision>
+    <SpatialRefSys>
+      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
+    </SpatialRefSys>
+    <WCSLayers type="QStringList"/>
+    <WCSUrl type="QString"></WCSUrl>
+    <WFSLayers type="QStringList"/>
+    <WFSTLayers>
+      <Delete type="QStringList"/>
+      <Insert type="QStringList"/>
+      <Update type="QStringList"/>
+    </WFSTLayers>
+    <WFSUrl type="QString"></WFSUrl>
+    <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
+    <WMSAddWktGeometry type="bool">false</WMSAddWktGeometry>
+    <WMSContactMail type="QString"></WMSContactMail>
+    <WMSContactOrganization type="QString"></WMSContactOrganization>
+    <WMSContactPerson type="QString"></WMSContactPerson>
+    <WMSContactPhone type="QString"></WMSContactPhone>
+    <WMSContactPosition type="QString"></WMSContactPosition>
+    <WMSDefaultMapUnitsPerMm type="double">1</WMSDefaultMapUnitsPerMm>
+    <WMSExtent type="QStringList">
+      <value>-5.338890814362023</value>
+      <value>43.89054763449153</value>
+      <value>3.3241928035576143</value>
+      <value>52.11511745847823</value>
+    </WMSExtent>
+    <WMSFees type="QString">conditions unknown</WMSFees>
+    <WMSImageQuality type="int">90</WMSImageQuality>
+    <WMSKeywordList type="QStringList">
+      <value></value>
+    </WMSKeywordList>
+    <WMSMaxAtlasFeatures type="int">1</WMSMaxAtlasFeatures>
+    <WMSOnlineResource type="QString"></WMSOnlineResource>
+    <WMSPrecision type="QString">8</WMSPrecision>
+    <WMSRootName type="QString"></WMSRootName>
+    <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
+    <WMSServiceAbstract type="QString"></WMSServiceAbstract>
+    <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
+    <WMSServiceTitle type="QString">get_feature_info</WMSServiceTitle>
+    <WMSTileBuffer type="int">0</WMSTileBuffer>
+    <WMSUrl type="QString"></WMSUrl>
+    <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
+    <WMTSGrids>
+      <CRS type="QStringList"/>
+      <Config type="QStringList"/>
+    </WMTSGrids>
+    <WMTSJpegLayers>
+      <Group type="QStringList"/>
+      <Layer type="QStringList"/>
+      <Project type="bool">false</Project>
+    </WMTSJpegLayers>
+    <WMTSLayers>
+      <Group type="QStringList"/>
+      <Layer type="QStringList"/>
+      <Project type="bool">false</Project>
+    </WMTSLayers>
+    <WMTSMinScale type="int">5000</WMTSMinScale>
+    <WMTSPngLayers>
+      <Group type="QStringList"/>
+      <Layer type="QStringList"/>
+      <Project type="bool">false</Project>
+    </WMTSPngLayers>
+    <WMTSUrl type="QString"></WMTSUrl>
+  </properties>
+  <visibility-presets/>
+  <transformContext/>
+  <projectMetadata>
+    <identifier></identifier>
+    <parentidentifier></parentidentifier>
+    <language></language>
+    <type></type>
+    <title></title>
+    <abstract></abstract>
+    <contact>
+      <name></name>
+      <organization></organization>
+      <position></position>
+      <voice></voice>
+      <fax></fax>
+      <email></email>
+      <role></role>
+    </contact>
+    <links/>
+    <author>Etienne Trimaille</author>
+    <creation>2021-06-01T09:36:05</creation>
+  </projectMetadata>
+  <Annotations/>
+  <Layouts/>
+  <Bookmarks/>
+  <ProjectViewSettings UseProjectScales="0">
+    <Scales/>
+  </ProjectViewSettings>
+</qgis>

--- a/test/server/data/get_feature_info.qgs.cfg
+++ b/test/server/data/get_feature_info.qgs.cfg
@@ -1,8 +1,8 @@
 {
     "metadata": {
         "qgis_desktop_version": 31014,
-        "lizmap_plugin_version": "master",
-        "lizmap_web_client_target_version": 30400
+        "lizmap_plugin_version": "dev",
+        "lizmap_web_client_target_version": 30500
     },
     "options": {
         "projection": {
@@ -63,6 +63,41 @@
             "popup": "True",
             "popupFrame": null,
             "popupSource": "auto",
+            "popupTemplate": "",
+            "popupMaxFeatures": 10,
+            "popupDisplayChildren": "False",
+            "noLegendImage": "False",
+            "groupAsLayer": "False",
+            "baseLayer": "False",
+            "displayInLegend": "True",
+            "group_visibility": [],
+            "singleTile": "True",
+            "imageFormat": "image/png",
+            "cached": "False",
+            "serverFrame": null,
+            "clientCacheExpiration": 300
+        },
+        "qgis_form": {
+            "id": "qgis_popup_a6f4c4e3_79bc_4443_aab6_7e44ef9fe24b",
+            "name": "qgis_form",
+            "type": "layer",
+            "geometryType": "polygon",
+            "extent": [
+                -5.1326269186972695,
+                46.279190985775415,
+                3.1179289078928605,
+                49.72647410719435
+            ],
+            "crs": "EPSG:4326",
+            "title": "qgis_form",
+            "abstract": "",
+            "link": "",
+            "minScale": 1,
+            "maxScale": 1000000000000,
+            "toggled": "False",
+            "popup": "True",
+            "popupFrame": null,
+            "popupSource": "form",
             "popupTemplate": "",
             "popupMaxFeatures": 10,
             "popupDisplayChildren": "False",

--- a/test/server/data/get_feature_info.qgs.cfg
+++ b/test/server/data/get_feature_info.qgs.cfg
@@ -1,0 +1,127 @@
+{
+    "metadata": {
+        "qgis_desktop_version": 31014,
+        "lizmap_plugin_version": "master",
+        "lizmap_web_client_target_version": 30400
+    },
+    "options": {
+        "projection": {
+            "proj4": "+proj=longlat +datum=WGS84 +no_defs",
+            "ref": "EPSG:4326"
+        },
+        "bbox": [
+            "-5.338890814362023",
+            "43.89054763449153",
+            "3.3241928035576143",
+            "52.11511745847823"
+        ],
+        "mapScales": [
+            10000,
+            25000,
+            50000,
+            100000,
+            250000,
+            500000
+        ],
+        "minScale": 1,
+        "maxScale": 1000000000,
+        "initialExtent": [
+            -5.338890814362023,
+            43.89054763449153,
+            3.3241928035576143,
+            52.11511745847823
+        ],
+        "popupLocation": "dock",
+        "pointTolerance": 25,
+        "lineTolerance": 10,
+        "polygonTolerance": 5,
+        "tmTimeFrameSize": 10,
+        "tmTimeFrameType": "seconds",
+        "tmAnimationFrameLength": 1000,
+        "datavizLocation": "dock",
+        "theme": "light"
+    },
+    "layers": {
+        "default_popup": {
+            "id": "france_parts_cd5cb238_5e2e_4cff_bd5d_ebf1172e00f3",
+            "name": "default_popup",
+            "type": "layer",
+            "geometryType": "polygon",
+            "extent": [
+                -5.1326269186972695,
+                46.279190985775415,
+                3.1179289078928605,
+                49.72647410719435
+            ],
+            "crs": "EPSG:4326",
+            "title": "default_popup",
+            "abstract": "",
+            "link": "",
+            "minScale": 1,
+            "maxScale": 1000000000000,
+            "toggled": "False",
+            "popup": "True",
+            "popupFrame": null,
+            "popupSource": "auto",
+            "popupTemplate": "",
+            "popupMaxFeatures": 10,
+            "popupDisplayChildren": "False",
+            "noLegendImage": "False",
+            "groupAsLayer": "False",
+            "baseLayer": "False",
+            "displayInLegend": "True",
+            "group_visibility": [],
+            "singleTile": "True",
+            "imageFormat": "image/png",
+            "cached": "False",
+            "serverFrame": null,
+            "clientCacheExpiration": 300
+        },
+        "qgis_popup": {
+            "id": "default_popup_cfe76c13_c331_4fd8_b8d0_c33af351c9f1",
+            "name": "qgis_popup",
+            "type": "layer",
+            "geometryType": "polygon",
+            "extent": [
+                -5.1326269186972695,
+                46.279190985775415,
+                3.1179289078928605,
+                49.72647410719435
+            ],
+            "crs": "EPSG:4326",
+            "title": "qgis_popup",
+            "abstract": "",
+            "link": "",
+            "minScale": 1,
+            "maxScale": 1000000000000,
+            "toggled": "False",
+            "popup": "True",
+            "popupFrame": null,
+            "popupSource": "qgis",
+            "popupTemplate": "",
+            "popupMaxFeatures": 10,
+            "popupDisplayChildren": "False",
+            "noLegendImage": "False",
+            "groupAsLayer": "False",
+            "baseLayer": "False",
+            "displayInLegend": "True",
+            "group_visibility": [],
+            "singleTile": "True",
+            "imageFormat": "image/png",
+            "cached": "False",
+            "serverFrame": null,
+            "clientCacheExpiration": 300
+        }
+    },
+    "atlas": {
+        "layers": []
+    },
+    "locateByLayer": {},
+    "attributeLayers": {},
+    "tooltipLayers": {},
+    "editionLayers": {},
+    "loginFilteredLayers": {},
+    "timemanagerLayers": {},
+    "datavizLayers": {},
+    "formFilterLayers": {}
+}

--- a/test/server/requirements.txt
+++ b/test/server/requirements.txt
@@ -1,3 +1,3 @@
 pytest
 lxml
-
+xmldiff

--- a/test/server/run-tests.sh
+++ b/test/server/run-tests.sh
@@ -15,5 +15,5 @@ export QT_LOGGING_RULES="*.debug=false;*.warning=false"
 export QGIS_DISABLE_MESSAGE_HOOKS=1
 export QGIS_NO_OVERRIDE_IMPORT=1
 
-pytest -v --qgis-plugins=/src $@
+pytest -vv --qgis-plugins=/src $@
 exit $?

--- a/test/server/test_get_feature_info.py
+++ b/test/server/test_get_feature_info.py
@@ -1,0 +1,122 @@
+import logging
+
+LOGGER = logging.getLogger('server')
+
+__copyright__ = 'Copyright 2021, 3Liz'
+__license__ = 'GPL version 3'
+__email__ = 'info@3liz.org'
+
+PROJECT = "get_feature_info.qgs"
+BBOX = "48.331869%2C-2.847776%2C48.971191%2C-0.659558"
+BASE_QUERY = (
+    f"?MAP={PROJECT}&"
+    f"STYLES=d%C3%A9faut&"
+    f"SERVICE=WMS&"
+    f"VERSION=1.3.0"
+    f"&REQUEST=GetFeatureInfo&"
+    f"EXCEPTIONS=application%2Fvnd.ogc.se_inimage&"
+    f"BBOX={BBOX}&"
+    f"FI_POINT_TOLERANCE=25&"
+    f"FI_LINE_TOLERANCE=10&"
+    f"FI_POLYGON_TOLERANCE=5&"
+    f"FEATURE_COUNT=10&"
+    f"HEIGHT=537&"
+    f"WIDTH=1838&"
+    f"FORMAT=image%2Fpng&"
+    f"CRS=EPSG%3A4326&"
+    f"INFO_FORMAT=text%2Fhtml&"
+)
+
+# Points
+NO_FEATURE = "I=817&J=87&"
+SINGLE_FEATURE = "I=1435&J=398&"
+
+# Layers
+LAYER_DEFAULT_POPUP = "default_popup"
+DEFAULT_POPUP = f"LAYERS={LAYER_DEFAULT_POPUP}&QUERY_LAYERS={LAYER_DEFAULT_POPUP}&"
+
+LAYER_QGIS_POPUP = "qgis_popup"
+QGIS_POPUP = f"LAYERS={LAYER_QGIS_POPUP}&QUERY_LAYERS={LAYER_QGIS_POPUP}&"
+
+
+def test_no_get_feature_info_default_popup(client):
+    """ Test the get feature info without a feature with default layer. """
+    qs = BASE_QUERY + NO_FEATURE + DEFAULT_POPUP
+    rv = client.get(qs, PROJECT)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type', '').find('text/html') == 0
+    expected = f'''<HEAD>
+<TITLE> GetFeatureInfo results </TITLE>
+<META http-equiv="Content-Type" content="text/html;charset=utf-8"/>
+</HEAD>
+<BODY>
+<TABLE border=1 width=100%>
+<TR><TH width=25%>Layer</TH><TD>{LAYER_DEFAULT_POPUP}</TD></TR>
+</BR></TABLE>
+<BR></BR>
+</BODY>
+'''
+    assert rv.content.decode('utf-8') == expected
+
+
+def test_single_get_feature_info_default_popup(client):
+    """ Test the get feature info with a single feature with default layer. """
+    qs = BASE_QUERY + SINGLE_FEATURE + DEFAULT_POPUP
+    rv = client.get(qs, PROJECT)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type', '').find('text/html') == 0
+    expected = f'''<HEAD>
+<TITLE> GetFeatureInfo results </TITLE>
+<META http-equiv="Content-Type" content="text/html;charset=utf-8"/>
+</HEAD>
+<BODY>
+<TABLE border=1 width=100%>
+<TR><TH width=25%>Layer</TH><TD>{LAYER_DEFAULT_POPUP}</TD></TR>
+</BR><TABLE border=1 width=100%>
+<TR><TH>Feature</TH><TD>1</TD></TR>
+<TR><TH>OBJECTID</TH><TD>2662</TD></TR>
+<TR><TH>NAME_0</TH><TD>France</TD></TR>
+<TR><TH>VARNAME_1</TH><TD>Bretaa|Brittany</TD></TR>
+<TR><TH>Region</TH><TD>Bretagne</TD></TR>
+<TR><TH>Shape_Leng</TH><TD>18.39336934850</TD></TR>
+<TR><TH>Shape_Area</TH><TD>3.30646936365</TD></TR>
+</TABLE>
+</BR>
+</TABLE>
+<BR></BR>
+</BODY>
+'''
+    assert rv.content.decode('utf-8') == expected
+
+
+def test_single_get_feature_info_qgis_popup(client):
+    """ Test the get feature info with a single feature with QGIS maptip. """
+    qs = BASE_QUERY + SINGLE_FEATURE + QGIS_POPUP + "WITH_MAPTIP=true&"
+    rv = client.get(qs, PROJECT)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type', '').find('text/html') == 0
+
+    # Note the line <TH>maptip</TH>
+    expected = f'''<HEAD>
+<TITLE> GetFeatureInfo results </TITLE>
+<META http-equiv="Content-Type" content="text/html;charset=utf-8"/>
+</HEAD>
+<BODY>
+<TABLE border=1 width=100%>
+<TR><TH width=25%>Layer</TH><TD>{LAYER_QGIS_POPUP}</TD></TR>
+</BR><TABLE border=1 width=100%>
+<TR><TH>Feature</TH><TD>1</TD></TR>
+<TR><TH>OBJECTID</TH><TD>2662</TD></TR>
+<TR><TH>NAME_0</TH><TD>France</TD></TR>
+<TR><TH>VARNAME_1</TH><TD>Bretaa|Brittany</TD></TR>
+<TR><TH>Region</TH><TD>Bretagne</TD></TR>
+<TR><TH>Shape_Leng</TH><TD>18.39336934850</TD></TR>
+<TR><TH>Shape_Area</TH><TD>3.30646936365</TD></TR>
+<TR><TH>maptip</TH><TD><p>France</p></TD></TR>
+</TABLE>
+</BR>
+</TABLE>
+<BR></BR>
+</BODY>
+'''
+    assert rv.content.decode('utf-8') == expected


### PR DESCRIPTION
<!---
PUT "dev" branch for any new features or next Lizmap version
PUT "master" for bug fix
-->

* **Funded by**: French Province Pyrénées-Atlantiques https://www.le64.fr/
* **Description**: 
  * Get the GetFeatureInfo from QGIS Server with the QGIS Form

@rldhont Should we use our own service/api ?
Or do you want to plug on the GetFeatureInfo request ?

I started on the GetFeatureInfo request as we can see on this draft.
But what would the best workflow ? 
1. Get the result from QGIS Server
2. Parse the result (HTML, GML etc) to have vector layer name and fature ID
3. Make again the QGIS project (to have relations). It seems in a QgsFilter, I couldn't have the Project used.
4. Call the class `Maptip` from Lizmap plugin with QgsVectorLayer and QgsProject

This doesn't seem efficient at all and very fragile so I would like to have your inputs.

At least, by writing the test file provided, I learned that the maptip is **inserted** in the HTML output, not replaced. So then I then I thought I would follow the same pattern.
