### PR TITLE
Form filter - allow two numeric filters : start and end values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased for the next version, so this won't be merged and no conflict
+
+* Add new "maximum field" for Lizmap Web Client ≥ 3.7 about the form filter with numeric values
+
 ## Unreleased
 
 * Remove notes about the Lizmap QGIS server plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
 # Changelog
 
-## Unreleased for the next version, so this won't be merged and no conflict
-
-* Add new "maximum field" for Lizmap Web Client ≥ 3.7 about the form filter with numeric values
-
 ## Unreleased
 
+* Add new "maximum field" for Lizmap Web Client ≥ 3.7 about the form filter with numeric values
 * Remove notes about the Lizmap QGIS server plugin
 
 ## 3.9.5 - 2022-11-29

--- a/lizmap/definitions/definitions.py
+++ b/lizmap/definitions/definitions.py
@@ -18,8 +18,9 @@ class LwcVersions(Enum):
     Lizmap_3_4 = '3.4'
     Lizmap_3_5 = '3.5'
     Lizmap_3_6 = '3.6'
-    # Enable only when the JSON file is published the new version below
-    # Lizmap_3_7 = '3.7'
+    Lizmap_3_7 = '3.7'
+    # Enable only when the JSON file is published with the new version below
+    # Lizmap_3_8 = '3.8'
 
     def __lt__(self, other):
         if self.__class__ is other.__class__:

--- a/lizmap/definitions/definitions.py
+++ b/lizmap/definitions/definitions.py
@@ -19,8 +19,6 @@ class LwcVersions(Enum):
     Lizmap_3_5 = '3.5'
     Lizmap_3_6 = '3.6'
     Lizmap_3_7 = '3.7'
-    # Enable only when the JSON file is published with the new version below
-    # Lizmap_3_8 = '3.8'
 
     def __lt__(self, other):
         if self.__class__ is other.__class__:

--- a/lizmap/definitions/filter_by_form.py
+++ b/lizmap/definitions/filter_by_form.py
@@ -1,6 +1,7 @@
 """Definitions for filter by form."""
 
 from lizmap.definitions.base import BaseDefinitions, InputType
+from lizmap.definitions.definitions import LwcVersions
 from lizmap.qgis_plugin_tools.tools.i18n import tr
 
 __copyright__ = 'Copyright 2020, 3Liz'
@@ -26,6 +27,7 @@ class FilterByFormDefinitions(BaseDefinitions):
                 'The title to give to the input, which will be displayed above the form input. '
                 'For example "Choose a category" for a layer field called "category".')
         }
+        # TODO switch to enum for the list with icons
         self._layer_config['type'] = {
             'type': InputType.List,
             'header': tr('Type'),
@@ -39,6 +41,8 @@ class FilterByFormDefinitions(BaseDefinitions):
             'tooltip': tr(
                 'The field name to apply the filter on.')
         }
+        # In a near future, we should merge min_date into start_field
+        # LWC 3.7 is able to read it already
         self._layer_config['min_date'] = {
             'type': InputType.Field,
             'header': tr('Date minimum'),
@@ -46,6 +50,8 @@ class FilterByFormDefinitions(BaseDefinitions):
             'tooltip': tr(
                 'The field containing the start date of your feature (ex: "start_date" of an event).')
         }
+        # In a near future, we should merge max_date into end_field
+        # LWC 3.7 is able to read it already
         self._layer_config['max_date'] = {
             'type': InputType.Field,
             'header': tr('Date maximum'),
@@ -55,6 +61,20 @@ class FilterByFormDefinitions(BaseDefinitions):
                 'one for the start date and another for the end date, you can differentiate them. '
                 'If not, you need to use the same field name for Min date and Max date.'
             )
