### PR TITLE
UX - Hide non numeric field type for the PK in attribute table panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* When adding a new layer in the attribute table panel, the primary key must be a numeric type
 * Add a new wizard helper for setting Lizmap Web Client groups in the plugin
 * Check the login and server URL before saving in the authentication database
 

--- a/lizmap/forms/attribute_table_edition.py
+++ b/lizmap/forms/attribute_table_edition.py
@@ -1,6 +1,5 @@
 """Dialog for attribute table edition."""
-
-from qgis.core import QgsMapLayerProxyModel
+from qgis.core import QgsFieldProxyModel, QgsMapLayerProxyModel
 
 from lizmap.definitions.attribute_table import (
     AttributeTableDefinitions,
@@ -45,6 +44,7 @@ class AttributeTableEditionDialog(BaseEditionDialog, CLASS):
         self.layer.layerChanged.connect(self.layer_changed)
         self.layer.layerChanged.connect(self.field_primary_key.setLayer)
         self.field_primary_key.setLayer(self.layer.currentLayer())
+        self.field_primary_key.setFilters(QgsFieldProxyModel.Numeric)
         self.layer.layerChanged.connect(self.fields_to_hide.set_layer)
         self.fields_to_hide.set_layer(self.layer.currentLayer())
 


### PR DESCRIPTION
I can restrict more if needed : https://api.qgis.org/api/classQgsFieldProxyModel.html#a320c1cc5a4fa5616d093eea353d4700e

@mdouchin @rldhont Keen to have your feedback.
