### PR TITLE
Do not enable the field combobox when expecting a primary key if the layer is in DB

### DIFF
--- a/lizmap/definitions/atlas.py
+++ b/lizmap/definitions/atlas.py
@@ -38,7 +38,7 @@ class AtlasDefinitions(BaseDefinitions):
             'tooltip': tr('The vector layer for the atlas.')
         }
         self._layer_config['primaryKey'] = {
-            'type': InputType.Field,
+            'type': InputType.PrimaryKeyField,
             'header': tr('Primary key'),
             'default': None,
             'tooltip': tr('Layer primary key (must be integer for PostgreSQL).')

--- a/lizmap/definitions/attribute_table.py
+++ b/lizmap/definitions/attribute_table.py
@@ -27,7 +27,7 @@ class AttributeTableDefinitions(BaseDefinitions):
             'tooltip': tr('The vector layer for the attribute table.')
         }
         self._layer_config['primaryKey'] = {
-            'type': InputType.Field,
+            'type': InputType.PrimaryKeyField,
             'header': tr('Primary key'),
             'default': None,
             'tooltip': tr('Primary key of the layer.')

--- a/lizmap/definitions/base.py
+++ b/lizmap/definitions/base.py
@@ -15,6 +15,7 @@ class InputType(Enum):
     CheckBox = 'CheckBox'  # QCheckbox
     CheckBoxAsDropdown = 'CheckBoxAsDropdown'  # QComboBox with only two options
     Field = 'Field'  # QgsFieldComboBox
+    PrimaryKeyField = 'PrimaryKeyField'  # QgsFieldComboBox, enabled if not coming from a database (SQlite, GPKG, PG)
     Fields = 'Fields'  # QListWidget then ListFieldsSelection, a custom widget in qgis_plugin_tools
     File = 'File'  # QgsFileWidget
     HtmlWysiwyg = 'HtmlWysiwyg'  # Own Lizmap Wysiwyg widget

--- a/lizmap/definitions/filter_by_polygon.py
+++ b/lizmap/definitions/filter_by_polygon.py
@@ -74,7 +74,7 @@ class FilterByPolygonDefinitions(BaseDefinitions):
             'tooltip': tr('The vector layer to filter.')
         }
         self._layer_config['primary_key'] = {
-            'type': InputType.Field,
+            'type': InputType.PrimaryKeyField,
             'header': tr('Primary key'),
             'tooltip': tr('Layer primary key.')
         }

--- a/lizmap/forms/atlas_edition.py
+++ b/lizmap/forms/atlas_edition.py
@@ -52,6 +52,7 @@ class AtlasEditionDialog(BaseEditionDialog, CLASS):
         self.layer.layerChanged.connect(self.primary_key.setLayer)
         self.layer.layerChanged.connect(self.feature_label.setLayer)
         self.layer.layerChanged.connect(self.sort_field.setLayer)
+        self.layer.layerChanged.connect(self.enable_primary_key_field)
 
         self.primary_key.setLayer(self.layer.currentLayer())
         self.feature_label.setLayer(self.layer.currentLayer())
@@ -59,6 +60,7 @@ class AtlasEditionDialog(BaseEditionDialog, CLASS):
 
         self.setup_ui()
         self.check_layer_wfs()
+        self.enable_primary_key_field()
 
     def check_layer_wfs(self):
         """ When the layer has changed in the combobox, check if the layer is published as WFS. """

--- a/lizmap/forms/attribute_table_edition.py
+++ b/lizmap/forms/attribute_table_edition.py
@@ -25,7 +25,7 @@ class AttributeTableEditionDialog(BaseEditionDialog, CLASS):
         self.setupUi(self)
         self.config = AttributeTableDefinitions()
         self.config.add_layer_widget('layerId', self.layer)
-        self.config.add_layer_widget('primaryKey', self.field_primary_key)
+        self.config.add_layer_widget('primaryKey', self.primary_key)
         self.config.add_layer_widget('hiddenFields', self.fields_to_hide)
         self.config.add_layer_widget('pivot', self.pivot_table)
         self.config.add_layer_widget('hideAsChild', self.hide_subpanels)
@@ -43,13 +43,15 @@ class AttributeTableEditionDialog(BaseEditionDialog, CLASS):
         self.layer.setFilters(QgsMapLayerProxyModel.VectorLayer)
         self.layer.layerChanged.connect(self.check_layer_wfs)
         self.layer.layerChanged.connect(self.layer_changed)
-        self.layer.layerChanged.connect(self.field_primary_key.setLayer)
-        self.field_primary_key.setLayer(self.layer.currentLayer())
+        self.layer.layerChanged.connect(self.primary_key.setLayer)
+        self.layer.layerChanged.connect(self.enable_primary_key_field)
+        self.primary_key.setLayer(self.layer.currentLayer())
         self.layer.layerChanged.connect(self.fields_to_hide.set_layer)
         self.fields_to_hide.set_layer(self.layer.currentLayer())
 
         self.setup_ui()
         self.check_layer_wfs()
