### PR TITLE
CFG - Error if duplicated layer/group names

### DIFF
--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -106,6 +106,7 @@ from lizmap.forms.tooltip_edition import ToolTipEditionDialog
 from lizmap.lizmap_api.config import LizmapConfig
 from lizmap.ogc_project_validity import OgcProjectValidity
 from lizmap.project_checker_tools import (
+    duplicated_layer_name_or_group,
     duplicated_layer_with_filter,
     invalid_int8_primary_key,
     invalid_tid_field,
@@ -3261,6 +3262,24 @@ class Lizmap:
                     tr("Please go back to the server panel and edit the server to add a login."),
                     stop_process
                 ), QMessageBox.Ok)
+            return False
+
+        duplicated_in_cfg = duplicated_layer_name_or_group(self.project)
+        message = tr('Some layer(s) or group(s) have a duplicated name in the legend.')
+        message += '\n\n'
+        message += tr(
+            "It's not possible to store all the Lizmap configuration for these layer(s) or group(s), you should "
+            "change them to make them unique and reconfigure their settings in the 'Layers' tab of the plugin.")
+        message += '\n\n'
+        display = False
+        for name, count in duplicated_in_cfg.items():
+            if count >= 2:
+                display = True
+                message += '"{}" → count {}\n'.format(name, count)
+        message += '\n\n'
+        message += stop_process
+        if display:
+            ScrollMessageBox(self.dlg, QMessageBox.Warning, tr('Configuration error'), message)
             return False
 
         if not self.is_dev_version:

--- a/lizmap/project_checker_tools.py
+++ b/lizmap/project_checker_tools.py
@@ -4,7 +4,13 @@ __email__ = 'info@3liz.org'
 
 from typing import Optional
 
-from qgis.core import QgsDataSourceUri, QgsProject, QgsVectorLayer
+from qgis.core import (
+    QgsDataSourceUri,
+    QgsLayerTree,
+    QgsMapLayer,
+    QgsProject,
+    QgsVectorLayer,
+)
 
 from lizmap.qgis_plugin_tools.tools.i18n import tr
 
@@ -56,6 +62,30 @@ def invalid_int8_primary_key(layer: QgsVectorLayer) -> bool:
 
     field_type = layer.fields().field(primary_key).typeName()
     return field_type.lower() == 'int8'
+
+
+def duplicated_layer_name_or_group(project: QgsProject) -> dict:
+    """ The CFG can only store layer/group names which are unique. """
+    result = {}
+    # Vector and raster layers
+    for layer in project.mapLayers().values():
+        layer: QgsMapLayer
+        name = layer.name()
+        if name not in result.keys():
+            result[name] = 1
+        else:
+            result[name] += 1
+
+    # Groups
+    for child in project.layerTreeRoot().children():
+        if QgsLayerTree.isGroup(child):
+            name = child.name()
+            if name not in result.keys():
+                result[name] = 1
+            else:
+                result[name] += 1
+
+    return result
 
 
 def duplicated_layer_with_filter(project: QgsProject) -> Optional[str]:


### PR DESCRIPTION
![image](https://github.com/3liz/lizmap-plugin/assets/1609292/54f26e3b-338a-410a-81ad-6cb1587d5197)

The best would be to change how the dictionary in the CFG is written, but in the meantime, it's better to **stop** the process (not only warning).

Related to https://github.com/3liz/lizmap-plugin/issues/291, https://github.com/3liz/lizmap-plugin/issues/325