### PR TITLE
CFG - Add the status of the current LWC release in the metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add a link to GIS Stackexchange on the first tab
 * Fix missing translations in the user interface of the plugin
 * Improve the panel about server information
+* Improve metadata in the CFG file about the status of the current Lizmap Web Client version which is used
 
 ## 3.9.0 - 2022-07-25
 

--- a/lizmap/definitions/definitions.py
+++ b/lizmap/definitions/definitions.py
@@ -28,6 +28,20 @@ class LwcVersions(Enum):
 
 
 @unique
+@total_ordering
+class ReleaseStatus(Enum):
+    Unknown = 'Unknown'
+    NotMaintained = 'NotMaintained'
+    Stable = 'Stable'
+    Dev = 'Dev'
+
+    def __lt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value < other.value
+        return NotImplemented
+
+
+@unique
 class LayerProperties(Enum):
     DataUrl = 'DataUrl'
 

--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -101,6 +101,7 @@ from lizmap.definitions.definitions import (
     ONLINE_HELP_LANGUAGES,
     LayerProperties,
     LwcVersions,
+    ReleaseStatus,
 )
 from lizmap.definitions.edition import EditionDefinitions
 from lizmap.definitions.filter_by_form import FilterByFormDefinitions
@@ -718,7 +719,11 @@ class Lizmap:
                     display_next_release = self.version not in ['dev', 'master']
 
         lwc_version = QgsSettings().value('lizmap/lizmap_web_client_version', DEFAULT_LWC_VERSION.value, str)
-        lwc_version = LwcVersions(lwc_version)
+        try:
+            lwc_version = LwcVersions(lwc_version)
+        except ValueError:
+            # The QgsSettings does not contain a valid LWC version item
+            lwc_version = DEFAULT_LWC_VERSION
         index = self.dlg.combo_lwc_version.findData(lwc_version)
         self.dlg.combo_lwc_version.setCurrentIndex(index)
 
@@ -2129,11 +2134,15 @@ class Lizmap:
                     )
                 ), QMessageBox.Ok)
 
+        target_status = self.dlg.combo_lwc_version.itemData(self.dlg.combo_lwc_version.currentIndex(), Qt.UserRole + 1)
+        if not target_status:
+            target_status = ReleaseStatus.Unknown
         metadata = {
             'qgis_desktop_version': Qgis.QGIS_VERSION_INT,
             'lizmap_plugin_version_str': current_version,
             'lizmap_plugin_version': int(format_version_integer(current_version)),
             'lizmap_web_client_target_version': int(format_version_integer('{}.0'.format(lwc_version))),
+            'lizmap_web_client_target_status': target_status.value,
         }
         if valid is not None:
             metadata['project_valid'] = valid

--- a/lizmap/test/data/lizmap_3_3.qgs.cfg
+++ b/lizmap/test/data/lizmap_3_3.qgs.cfg
@@ -3,6 +3,7 @@
         "qgis_desktop_version": 31615,
         "lizmap_plugin_version": "3.7.8-pre",
         "lizmap_web_client_target_version": 30300,
+        "lizmap_web_client_target_status": "NotMaintained",
         "project_valid": false
     },
     "options": {
@@ -388,7 +389,9 @@
         }
     },
     "filter_by_polygon": {
-        "config": {},
+        "config": {
+            "filter_by_user": false
+        },
         "layers": []
     },
     "formFilterLayers": {

--- a/lizmap/version_checker.py
+++ b/lizmap/version_checker.py
@@ -7,10 +7,10 @@ import logging
 import os
 
 from qgis.core import QgsNetworkContentFetcher
-from qgis.PyQt.QtCore import QDate, QLocale, QUrl
+from qgis.PyQt.QtCore import QDate, QLocale, Qt, QUrl
 from qgis.PyQt.QtWidgets import QDialog
 
-from lizmap.definitions.definitions import LwcVersions
+from lizmap.definitions.definitions import LwcVersions, ReleaseStatus
 from lizmap.qgis_plugin_tools.tools.i18n import tr
 from lizmap.tools import lizmap_user_folder
 
@@ -52,8 +52,8 @@ class VersionChecker:
     def update_lwc_selector(self, released_versions: dict):
         """ Update LWC selector showing outdated versions. """
         for i, json_version in enumerate(released_versions):
+            index = self.dialog.combo_lwc_version.findData(LwcVersions(json_version['branch']))
             if not json_version['maintained']:
-                index = self.dialog.combo_lwc_version.findData(LwcVersions(json_version['branch']))
                 if not index and json_version['branch'] != LwcVersions.Lizmap_3_1.value:
                     LOGGER.warning(
                         "We did not find the version {} in the selector version".format(
@@ -65,9 +65,14 @@ class VersionChecker:
                 if i == 0:
                     # If it's the first item in the list AND not maintained, then it's the next LWC version
                     new_text = text + ' - ' + tr('Next')
+                    flag = ReleaseStatus.Dev
                 else:
                     new_text = text + ' - ' + tr('Not maintained')
+                    flag = ReleaseStatus.NotMaintained
                 self.dialog.combo_lwc_version.setItemText(index, new_text)
+            else:
+                flag = ReleaseStatus.Stable
+            self.dialog.combo_lwc_version.setItemData(index, flag, Qt.UserRole + 1)
 
     def update_lwc_releases(self, released_versions: dict):
         """ Update labels about latest releases. """


### PR DESCRIPTION
Hop @mdouchin !

So later, you can know if it's a true 3.6 CFG file or a 3.6 ghost with missing keys ...

```json
    "metadata": {
        "qgis_desktop_version": 31615,
        "lizmap_plugin_version": "3.7.8-pre",
        "lizmap_web_client_target_version": 30300,
        "lizmap_web_client_target_status": "NotMaintained",
        "project_valid": false
    },
```
