### PR TITLE
Tooltip: use base_file_name for external resource

### DIFF
--- a/lizmap/tooltip.py
+++ b/lizmap/tooltip.py
@@ -4,6 +4,7 @@ import logging
 import re
 
 from qgis.core import (
+    Qgis,
     QgsAttributeEditorContainer,
     QgsAttributeEditorElement,
     QgsAttributeEditorField,
@@ -281,7 +282,17 @@ class Tooltip:
                     )'''.format(name, fname)
 
         elif dview == QgsExternalResourceWidget.NoContent:
-            field_view = '''
+            if Qgis.QGIS_VERSION_INT >= 30800:
+                field_view = '''
+                    concat(
+                        '<a href="',
+                        "{0}",
+                        '" target="_blank">',
+                        base_file_name({0}),
+                        '</a>'
+                    )'''.format(name)
+            else:
+                field_view = '''
                     concat(
                         '<a href="',
                         "{}",


### PR DESCRIPTION
Instead of displaying the field name in the link for external resource not as web or image, use base_file_name to display the file name in the link of tooltip.
