### PR TITLE
UX - Remove the check for relative path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Open the Lizmap URL instance from a right click in the "Information" panel
 * Allow to open the documentation in Japanese
 * Update the "Information" panel about links
+* Removing the check if all layers are in a subfolder of the project. Users on their own server might have data where they want
 * Refactor some code on the server side
 
 ## 3.5.7 - 2021-08-31


### PR DESCRIPTION
<!---
PUT "dev" branch for any new features or next Lizmap version
PUT "master" for bug fix
-->

* **Funded by**: 3Liz
* **Description**: Remove the check for relative path
  * Fix #346 

I think we agreed to totally remove the check for paths.
Users might have data in `/mnt/data` and their project in `/home/etienne/dev/lizmap/test`
`QGIS_SERVER_IGNORE_BAD_LAYERS` or LayerBoard plugin should warn them about these paths.