### PR TITLE
[Server] Set project custom variables to get User login and groups

### DIFF
--- a/lizmap/server/lizmap_filter.py
+++ b/lizmap/server/lizmap_filter.py
@@ -2,11 +2,6 @@ __copyright__ = 'Copyright 2021, 3Liz'
 __license__ = 'GPL version 3'
 __email__ = 'info@3liz.org'
 
-import json
-import os
-
-from typing import List
-
 from qgis.core import QgsProject
 from qgis.server import QgsServerFilter, QgsServerInterface
 
@@ -78,8 +73,8 @@ class LizmapFilter(QgsServerFilter):
             # If one Lizmap user group provided in request headers is
             # defined in project acl option, the request can be evaluated
             # by QGIS Server
-            for g in groups:
-                if g in cfg_acl:
+            for group in groups:
+                if group in cfg_acl:
                     return
 
             # The lizmap user groups provided in request header are not

--- a/lizmap/server/lizmap_filter.py
+++ b/lizmap/server/lizmap_filter.py
@@ -33,7 +33,7 @@ class LizmapFilter(QgsServerFilter):
 
             # Set lizmap variables for expression
             project = QgsProject.instance()
-            project.setCustomVariable({
+            project.setCustomVariables({
                 'lizmap_user': user_login,
                 'lizmap_user_groups': groups,
             })
@@ -95,4 +95,4 @@ class LizmapFilter(QgsServerFilter):
         custom_var = project.customVariables()
         custom_var.pop('lizmap_user', None)
         custom_var.pop('lizmap_user_groups', None)
-        project.setCustomVariable(custom_var)
+        project.setCustomVariables(custom_var)


### PR DESCRIPTION
On request ready lizmap plugin set 2 variables with values provided in request:
* lizmap_user
* lizmap_user_groups

These varaibles could be used in Expression service for default values, in WMS GetPrint request or other request that can have  QGIS expressions.