### PR TITLE
[Server] Set project custom variables to get User login and groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 * Follow up from version 3.6.0 about not supporting spatialite for editing capabilties, the plugin will now remove these lines from the CFG file
+* Variables `@lizmap_user` and `@lizmap_user_groups` are available at the project level with current Lizmap user and his groups.
+  It's possible to use them in QGIS Desktop.
 
 ## 3.6.2 - 2021-09-23
 

--- a/lizmap/server/expression_service.py
+++ b/lizmap/server/expression_service.py
@@ -20,10 +20,17 @@ from qgis.core import (
     QgsProject,
 )
 from qgis.PyQt.QtCore import QTextCodec
-from qgis.server import QgsServerRequest, QgsServerResponse, QgsService
+from qgis.server import (
+    QgsRequestHandler,
+    QgsServerRequest,
+    QgsServerResponse,
+    QgsService,
+)
 
 from lizmap.server.core import (
     find_vector_layer,
+    get_lizmap_groups,
+    get_lizmap_user_login,
     get_server_fid,
     to_bool,
     write_json_response,
@@ -54,6 +61,15 @@ class ExpressionService(QgsService):
                        project: QgsProject) -> None:
         """ Execute a 'EXPRESSION' request
         """
+
+        # Set lizmap variables
+        request_handler = QgsRequestHandler(request, response)
+        groups = get_lizmap_groups(request_handler)
+        user_login = get_lizmap_user_login(request_handler)
+        custom_var = project.customVariables()
+        custom_var['lizmap_user'] = user_login
+        custom_var['lizmap_user_groups'] = list(groups)  # QGIS can't store a tuple
+        project.setCustomVariables(custom_var)
 
         params = request.parameters()
 

--- a/lizmap/server/lizmap_accesscontrol.py
+++ b/lizmap/server/lizmap_accesscontrol.py
@@ -2,7 +2,13 @@ __copyright__ = 'Copyright 2021, 3Liz'
 __license__ = 'GPL version 3'
 __email__ = 'info@3liz.org'
 
