### PR TITLE
Switch from "Overview" to "overview" for the group name

### DIFF
--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -2009,7 +2009,7 @@ class Lizmap:
                         predefined_group = PredefinedGroup.Hidden.value
                     if self.myDic[child_id]['name'] == 'baselayers':
                         predefined_group = PredefinedGroup.Baselayers.value
-                    if self.myDic[child_id]['name'] == 'Overview':
+                    if self.myDic[child_id]['name'].lower() == 'overview':
                         predefined_group = PredefinedGroup.Overview.value
 
                 elif parent_node.data(0, Qt.UserRole + 1) != PredefinedGroup.No.value:
@@ -2317,7 +2317,10 @@ class Lizmap:
 
     def add_group_overview(self):
         """ Add the overview group. """
-        self._add_group_legend('Overview')
+        label = 'overview'
+        if self.dlg.current_lwc_version() < LwcVersions.Lizmap_3_7:
+            label = 'Overview'
+        self._add_group_legend(label)
 
     @staticmethod
     def string_to_list(text):


### PR DESCRIPTION
Other groups are already lower case : `hidden`, `baselayers`, `project-background-color`

It would be nice to have `overview` as well to make things easier, same behavior everywhere.

But it seems this is hardcoded in LWC `Overview` : https://github.com/3liz/lizmap-web-client/blob/bc59e16cf30d44c259e70ba152d91a6cae290b30/assets/src/components/OverviewMap.js#L18
