### PR TITLE
Fix concatenate with number in aggregate

### DIFF
--- a/lizmap/test/test_tooltip.py
+++ b/lizmap/test/test_tooltip.py
@@ -100,7 +100,7 @@ class TestToolTip(unittest.TestCase):
                     aggregate(
                         layer:='layer_id',
                         aggregate:='concatenate',
-                        expression:=display_expression,
+                        expression:=to_string(display_expression),
                         filter:=
                     "parent_pk" = attribute(@parent, 'name')
                 
@@ -316,7 +316,7 @@ class TestToolTip(unittest.TestCase):
                     aggregate(
                         layer:='layer_id',
                         aggregate:='concatenate',
-                        expression:="value",
+                        expression:=to_string("value"),
                         filter:="key" = attribute(@parent, 'foo') AND filter_expression
                     )'''
         self.assertEqual(expected, result)
@@ -349,7 +349,7 @@ class TestToolTip(unittest.TestCase):
                     aggregate(
                         layer:='layer_id',
                         aggregate:='concatenate',
-                        expression:="value",
+                        expression:=to_string("value"),
                         filter:="key" = attribute(@parent, 'foo') AND intersects(geometry(@parent), $geometry)
                     )'''
         self.assertEqual(expected, result)
@@ -369,7 +369,7 @@ class TestToolTip(unittest.TestCase):
                     aggregate(
                         layer:='layer_id',
                         aggregate:='concatenate',
-                        expression:="value",
+                        expression:=to_string("value"),
                         filter:="key" = attribute(@parent, 'foo') AND "fkey" = attribute(@parent, 'bar')
                     )'''
         self.assertEqual(expected, result)

--- a/lizmap/test/test_tooltip.py
+++ b/lizmap/test/test_tooltip.py
@@ -329,7 +329,7 @@ class TestToolTip(unittest.TestCase):
                     aggregate(
                         layer:='layer_id',
                         aggregate:='concatenate',
-                        expression:="value",
+                        expression:=to_string("value"),
                         filter:="key" = attribute(@parent, 'foo')
                     )'''
         self.assertEqual(expected, result)

--- a/lizmap/tooltip.py
+++ b/lizmap/tooltip.py
@@ -208,7 +208,7 @@ class Tooltip:
                     aggregate(
                         layer:='{}',
                         aggregate:='concatenate',
-                        expression:={},
+                        expression:=to_string({}),
                         filter:={}
                     )'''.format(
             layer_id,
@@ -353,7 +353,7 @@ class Tooltip:
                     aggregate(
                         layer:='{}',
                         aggregate:='concatenate',
-                        expression:="{}",
+                        expression:=to_string("{}"),
                         filter:={}
                     )'''.format(
                                 vlid,


### PR DESCRIPTION
<!---
PUT "dev" branch for any new features or next Lizmap version
PUT "master" for bug fix
-->

* **Funded by**: Faunalia
* **Description**:
  * QGIS concatenate aggregation expression is not working with numeric fields, therefore with need to force a string conversion when creating the tooltip

ref https://github.com/3liz/lizmap-plugin/issues/501 

Probably the same fix should also be done in the lizmap server plugin?