### PR TITLE
Change the behavior of the key compared to the new service ign

### DIFF
--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -960,17 +960,11 @@ class Lizmap:
     def check_ign_french_free_key(self):
         """ French IGN free API keys choisirgeoportail/pratique do not include all layers. """
         key = self.global_options['ignKey']['widget'].text()
-        if key in ['choisirgeoportail', 'pratique']:
+        if not key:
             self.global_options['ignTerrain']['widget'].setEnabled(False)
             self.global_options['ignTerrain']['widget'].setChecked(False)
         else:
             self.global_options['ignTerrain']['widget'].setEnabled(True)
-
-        if key in ['pratique']:
-            self.global_options['ignCadastral']['widget'].setEnabled(False)
-            self.global_options['ignCadastral']['widget'].setChecked(False)
-        else:
-            self.global_options['ignCadastral']['widget'].setEnabled(True)
 
     def enable_popup_source_button(self):
         """Enable or not the "Configure" button according to the popup source."""


### PR DESCRIPTION
<!---
PUT "dev" branch for any new features or next Lizmap version
PUT "master" for bug fix
-->

After change IGN urls with its new urls of its new services the free key like `ChoisirGeoportail` was deleted. So in the Lizmap plugin  we need to change the behavior of the ignkey with the checkbox to add ign basemaps in the config.

Now we only need an IGN key to use the `scan25` basemap.