-from qgis.core import Qgis, QgsExpression, QgsMapLayer, QgsVectorLayer
+from qgis.core import (
+    Qgis,
+    QgsExpression,
+    QgsMapLayer,
+    QgsProject,
+    QgsVectorLayer,
+)
 from qgis.server import QgsAccessControlFilter, QgsServerInterface
 
 from lizmap.server.core import (
@@ -64,6 +70,15 @@ class LizmapAccessControlFilter(QgsAccessControlFilter):
 
         # Get Lizmap user groups provided by the request
         groups = get_lizmap_groups(self.iface.requestHandler())
+
+        # Set lizmap variables
+        user_login = get_lizmap_user_login(self.iface.requestHandler())
+        project = QgsProject.instance()
+        custom_var = project.customVariables()
+        if custom_var.get('lizmap_user', None) != user_login:
+            custom_var['lizmap_user'] = user_login
+            custom_var['lizmap_user_groups'] = list(groups)  # QGIS can't store a tuple
+            project.setCustomVariables(custom_var)
 
         # If groups is empty, no Lizmap user groups provided by the request
         # The default layer rights is applied

--- a/lizmap/server/lizmap_filter.py
+++ b/lizmap/server/lizmap_filter.py
@@ -2,6 +2,7 @@ __copyright__ = 'Copyright 2021, 3Liz'
 __license__ = 'GPL version 3'
 __email__ = 'info@3liz.org'
 
+from qgis.core import QgsProject
 from qgis.server import QgsServerFilter, QgsServerInterface
 
 from lizmap.server.core import get_lizmap_config, get_lizmap_groups
@@ -75,3 +76,11 @@ class LizmapFilter(QgsServerFilter):
 
         except Exception as e:
             logger.log_exception(e)
+
+    def responseComplete(self):
+        # Remove lizmap variables for expression
+        project = QgsProject.instance()
+        custom_var = project.customVariables()
+        custom_var.pop('lizmap_user', None)
+        custom_var.pop('lizmap_user_groups', None)
+        project.setCustomVariables(custom_var)

--- a/test/server/data/get_feature_info.qgs
+++ b/test/server/data/get_feature_info.qgs
@@ -959,7 +959,10 @@ def my_form_open(dialog, layer, feature):
       <layerDependencies></layerDependencies>
       <dataDependencies></dataDependencies>
       <legend type="default-vector"></legend>
-      <expressionfields></expressionfields>
+      <expressionfields>
+        <field name="lwc_user" precision="0" length="0" expression="CASE WHEN @lizmap_user IS NULL OR @lizmap_user = '' THEN 'No user provided' ELSE @lizmap_user END" subType="0" comment="" typeName="string" type="10"/>
+        <field name="lwc_groups" precision="0" length="0" expression="CASE WHEN @lizmap_user_groups IS NULL OR array_length(@lizmap_user_groups) = 0 THEN 'No user groups provided' ELSE  array_to_string(@lizmap_user_groups, ', ') END" subType="0" comment="" typeName="string" type="10"/>
+      </expressionfields>
       <map-layer-style-manager current="défaut">
         <map-layer-style name="défaut"></map-layer-style>
       </map-layer-style-manager>

--- a/test/server/test_expression_service_evaluate.py
+++ b/test/server/test_expression_service_evaluate.py
@@ -137,6 +137,27 @@ def test_request_without_features(client):
     assert 'b' in b['results'][0]
     assert b['results'][0]['b'] == 2
 
+    # Request with lizmap headers and custom variables
+    qs = "?SERVICE=EXPRESSION&REQUEST=Evaluate&MAP=france_parts.qgs&LAYER=france_parts&EXPRESSIONS={\"a\":\"%s\", \"b\":\"%s\"}" % (
+        quote('@lizmap_user', safe=''), quote('@lizmap_user_groups', safe=''))
+    headers = {'X-Lizmap-User-Groups': 'test1', 'X-Lizmap-User': 'Bretagne'}
+    rv = client.get(qs, projectfile, headers)
+    assert rv.status_code == 200
+
+    assert rv.headers.get('Content-Type', '').find('application/json') == 0
+
+    b = json.loads(rv.content.decode('utf-8'))
+
+    assert 'status' in b
+    assert b['status'] == 'success'
+
+    assert 'results' in b
+    assert len(b['results']) == 1
+    assert 'a' in b['results'][0]
+    assert b['results'][0]['a'] == 'Bretagne'
+    assert 'b' in b['results'][0]
+    assert b['results'][0]['b'] == ['test1']
+
 
 def test_request_with_features(client):
     """  Test Expression Evaluate request with Feature or Features parameter

--- a/test/server/test_get_feature_info.py
+++ b/test/server/test_get_feature_info.py
@@ -74,6 +74,34 @@ def test_single_get_feature_info_default_popup(client):
    <Attribute name="Region" value="Bretagne"/>
    <Attribute name="Shape_Leng" value="18.39336934850"/>
    <Attribute name="Shape_Area" value="3.30646936365"/>
+   <Attribute name="lwc_user" value="No user provided"/>
+   <Attribute name="lwc_groups" value="No user groups provided"/>
+  </Feature>
+ </Layer>
+</GetFeatureInfoResponse>
+'''
+    diff = xml_diff.diff_texts(expected, rv.content.decode('utf-8'))
+    assert diff == [], diff
+
+
+def test_single_get_feature_info_default_popup_user(client):
+    """ Test the get feature info with a single feature with default layer. """
+    qs = BASE_QUERY + SINGLE_FEATURE + DEFAULT_POPUP
+    headers = {'X-Lizmap-User-Groups': 'test1', 'X-Lizmap-User': 'Bretagne'}
+    rv = client.get(qs, PROJECT, headers)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type', '').find('text/xml') == 0
+    expected = f'''<GetFeatureInfoResponse>
+ <Layer name="{LAYER_DEFAULT_POPUP}">
+  <Feature id="1">
+   <Attribute name="OBJECTID" value="2662"/>
+   <Attribute name="NAME_0" value="France"/>
+   <Attribute name="VARNAME_1" value="Bretaa|Brittany"/>
+   <Attribute name="Region" value="Bretagne"/>
+   <Attribute name="Shape_Leng" value="18.39336934850"/>
+   <Attribute name="Shape_Area" value="3.30646936365"/>
+   <Attribute name="lwc_user" value="Bretagne"/>
+   <Attribute name="lwc_groups" value="test1"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>


### PR DESCRIPTION
Linked to #371 and follow up with #368 

Using access control layer permissions, to set variables `@lizmap_user` and `@lizmap_user_groups`.

These variables are also availables for `EXPRESSION` service.
