### PR TITLE
UX - Disable the toggled checkbox if the maptheme is enabled

### DIFF
--- a/lizmap/dialogs/main.py
+++ b/lizmap/dialogs/main.py
@@ -75,6 +75,7 @@ class LizmapDialog(QDialog, FORM_CLASS):
 
         # Layer tree
         self.layer_tree.headerItem().setText(0, tr('List of layers'))
+        self.activate_first_map_theme.toggled.connect(self.enable_toggled_layer_checkbox)
 
         tooltip = tr(
             'You can add either a URL starting by "http" or insert a string starting by "media/", "../media/" to '
@@ -136,6 +137,10 @@ class LizmapDialog(QDialog, FORM_CLASS):
             self.cbIgnTerrain.setChecked(False)
         else:
             self.cbIgnTerrain.setEnabled(True)
+
+    def enable_toggled_layer_checkbox(self):
+        """ If the theme is loaded at startup, the toggled checkbox is not used. """
+        self.cbToggled.setEnabled(not self.activate_first_map_theme.isChecked())
 
     def check_qgis_version(self, message_bar=False, widget=False):
         """ Compare QGIS desktop and server versions and display results if necessary. """

--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -1481,6 +1481,7 @@ class Lizmap:
             self.load_config_into_table_widget(key)
 
         self.dlg.check_ign_french_free_key()
+        self.dlg.enable_toggled_layer_checkbox()
         out = '' if json_file.exists() else 'out'
         LOGGER.info(f'Dialog has been loaded successful, with{out} CFG file')
 
@@ -2157,6 +2158,7 @@ class Lizmap:
                         val['widget'].setCurrentIndex(index)
 
         self.enable_popup_source_button()
+        self.dlg.enable_toggled_layer_checkbox()
 
     # def enable_or_not_toggle_checkbox(self):
     #     """ Only for groups, to determine the state of the "toggled" option. """


### PR DESCRIPTION
Better UX like this @nboisteault ! It makes it much clearer what to expect.
Note that the state of the checkbox is not lost, just disabled. So we don't loose configuration layer per layer.

Side note, if we enable the maptheme on startup, in a better world, the content of the dropdown menu should be updated : 

It should be either : 
* Follow maptheme
* Disabled

Right ?

![ksnip_20230717-175824](https://github.com/3liz/lizmap-plugin/assets/1609292/bd0a096a-1497-4645-b189-a8cc53a88607)
