### PR TITLE
Add buttons for the French orthophoto and plan

### DIFF
--- a/lizmap/definitions/definitions.py
+++ b/lizmap/definitions/definitions.py
@@ -4,6 +4,7 @@ __copyright__ = 'Copyright 2023, 3Liz'
 __license__ = 'GPL version 3'
 __email__ = 'info@3liz.org'
 
+from collections import namedtuple
 from enum import Enum, unique
 from functools import total_ordering
 
@@ -119,3 +120,12 @@ class PredefinedGroup(Enum):
     Baselayers = Qt.UserRole + 2
     BackgroundColor = Qt.UserRole + 3
     Overview = Qt.UserRole + 4
+
+
+IgnLayer = namedtuple('IgnLayer', ['name', 'title', 'format'])
+
+
+class IgnLayers(IgnLayer, Enum):
+    """ IGN layers available. """
+    IgnPlan = IgnLayer('GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2', 'Plan IGN', 'image/png')
+    IgnOrthophoto = IgnLayer('ORTHOIMAGERY.ORTHOPHOTOS', 'Orthophoto IGN', 'image/jpeg')

--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -2505,7 +2505,11 @@ class Lizmap:
     def add_osm_mapnik(self):
         """ Add the OSM mapnik base layer. """
         source = 'type=xyz&url=https://tile.openstreetmap.org/{z}/{x}/{y}.png&zmax=19&zmin=0'
-        self._add_base_layer(source, 'OpenStreetMap')
+        self._add_base_layer(
+            source,
+            'OpenStreetMap',
+            'https://openstreetmap.org',
+            '© ' + tr('OpenStreetMap contributors'))
 
     def add_french_ign_layer(self, layer: IgnLayer):
         """ Add some French IGN layers. """
@@ -2520,12 +2524,16 @@ class Lizmap:
         }
         # Do not use urlencode
         source = '&'.join(['{}={}'.format(k, v) for k, v in params.items()])
-        self._add_base_layer(source, layer.title)
+        self._add_base_layer(source, layer.title, 'https://www.ign.fr/', 'IGN France')
 
-    def _add_base_layer(self, source: str, name: str):
+    def _add_base_layer(self, source: str, name: str, attribution_url: str = None, attribution_name: str = None):
         """ Add a base layer to the "baselayers" group. """
         self.add_group_baselayers()
         raster = QgsRasterLayer(source, name, 'wms')
+        if attribution_url:
+            raster.setAttributionUrl(attribution_url)
+        if attribution_name:
+            raster.setAttribution(attribution_name)
         root_group = self.project.layerTreeRoot()
 
         groups = root_group.findGroups()

