### PR TITLE
Tooltip: adapt ValueRelation filter to aggregate context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Tooltip : Fix generation of the tooltip expression when using `@current_geometry` and `current_value()` when it's
+  used outside the form context.
+
 ## 3.6.4 - 2021-11-15
 
 * Desktop - Add link to the Lizmap IRC channel on libera.chat

--- a/lizmap/tooltip.py
+++ b/lizmap/tooltip.py
@@ -337,6 +337,10 @@ class Tooltip:
 
         filter_exp = widget_config['FilterExpression'].strip()
         if filter_exp:
+            # replace @current_geometry only available in form by geometry(@parent) for aggregate
+            filter_exp = filter_exp.replace('@current_geometry', 'geometry(@parent)')
+            # replace current_value( only available in form by attribute(@parent, for aggregate
+            filter_exp = filter_exp.replace('current_value(', 'attribute(@parent, ')
             expression += ' AND {}'.format(filter_exp)
 
         field_view = '''


### PR DESCRIPTION
In ValueRelation context `@current_geometry` and `current_value('field_name')` can be used to get geometry or values associated to the form. In the tooltip with aggregate function they are not available and has to be replaced by `geometry(@parent)` and `attribute(@parent, '' )`.

* **Funded by**: DDTM34