+        }
+        self._layer_config['start_field'] = {
+            'type': InputType.Field,
+            'header': tr('Start field'),
+            'default': '',
+            'tooltip': tr('The field containing the minimum/start value'),
+            # 'version': LwcVersions.Lizmap_3_7, # This field is kinda not new, used for legacy CFG from < 3.7
+        }
+        self._layer_config['end_field'] = {
+            'type': InputType.Field,
+            'header': tr('End field'),
+            'default': '',
+            'tooltip': tr('The field containing the maximum/end value of your data.'),
+            'version': LwcVersions.Lizmap_3_7,
         }
         self._layer_config['format'] = {
             'type': InputType.List,

--- a/lizmap/definitions/filter_by_form.py
+++ b/lizmap/definitions/filter_by_form.py
@@ -1,7 +1,6 @@
 """Definitions for filter by form."""
 
 from lizmap.definitions.base import BaseDefinitions, InputType
-from lizmap.definitions.definitions import LwcVersions
 from lizmap.qgis_plugin_tools.tools.i18n import tr
 
 __copyright__ = 'Copyright 2020, 3Liz'
@@ -41,40 +40,22 @@ class FilterByFormDefinitions(BaseDefinitions):
             'tooltip': tr(
                 'The field name to apply the filter on.')
         }