--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -74,6 +74,8 @@ from lizmap.definitions.definitions import (
     DURATION_WARNING_BAR,
     UNSTABLE_VERSION_PREFIX,
     Html,
+    IgnLayer,
+    IgnLayers,
     LayerProperties,
     LwcVersions,
     PredefinedGroup,
@@ -206,7 +208,8 @@ class Lizmap:
 
         setup_logger(plugin_name())
 
-        _, file_path = setup_translation('lizmap_qgis_plugin_{}.qm', plugin_path('i18n'))
+        locale, file_path = setup_translation('lizmap_qgis_plugin_{}.qm', plugin_path('i18n'))
+        LOGGER.info("Language in QGIS : {}".format(locale))
 
         if file_path:
             self.translator = QTranslator()
@@ -244,6 +247,16 @@ class Lizmap:
 
             self.dlg.setWindowTitle('Lizmap branch {}, commit {}, next {}'.format(
                 self.version, current_git_hash(), next_git_tag()))
+
+        # Make the IGN french orthophoto visible only for dev or for French language user
+        # locale can be "fr" or "fr_FR"
+        french_buttons = (
+            self.dlg.button_ign_orthophoto,
+            self.dlg.button_ign_plan,
+        )
+        for button in french_buttons:
+            button.setVisible(locale[0:2].lower() == 'fr' or self.is_dev_version)
+            button.setIcon(QIcon(':images/flags/fr.svg'))
 
         if Qgis.QGIS_VERSION_INT >= 32200:
             self.webdav = WebDav()
@@ -421,8 +434,6 @@ class Lizmap:
         self.dlg.cbOsmStamenToner.setToolTip(tr(
             'This base-layer is now deprecated by Stamen, see https://stamen.com/faq how to migrate. The base layer '
             'will be deactivated automatically when saving the CFG file.'))
-        # Hiding the button, until we find another good layer without any key
-        self.dlg.button_stamen_toner_lite.setVisible(False)
 
         self.layer_options_list = lizmap_config.layerOptionDefinitions
         # Add widget information
@@ -520,7 +531,10 @@ class Lizmap:
         self.dlg.add_group_overview.clicked.connect(self.add_group_overview)
 
         self.dlg.button_osm_mapnik.clicked.connect(self.add_osm_mapnik)
-        self.dlg.button_stamen_toner_lite.clicked.connect(self.add_stamen_toner_lite)
+        self.dlg.button_ign_orthophoto.clicked.connect(
+            partial(self.add_french_ign_layer, IgnLayers.IgnOrthophoto))
+        self.dlg.button_ign_plan.clicked.connect(
+            partial(self.add_french_ign_layer, IgnLayers.IgnPlan))
 
         self.dlg.label_lizmap_search_grant.setText(tr(
             "About \"lizmap_search\", for an instance hosted on lizmap.com cloud solution, you must do the \"GRANT\" "
@@ -2493,10 +2507,20 @@ class Lizmap:
         source = 'type=xyz&url=https://tile.openstreetmap.org/{z}/{x}/{y}.png&zmax=19&zmin=0'
         self._add_base_layer(source, 'OpenStreetMap')
 
-    def add_stamen_toner_lite(self):
-        """ Add the Stamen Toner lite base layer. """
-        source = 'type=xyz&zmin=0&zmax=20&url=https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png'
-        self._add_base_layer(source, 'Stamen Toner Lite')
+    def add_french_ign_layer(self, layer: IgnLayer):
+        """ Add some French IGN layers. """
+        params = {
+            'crs': 'EPSG:3857',
+            'dpiMode': 7,
+            'format': layer.format,
+            'layers': layer.name,
+            'styles': 'normal',
+            'tileMatrixSet': 'PM',
+            'url': 'https://data.geopf.fr/wmts?SERVICE%3DWMTS%26VERSION%3D1.0.0%26REQUEST%3DGetCapabilities',
+        }
+        # Do not use urlencode
+        source = '&'.join(['{}={}'.format(k, v) for k, v in params.items()])
+        self._add_base_layer(source, layer.title)
 
     def _add_base_layer(self, source: str, name: str):
         """ Add a base layer to the "baselayers" group. """

--- a/lizmap/resources/ui/ui_lizmap.ui
+++ b/lizmap/resources/ui/ui_lizmap.ui
@@ -2691,9 +2691,16 @@ This is different to the map maximum extent (defined in QGIS project properties,
                         </widget>
                        </item>
                        <item>
-                        <widget class="QPushButton" name="button_stamen_toner_lite">
+                        <widget class="QPushButton" name="button_ign_orthophoto">
                          <property name="text">
-                          <string>Stamen Toner Lite</string>
+                          <string notr="true">IGN Orthophoto</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QPushButton" name="button_ign_plan">
+                         <property name="text">
+                          <string notr="true">IGN Plan</string>
                          </property>
                         </widget>
                        </item>


### PR DESCRIPTION
* Recycling the deprecated button stamen to the French orthophoto
* Visible only for developers or French QGIS user
* #471 and https://github.com/3liz/lizmap-web-client/issues/3591

* [x] Add source in metadata