### PR TITLE
LWC 3.6 - Check for the layer id as name

### DIFF
--- a/lizmap/definitions/warnings.py
+++ b/lizmap/definitions/warnings.py
@@ -1,0 +1,12 @@
+__copyright__ = 'Copyright 2022, 3Liz'
+__license__ = 'GPL version 3'
+__email__ = 'info@3liz.org'
+
+
+from enum import Enum, unique
+
+
+@unique
+class Warnings(Enum):
+    OgcNotValid = 'ogc_not_valid'
+    UseLayerIdAsName = 'use_layer_id_as_name'


### PR DESCRIPTION
<!---
PUT "dev" branch for any new features or next Lizmap version
PUT "master" for bug fix
-->

* **Funded by**: 3Liz
* **Description**: 
  * LWC 3.6 - Check for the layer id as name


New section in the CFG, empty of course if everything is fine : 
```json
    "warnings": [
        "use_layer_id_as_name",
        "ogc_not_valid"
    ],
```