-        # In a near future, we should merge min_date into start_field
-        # LWC 3.7 is able to read it already
-        self._layer_config['min_date'] = {
-            'type': InputType.Field,
-            'header': tr('Date minimum'),
-            'default': '',
-            'tooltip': tr(
-                'The field containing the start date of your feature (ex: "start_date" of an event).')
-        }
-        # In a near future, we should merge max_date into end_field
-        # LWC 3.7 is able to read it already
-        self._layer_config['max_date'] = {
-            'type': InputType.Field,
-            'header': tr('Date maximum'),
-            'default': '',
-            'tooltip': tr(
-                'The field containing the end date of your data. If you have 2 fields containing dates, '
-                'one for the start date and another for the end date, you can differentiate them. '
-                'If not, you need to use the same field name for Min date and Max date.'
-            )
-        }
         self._layer_config['start_field'] = {
             'type': InputType.Field,
             'header': tr('Start field'),
             'default': '',
-            'tooltip': tr('The field containing the minimum/start value'),
-            # 'version': LwcVersions.Lizmap_3_7, # This field is kinda not new, used for legacy CFG from < 3.7
+            'tooltip': tr('The field containing the minimum/start value (ex: "start_date" of an event).'),
+            # 'version': LwcVersions.Lizmap_3_7, # This key has been renamed from start_date
         }
         self._layer_config['end_field'] = {
             'type': InputType.Field,
             'header': tr('End field'),
             'default': '',
-            'tooltip': tr('The field containing the maximum/end value of your data.'),
-            'version': LwcVersions.Lizmap_3_7,
+            'tooltip': tr(
+                'The field containing the maximum/end value of your data. If you have 2 fields containing dates, one '
+                'for the start date and another for the end date, you can differentiate them.'
+            ),
+            # 'version': LwcVersions.Lizmap_3_7, # This key has been renamed from end_date
         }
         self._layer_config['format'] = {
             'type': InputType.List,

--- a/lizmap/forms/base_edition_dialog.py
+++ b/lizmap/forms/base_edition_dialog.py
@@ -138,6 +138,7 @@ class BaseEditionDialog(QDialog):
         QDesktopServices.openUrl(QUrl(url))
 
     def version_lwc(self):
+        """ Make all colors about widgets if it is available or not. """
         current_version = QgsSettings().value('lizmap/lizmap_web_client_version', DEFAULT_LWC_VERSION.value, str)
         current_version = LwcVersions(current_version)
 

--- a/lizmap/forms/base_edition_dialog.py
+++ b/lizmap/forms/base_edition_dialog.py
@@ -37,6 +37,9 @@ class BaseEditionDialog(QDialog):
         self.lwc_versions[LwcVersions.Lizmap_3_2] = []
         self.lwc_versions[LwcVersions.Lizmap_3_3] = []
         self.lwc_versions[LwcVersions.Lizmap_3_4] = []
+        self.lwc_versions[LwcVersions.Lizmap_3_5] = []
+        self.lwc_versions[LwcVersions.Lizmap_3_6] = []
+        self.lwc_versions[LwcVersions.Lizmap_3_7] = []
 
     def setup_ui(self):
         self.button_box.button(QDialogButtonBox.Help).setToolTip(

--- a/lizmap/forms/filter_by_form_edition.py
+++ b/lizmap/forms/filter_by_form_edition.py
@@ -1,7 +1,9 @@
 """Dialog for filter by form."""
 
 from qgis.core import QgsMapLayerProxyModel, QgsProject
+from qgis.PyQt.QtGui import QIcon
 
+from lizmap import LwcVersions
 from lizmap.definitions.filter_by_form import FilterByFormDefinitions
 from lizmap.forms.base_edition_dialog import BaseEditionDialog
 from lizmap.qgis_plugin_tools.tools.i18n import tr
@@ -28,6 +30,8 @@ class FilterByFormEditionDialog(BaseEditionDialog, CLASS):
         self.config.add_layer_widget('field', self.field)
         self.config.add_layer_widget('min_date', self.min_date)
         self.config.add_layer_widget('max_date', self.max_date)
+        self.config.add_layer_widget('start_field', self.start_field)
+        self.config.add_layer_widget('end_field', self.end_field)
         self.config.add_layer_widget('format', self.filter_format)
         self.config.add_layer_widget('splitter', self.splitter)
 
@@ -37,16 +41,43 @@ class FilterByFormEditionDialog(BaseEditionDialog, CLASS):
         self.config.add_layer_label('field', self.label_field)
         self.config.add_layer_label('min_date', self.label_min_date)
         self.config.add_layer_label('max_date', self.label_max_date)
+        self.config.add_layer_label('start_field', self.label_start_field)
+        self.config.add_layer_label('end_field', self.label_end_field)
         self.config.add_layer_label('format', self.label_format)
         self.config.add_layer_label('splitter', self.label_splitter)
 
-        self.type.addItem(tr('Text'), 'text')
-        self.type.addItem(tr('Unique values'), 'uniquevalues')
-        self.type.addItem(tr('Numeric'), 'numeric')
-        self.type.addItem(tr('Date'), 'date')
+        # TODO this shouldn't be here but in the definitions package
+        self.type.addItem(
+            QIcon(":images/themes/default/mIconFieldText.svg"),
+            tr('Text'),
+            'text'
+        )
+        self.type.addItem(
+            QIcon(":images/themes/default/algorithms/mAlgorithmUniqueValues.svg"),
+            tr('Unique values'),
+            'uniquevalues'
+        )
+        self.type.addItem(
+            QIcon(":images/themes/default/mIconFieldInteger.svg"),
+            tr('Numeric'),
+            'numeric',
+        )
+        self.type.addItem(
+            QIcon(":images/themes/default/mIconFieldDateTime.svg"),
+            tr('Date'),
+            'date',
+        )
 
-        self.filter_format.addItem(tr('Checkboxes'), 'checkboxes')
-        self.filter_format.addItem(tr('Combobox'), 'select')
+        self.filter_format.addItem(
+            QIcon(":images/themes/default/mIconDeselected.svg"),
+            tr('Checkboxes'),
+            'checkboxes'
+        )
+        self.filter_format.addItem(
+            QIcon(":images/themes/default/mIconDropDownMenu.svg"),
+            tr('Combobox'),
+            'select'
+        )
 
         self.layer.setFilters(QgsMapLayerProxyModel.VectorLayer)
 
@@ -54,14 +85,18 @@ class FilterByFormEditionDialog(BaseEditionDialog, CLASS):
         self.layer.layerChanged.connect(self.field.setLayer)
         self.layer.layerChanged.connect(self.min_date.setLayer)
         self.layer.layerChanged.connect(self.max_date.setLayer)
+        self.layer.layerChanged.connect(self.start_field.setLayer)
+        self.layer.layerChanged.connect(self.end_field.setLayer)
 
         self.field.setLayer(self.layer.currentLayer())
         self.min_date.setLayer(self.layer.currentLayer())
         self.max_date.setLayer(self.layer.currentLayer())
+        self.start_field.setLayer(self.layer.currentLayer())
+        self.end_field.setLayer(self.layer.currentLayer())
 
-        self.field.setAllowEmptyFieldName(False)
-        self.min_date.setAllowEmptyFieldName(False)
-        self.max_date.setAllowEmptyFieldName(True)
+        self.lwc_versions[LwcVersions.Lizmap_3_7] = [
+            self.label_end_field,
+        ]
 
         block_list = []
         for layer in QgsProject().instance().mapLayers().values():
@@ -85,51 +120,76 @@ class FilterByFormEditionDialog(BaseEditionDialog, CLASS):
         self.show_error(not_in_wfs)
 
     def update_visibility(self):
-        """Show/Hide fields depending of chosen type."""
+        """Show/Hide fields depending on chosen type."""
         index = self.type.currentIndex()
         data = self.type.itemData(index)
+
+        # Make all not common fields not visible by default
+        # And enable them one per one
+        # Field
+        self.label_field.setVisible(False)
+        self.field.setVisible(False)
+        self.field.setAllowEmptyFieldName(False)
+
+        # Start field
+        self.label_start_field.setVisible(False)
+        self.start_field.setVisible(False)
+        self.start_field.setAllowEmptyFieldName(False)
+
+        # End field
+        self.label_end_field.setVisible(False)
+        self.end_field.setVisible(False)
+        self.end_field.setAllowEmptyFieldName(False)
+
+        # Format
+        self.filter_format.setVisible(False)
+        self.label_format.setVisible(False)
+
+        # Splitter
+        self.splitter.setVisible(False)
+        self.label_splitter.setVisible(False)
+
+        # Min date
+        self.label_min_date.setVisible(False)
+        self.min_date.setVisible(False)
+        self.min_date.setAllowEmptyFieldName(False)
+
+        # Max date
+        self.label_max_date.setVisible(False)
+        self.max_date.setVisible(False)
+        self.max_date.setAllowEmptyFieldName(False)
 
         if data == 'date':
             self.min_date.setVisible(True)
             self.min_date.setAllowEmptyFieldName(False)
             self.max_date.setVisible(True)
+            self.max_date.setAllowEmptyFieldName(True)
             self.label_min_date.setVisible(True)
             self.label_max_date.setVisible(True)
-        else:
-            self.min_date.setVisible(False)
-            self.min_date.setAllowEmptyFieldName(True)
-            self.min_date.setField('')
-            self.max_date.setVisible(False)
-            self.max_date.setField('')
-            self.label_min_date.setVisible(False)
-            self.label_max_date.setVisible(False)
-
-        if data == 'uniquevalues':
+        elif data == 'uniquevalues':
+            self.label_field.setVisible(True)
+            self.field.setVisible(True)
             self.filter_format.setVisible(True)
             index = self.filter_format.findData('')
             self.filter_format.removeItem(index)
             self.splitter.setVisible(True)
             self.label_format.setVisible(True)
             self.label_splitter.setVisible(True)
-        else:
-            self.filter_format.setVisible(False)
+        elif data == 'numeric':
+            self.label_start_field.setVisible(True)
+            self.label_end_field.setVisible(True)
+            self.start_field.setVisible(True)
+            self.end_field.setVisible(True)
+            self.end_field.setAllowEmptyFieldName(True)
+        elif data == 'text':
+            self.label_field.setVisible(True)
+            self.field.setVisible(True)
             self.filter_format.addItem('', '')
             index = self.filter_format.findData('')
             self.filter_format.setCurrentIndex(index)
-            self.splitter.setVisible(False)
             self.splitter.setText('')
-            self.label_format.setVisible(False)
-            self.label_splitter.setVisible(False)
-
-        if data in ['text', 'uniquevalues', 'numeric']:
-            self.field.setVisible(True)
-            self.field.setAllowEmptyFieldName(False)
-            self.label_field.setVisible(True)
         else:
-            self.field.setVisible(False)
-            self.field.setAllowEmptyFieldName(True)
-            self.field.setField('')
-            self.label_field.setVisible(False)
+            raise Exception('Unknown type')
 
     def validate(self) -> str:
         upstream = super().validate()
@@ -144,11 +204,15 @@ class FilterByFormEditionDialog(BaseEditionDialog, CLASS):
         index = self.type.currentIndex()
         data = self.type.itemData(index)
 
+        field_required = tr('Field is mandatory.')
         if data == 'date':
             if not self.min_date.currentField():
                 return tr('Field min date is mandatory.')
-        elif data in ['text', 'uniquevalues', 'numeric']:
+        elif data in ('text', 'uniquevalues'):
             if not self.field.currentField():
-                return tr('Field is mandatory.')
+                return field_required
+        elif data == 'numeric':
+            if not self.start_field.currentField():
+                return field_required
         else:
             raise Exception('Unknown option')

--- a/lizmap/forms/table_manager.py
+++ b/lizmap/forms/table_manager.py
@@ -534,15 +534,23 @@ class TableManager:
             if self.definitions.key() == 'formFilterLayers':
                 if version < LwcVersions.Lizmap_3_7:
                     # We need to change keys to write in the legacy format
-                    if layer_data.get('end_field'):
-                        # Incompatible with this format, but we don't remove it just in case
-                        LOGGER.error(
-                            "A end_field is defined for the form filter. This is not compatible for this version of "
-                            "Lizmap Web Client"
-                        )
-                    if layer_data.get('start_field'):
-                        layer_data['field'] = layer_data.get('start_field')
-                        del layer_data['start_field']
+                    if layer_data.get('type') == 'numeric':
+                        if layer_data.get('end_field'):
+                            # Incompatible with this format, but we don't remove it just in case
+                            LOGGER.error(
+                                "A end_field is defined for the form filter. This is not compatible for this version "
+                                "of Lizmap Web Client"
+                            )
+                        if layer_data.get('start_field'):
+                            layer_data['field'] = layer_data.get('start_field')
+                            del layer_data['start_field']
+                    elif layer_data.get('type') == 'date':
+                        if layer_data.get('start_field'):
+                            layer_data['min_date'] = layer_data.get('start_field')
+                            del layer_data['start_field']
+                        if layer_data.get('end_field'):
+                            layer_data['max_date'] = layer_data.get('end_field')
+                            del layer_data['end_field']
 
             if export_legacy_single_row:
                 if self.definitions.key() == 'atlas':
@@ -654,13 +662,23 @@ class TableManager:
     def _from_json_legacy_form_filter(data):
         """ Read form filter and transform it if needed. """
         for layer in data.get('layers'):
-            if layer.get('type') != 'numeric':
-                continue
+            if layer.get('type') == 'numeric':
 
-            if layer.get('field'):
-                # We upgrade from < 3.7 to 3.7 format
-                layer['start_field'] = layer['field']
-                del layer['field']
+                if layer.get('field'):
+                    # We upgrade from < 3.7 to 3.7 format
+                    layer['start_field'] = layer['field']
+                    del layer['field']
+
+            if layer.get('type') == 'date':
+                if layer.get('min_date'):
+                    # We upgrade from < 3.7 to 3.7 format
+                    layer['start_field'] = layer['min_date']
+                    del layer['min_date']
+
+                if layer.get('end_date'):
+                    # We upgrade from < 3.7 to 3.7 format
+                    layer['end_field'] = layer['end_date']
+                    del layer['end_date']
 
         return data
 

--- a/lizmap/resources/ui/ui_form_filter_by_form.ui
+++ b/lizmap/resources/ui/ui_form_filter_by_form.ui
@@ -79,7 +79,7 @@
        <property name="toolTip">
         <string/>
        </property>
-       <property name="allowEmptyFieldName">
+       <property name="allowEmptyFieldName" stdset="0">
         <bool>true</bool>
        </property>
       </widget>
@@ -113,57 +113,23 @@
       </widget>
      </item>
      <item row="6" column="0">
-      <widget class="QLabel" name="label_min_date">
-       <property name="text">
-        <string>Min date</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QgsFieldComboBox" name="min_date">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="allowEmptyFieldName">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="label_max_date">
-       <property name="text">
-        <string>Max date</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="QgsFieldComboBox" name="max_date">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="allowEmptyFieldName">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
       <widget class="QLabel" name="label_start_field">
        <property name="text">
         <string>Start/min field</string>
        </property>
       </widget>
      </item>
-     <item row="9" column="0">
+     <item row="6" column="1">
+      <widget class="QgsFieldComboBox" name="start_field"/>
+     </item>
+     <item row="7" column="0">
       <widget class="QLabel" name="label_end_field">
        <property name="text">
         <string>End/max field</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
-      <widget class="QgsFieldComboBox" name="start_field"/>
-     </item>
-     <item row="9" column="1">
+     <item row="7" column="1">
       <widget class="QgsFieldComboBox" name="end_field"/>
      </item>
     </layout>

--- a/lizmap/resources/ui/ui_form_filter_by_form.ui
+++ b/lizmap/resources/ui/ui_form_filter_by_form.ui
@@ -15,6 +15,16 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Only layers stored in Spatialite, GPKG or PostgreSQL are available in this tool.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QFormLayout" name="formLayout">
      <item row="0" column="0">
       <widget class="QLabel" name="label_layer">
@@ -135,6 +145,26 @@
         <bool>true</bool>
        </property>
       </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="label_start_field">
+       <property name="text">
+        <string>Start/min field</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="label_end_field">
+       <property name="text">
+        <string>End/max field</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QgsFieldComboBox" name="start_field"/>
+     </item>
+     <item row="9" column="1">
+      <widget class="QgsFieldComboBox" name="end_field"/>
      </item>
     </layout>
    </item>

--- a/lizmap/test/test_table_manager.py
+++ b/lizmap/test/test_table_manager.py
@@ -62,7 +62,7 @@ class TestTableManager(unittest.TestCase):
             '1': {
                 'title': 'Line filtering',
                 'type': 'numeric',
-                'field': 'id',
+                'field': 'id',  # Numeric and 'field', this is a < 3.7 format
                 'min_date': '',
                 'max_date': '',
                 'format': 'checkboxes',
@@ -76,7 +76,7 @@ class TestTableManager(unittest.TestCase):
         self.assertEqual(table_manager.table.rowCount(), 0)
         table_manager.from_json(json)
         self.assertEqual(table_manager.table.rowCount(), 2)
-        data = table_manager.to_json()
+        data = table_manager.to_json(version=LwcVersions.Lizmap_3_6)
 
         expected = {
             '0': {
@@ -96,6 +96,88 @@ class TestTableManager(unittest.TestCase):
                 'field': 'id',
                 'format': 'checkboxes',
                 'order': 1
+            }
+        }
+        self.assertDictEqual(data, expected)
+
+        # Version >= 3.7
+        data = table_manager.to_json(version=LwcVersions.Lizmap_3_7)
+
+        expected = {
+            '0': {
+                'layerId': self.layer.id(),
+                'provider': 'ogr',  # Added automatically on the fly
+                'title': 'Line filtering',
+                'type': 'text',
+                'field': 'name',
+                'format': 'checkboxes',
+                'order': 0
+            },
+            '1': {
+                'layerId': self.layer.id(),
+                'provider': 'ogr',  # Added automatically on the fly
+                'title': 'Line filtering',
+                'type': 'numeric',
+                'start_field': 'id',
+                'format': 'checkboxes',
+                'order': 1
+            }
+        }
+        self.assertDictEqual(data, expected)
+
+    def test_form_filter_3_7(self):
+        """ Test to write to 3.6 format. """
+        table_manager = TableManager(
+            None, FilterByFormDefinitions(), None, QTableWidget(), None, None, None, None)
+
+        json = {
+            '0': {
+                'title': 'Line filtering',
+                'type': 'numeric',
+                'start_field': 'id',
+                'end_field': 'id',
+                'min_date': '',
+                'max_date': '',
+                'format': 'checkboxes',
+                'splitter': '',
+                'provider': 'ogr',
+                'layerId': self.layer.id(),
+                'order': 0
+            }
+        }
+
+        self.assertEqual(table_manager.table.rowCount(), 0)
+        table_manager.from_json(json)
+        self.assertEqual(table_manager.table.rowCount(), 1)
+        data = table_manager.to_json(version=LwcVersions.Lizmap_3_6)
+
+        expected = {
+            '0': {
+                'layerId': self.layer.id(),
+                'provider': 'ogr',
+                'title': 'Line filtering',
+                'type': 'numeric',
+                'field': 'id',
+                # Not used, but we keep it in memory, more convenient if the end user has just temporary changed its
+                # LWC version
+                'end_field': 'id',
+                'format': 'checkboxes',
+                'order': 0
+            }
+        }
+        self.assertDictEqual(data, expected)
+
+        data = table_manager.to_json(version=LwcVersions.Lizmap_3_7)
+        expected = {
+            '0': {
+                'layerId': self.layer.id(),
+                'provider': 'ogr',
+                'title': 'Line filtering',
+                'type': 'numeric',
+                'start_field': 'id',
+                'end_field': 'id',
+                'format': 'checkboxes',
+                'order': 0
             }
         }
         self.assertDictEqual(data, expected)


### PR DESCRIPTION
* Form filter - allow two numeric filters : start and end values
* Linked to https://github.com/3liz/lizmap-web-client/pull/3162
* Funded by Terre de Provence Agglomération https://www.terredeprovence-agglo.com/

⚠ This PR mustn't be merged before 3.6.0 is released ! It's technically not possible for now to have two dev versions (3.6 and 3.7)

