### PR TITLE
Fix typo in FTP server

### DIFF
--- a/lizmap/server_ftp.py
+++ b/lizmap/server_ftp.py
@@ -67,7 +67,7 @@ class FtpServer:
             self.dialog.button_ftp_reset.setEnabled(False)
             self.dialog.button_ftp_check.setEnabled(False)
             # self.dialog.input_ftp_port.setEnabled(False)
-            self.dialog.input_ftp_host.ssetEnabled(False)
+            self.dialog.input_ftp_host.setEnabled(False)
             self.dialog.input_ftp_user.setEnabled(False)
             self.dialog.input_ftp_password.setEnabled(False)
             self.dialog.input_ftp_directory.setEnabled(False)


### PR DESCRIPTION
This has been raided when loading plugin on QGIS built from MinGW GH Action in PR.

```python
mpossible de charger l'extension 'lizmap' provoque une erreur lors de l'appel à sa méthode classFactory() 

AttributeError: 'QLineEdit' object has no attribute 'ssetEnabled' 
Traceback (most recent call last):
  File "D:\Downloads\QGIS-Portable\lib\python3.11\site-packages\qgis\utils.py", line 423, in _startPlugin
    plugins[packageName] = package.classFactory(iface)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users/godet/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\lizmap\__init__.py", line 58, in classFactory
    return Lizmap(iface)
           ^^^^^^^^^^^^^
  File "C:\Users/godet/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\lizmap\plugin.py", line 640, in __init__
    self.server_ftp = FtpServer(self.dlg)
                      ^^^^^^^^^^^^^^^^^^^
  File "C:\Users/godet/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\lizmap\server_ftp.py", line 70, in __init__
    self.dialog.input_ftp_host.ssetEnabled(False)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'QLineEdit' object has no attribute 'ssetEnabled'


Version de Python : 3.11.2 (main, Feb 12 2023, 00:00:00) [GCC 12.2.1 20221121 (Fedora MinGW 12.2.1-7.fc38)] 
Version de QGIS : 3.31.0-Master Master, exported 

Chemin Python :
C:\Users/godet/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\stationlines
C:\Users/godet/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\LAStools
C:\Users/godet/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\geometric_attributes
D:/Downloads/QGIS-Portable/share/qgis/python
C:/Users/godet/AppData/Roaming/QGIS/QGIS3\profiles\default/python
C:/Users/godet/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins
D:/Downloads/QGIS-Portable/share/qgis/python/plugins
D:\Downloads\QGIS-Portable\lib\python311.zip
D:\Downloads\QGIS-Portable\lib\python3.11
D:\Downloads\QGIS-Portable\lib\python3.11\lib-dynload
D:\Downloads\QGIS-Portable\lib\python3.11\site-packages
C:/Users/godet/AppData/Roaming/QGIS/QGIS3\profiles\default/python
```