+        self.enable_primary_key_field()
 
     def check_layer_wfs(self):
         """ When the layer has changed in the combobox, check if the layer is published as WFS. """
@@ -67,6 +69,7 @@ class AttributeTableEditionDialog(BaseEditionDialog, CLASS):
     def layer_changed(self):
         layer = self.layer.currentLayer()
         self.has_custom_config.setChecked(layer_has_custom_attribute_table(layer))
+        self.enable_primary_key_field()
 
     def validate(self) -> str:
         upstream = super().validate()
@@ -78,5 +81,5 @@ class AttributeTableEditionDialog(BaseEditionDialog, CLASS):
         if not_in_wfs:
             return not_in_wfs
 
-        if not self.field_primary_key.currentField():
+        if not self.primary_key.currentField():
             return tr('Primary key field is mandatory.')

--- a/lizmap/forms/filter_by_polygon.py
+++ b/lizmap/forms/filter_by_polygon.py
@@ -37,11 +37,13 @@ class FilterByPolygonEditionDialog(BaseEditionDialog, CLASS):
 
         self.layer.setFilters(QgsMapLayerProxyModel.VectorLayer)
         self.layer.layerChanged.connect(self.primary_key.setLayer)
+        self.layer.layerChanged.connect(self.enable_primary_key_field)
 
         self.primary_key.setAllowEmptyFieldName(False)
         self.primary_key.setLayer(self.layer.currentLayer())
 
         self.setup_ui()
+        self.enable_primary_key_field()
 
     def validate(self) -> str:
         layer = self.layer.currentLayer()

--- a/lizmap/resources/ui/ui_form_attribute_table.ui
+++ b/lizmap/resources/ui/ui_form_attribute_table.ui
@@ -34,7 +34,7 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QgsFieldComboBox" name="field_primary_key"/>
+      <widget class="QgsFieldComboBox" name="primary_key"/>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_fields_to_hide">

--- a/lizmap/table_manager/base.py
+++ b/lizmap/table_manager/base.py
@@ -278,7 +278,7 @@ class TableManager:
                 cell.setData(Qt.UserRole, value)
                 cell.setData(Qt.ToolTipRole, display)
 
-            elif input_type == InputType.Field:
+            elif input_type in (InputType.Field, InputType.PrimaryKeyField):
                 cell.setText(value)
                 cell.setData(Qt.UserRole, value)
                 cell.setData(Qt.ToolTipRole, value)
@@ -510,7 +510,7 @@ class TableManager:
                     layer = widget.currentLayer()
                     # The combobox might be empty, the layer me be deleted in the meantime
                     data['config'][config_key] = layer.id() if layer else None
-                elif input_type == InputType.Field:
+                elif input_type in (InputType.Field, InputType.PrimaryKeyField):
                     data['config'][config_key] = widget.currentField()
                 elif input_type == InputType.CheckBox:
                     data['config'][config_key] = widget.isChecked()
@@ -552,7 +552,7 @@ class TableManager:
                     layer_data[key] = cell
                 elif input_type == InputType.Color:
                     layer_data[key] = cell
-                elif input_type == InputType.Field:
+                elif input_type in (InputType.Field, InputType.PrimaryKeyField):
                     layer_data[key] = cell
                 elif input_type == InputType.Fields:
                     layer_data[key] = cell
@@ -903,7 +903,7 @@ class TableManager:
                                 self.definitions.key(), config_key, value))
                     else:
                         settings.insert(0, Setting(widget, widget_type, vector_layer))
-                elif widget_type == InputType.Field:
+                elif widget_type in (InputType.Field, InputType.PrimaryKeyField):
                     settings.append(Setting(widget, widget_type, value))
                 elif widget_type in (InputType.CheckBox, InputType.CheckBoxAsDropdown):
                     settings.append(Setting(widget, widget_type, value))
@@ -914,7 +914,7 @@ class TableManager:
             for setting in settings:
                 if setting.type == InputType.Layer:
                     setting.widget.setLayer(setting.value)
-                elif setting.type == InputType.Field:
+                elif setting.type in (InputType.Field, InputType.PrimaryKeyField):
                     setting.widget.setField(setting.value)
                 elif setting.type == InputType.CheckBox:
                     setting.widget.setChecked(setting.value)
@@ -955,7 +955,7 @@ class TableManager:
                         layer_data[key] = value
                     elif definition['type'] == InputType.Layers:
                         layer_data[key] = value
-                    elif definition['type'] == InputType.Field:
+                    elif definition['type'] in (InputType.Field, InputType.PrimaryKeyField):
                         layer_data[key] = value
                     elif definition['type'] == InputType.Fields:
                         layer_data[key] = value


### PR DESCRIPTION
The primary key is asked in 3 tools : 

* atlas
* attribute table
* filter by polygon

Now, if the layer is database based (PG, SQLite or Geopackage), the datasource about the primary key will be set automatically in the CFG file.
The primary key widget will be enabled for other kind of layer.