### PR TITLE
UX - Add option to define the overview map scale dynamic or static

### DIFF
--- a/lizmap/lizmap_api/config.py
+++ b/lizmap/lizmap_api/config.py
@@ -51,6 +51,7 @@ import os
 from qgis.core import QgsMapLayer, QgsProject
 
 from lizmap import DEFAULT_LWC_VERSION
+from lizmap.qgis_plugin_tools.tools.i18n import tr
 from lizmap.qgis_plugin_tools.tools.version import (
     format_version_integer,
     version,
@@ -238,6 +239,16 @@ class LizmapConfig:
         'atlasAutoPlay': {
             'wType': 'checkbox', 'type': 'boolean', 'default': False
         },
+        'fixed_scale_overview_map': {
+            'wType': 'checkbox',
+            'type': 'boolean',
+            'default': False,
+            'tooltip': tr(
+                "If not checked, the overview map will follow the scale of the main map with a small scale. "
+                "If disabled, the overview map will have a fixed scale covering the project extent."
+            ),
+            'use_proper_boolean': True,
+        }
     }
 
     layerOptionDefinitions = {

--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -368,6 +368,7 @@ class Lizmap:
         # List of ui widget for data driven actions and checking
         self.global_options = LizmapConfig.globalOptionDefinitions
         # Add widgets (not done in lizmap_var to avoid dependencies on ui)
+        self.global_options['fixed_scale_overview_map']['widget'] = self.dlg.checkbox_scale_overiew_map
         self.global_options['mapScales']['widget'] = self.dlg.inMapScales
         self.global_options['minScale']['widget'] = self.dlg.inMinScale
         self.global_options['maxScale']['widget'] = self.dlg.inMaxScale
@@ -1113,6 +1114,9 @@ class Lizmap:
         # Set the global options (map, tools, etc.)
         for key, item in self.global_options.items():
             if item.get('widget'):
+                if item.get('tooltip'):
+                    item['widget'].setToolTip(item.get('tooltip'))
+
                 if item['wType'] == 'checkbox':
                     item['widget'].setChecked(item['default'])
                     if key in json_options:
@@ -2049,7 +2053,9 @@ class Lizmap:
                         inputValue = int(item['default'])
 
                 elif item['type'] == 'boolean':
-                    inputValue = str(inputValue)
+                    inputValue = item['widget'].isChecked()
+                    if not item.get('use_proper_boolean'):
+                        inputValue = str(inputValue)
 
                 # Add value to the option
                 if inputValue and inputValue != "False":

--- a/lizmap/resources/ui/ui_lizmap.ui
+++ b/lizmap/resources/ui/ui_lizmap.ui
@@ -1169,6 +1169,16 @@ This is different to the map maximum extent (defined in QGIS project properties,
                     </item>
                    </layout>
                   </item>
+                  <item>
+                   <widget class="QCheckBox" name="checkbox_scale_overiew_map">
+                    <property name="toolTip">
+                     <string/>
+                    </property>
+                    <property name="text">
+                     <string>Static scale for the overview map</string>
+                    </property>
+                   </widget>
+                  </item>
                  </layout>
                 </widget>
                </item>


### PR DESCRIPTION
<!---
PUT "dev" branch for any new features or next Lizmap version
PUT "master" for bug fix
-->
* **Description**: 
  * Linked to https://github.com/3liz/lizmap-web-client/issues/2837

```json
    "options": {
        "fixed_scale_overview_map": true,
    },
```

@nboisteault Notice the proper boolean compare to others ;-)

By default, the value is false, dynamic. But I'm not sure we should keep this value.
