### PR TITLE
UX - Add a new dock for HTML maptip preview

### DIFF
--- a/lizmap/dialogs/dock_html_preview.py
+++ b/lizmap/dialogs/dock_html_preview.py
@@ -1,0 +1,182 @@
+__copyright__ = 'Copyright 2023, 3Liz'
+__license__ = 'GPL version 3'
+__email__ = 'info@3liz.org'
+
+import logging
+
+from qgis.core import (
+    Qgis,
+    QgsApplication,
+    QgsExpression,
+    QgsExpressionContext,
+    QgsExpressionContextUtils,
+    QgsMapLayerProxyModel,
+    QgsProject,
+)
+
+if Qgis.QGIS_VERSION_INT >= 31400:
+    from qgis.gui import QgsFeaturePickerWidget
+
+from qgis.gui import QgsMapLayerComboBox
+from qgis.PyQt.QtCore import QDateTime, QLocale, QUrl
+from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtWidgets import (
+    QDockWidget,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+from qgis.utils import iface
+
+from lizmap.qgis_plugin_tools.tools.i18n import tr
+from lizmap.qgis_plugin_tools.tools.resources import resources_path
+
+try:
+    from qgis.PyQt.QtWebKitWidgets import QWebView
+    WEBKIT_AVAILABLE = True
+except ModuleNotFoundError:
+    WEBKIT_AVAILABLE = False
+
+LOGGER = logging.getLogger('Lizmap')
+
+
+class HtmlPreview(QDockWidget):
+
+    # noinspection PyArgumentList
+    def __init__(self, parent, *__args):
+        """ Constructor. """
+        super().__init__(parent, *__args)
+        self.setWindowTitle("Lizmap HTML Maptip Preview")
+
+        self._server_url = None
+
+        self.dock = QWidget(parent)
+        self.layout = QVBoxLayout(self.dock)
+
+        if Qgis.QGIS_VERSION_INT < 31400:
+            self.label = QLabel('You must install at least QGIS 3.14')
+            self.label.setWordWrap(True)
+            self.layout.addWidget(self.label)
+            return
+
+        if not WEBKIT_AVAILABLE:
+            self.label = QLabel(tr('You must install Qt Webkit to enable this feature.'))
+        else:
+            self.label = QLabel(tr("This only a preview of the HTML maptip. Lizmap will add more CSS classes."))
+
+        self.label.setWordWrap(True)
+        self.layout.addWidget(self.label)
+
+        if not WEBKIT_AVAILABLE:
+            return
+
+        horizontal = QHBoxLayout(self.dock)
+
+        self.layer = QgsMapLayerComboBox(self.dock)
+        horizontal.addWidget(self.layer)
+
+        self.feature = QgsFeaturePickerWidget(self.dock)
+        horizontal.addWidget(self.feature)
+
+        self.layout.addLayout(horizontal)
+
+        horizontal = QHBoxLayout(self.dock)
+
+        self.refresh = QPushButton(self.dock)
+        self.refresh.setIcon(QIcon(QgsApplication.iconPath('mActionRefresh.svg')))
+        # noinspection PyUnresolvedReferences
+        self.refresh.clicked.connect(self.update_html)
+        horizontal.addWidget(self.refresh)
+
+        self.label = QLabel()
+        horizontal.addWidget(self.label)
+
+        self.layout.addLayout(horizontal)
+
+        self.web_view = QWebView(self.dock)
+        size_policy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.MinimumExpanding)
+        size_policy.setHorizontalStretch(0)
+        size_policy.setVerticalStretch(0)
+        size_policy.setHeightForWidth(self.web_view.sizePolicy().hasHeightForWidth())
+        self.web_view.setSizePolicy(size_policy)
+        self.layout.addWidget(self.web_view)
+
+        self.setWidget(self.dock)
+
+        self.layer.setFilters(QgsMapLayerProxyModel.VectorLayer)
+        # noinspection PyUnresolvedReferences
+        self.layer.layerChanged.connect(self.current_layer_changed)
+        self.current_layer_changed()
+        # noinspection PyUnresolvedReferences
+        self.feature.featureChanged.connect(self.update_html)
+        self.feature.setShowBrowserButtons(True)
+
+        # We don't have a better signal to listen to
+        QgsProject.instance().dirtySet.connect(self.update_html)
+
+        self.update_html()
+
+    def set_server_url(self, url: str):
+        """ Set the server URL according to the main dialog. """
+        if not url.endswith('/'):
+            url += '/'
+        self._server_url = url
+
+    def css(self) -> str:
+        """ Link to CSS style sheet according to server. """
+        asset = 'assets/css/bootstrap.min.css'
+        return self._server_url + asset
+
+    def current_layer_changed(self):
+        """ When the layer has changed. """
+        self.feature.setLayer(self.layer.currentLayer())
+        # Need to disconnect all layers before ?
+        # self.layer.currentLayer().repaintRequested.connect(self.update_html())
+
+    # noinspection PyArgumentList
+    def update_html(self):
+        """ Update the HTML preview. """
+        # This function is called when the project is "setDirty",
+        # because it means maybe the vector layer properties has been "applied"
+
+        if not self.isVisible():
+            # If the dock is not visible, we don't care
+            return
+
+        layer = self.layer.currentLayer()
+        if not layer:
+            return
+
+        if iface.activeLayer() != layer:
+            # This function is called when the project is "setDirty",
+            # because it means maybe the vector layer properties has been "applied"
+            return
+
+        feature = self.feature.feature()
+        if not feature:
+            return
+
+        now = QDateTime.currentDateTime()
+        now_str = now.toString(QLocale.c().timeFormat(QLocale.ShortFormat))
+        self.label.setText(tr("Last update") + " " + now_str)
+
+        exp_context = QgsExpressionContext()
+        exp_context.appendScope(QgsExpressionContextUtils.globalScope())
+        exp_context.appendScope(QgsExpressionContextUtils.projectScope(QgsProject.instance()))
+        exp_context.appendScope(QgsExpressionContextUtils.layerScope(layer))
+        exp_context.setFeature(feature)
+        html_string = QgsExpression.replaceExpressionText(layer.mapTipTemplate(), exp_context)
+        base_url = QUrl.fromLocalFile(resources_path('images', 'non_existing_file.png'))
+
+        with open(resources_path('html', 'maptip_preview.html'), encoding='utf8') as f:
+            html_template = f.read()
+
+        html_content = html_template.format(
+            css=self.css(),
+            maptip=html_string,
+        )
+
+        self.web_view.setHtml(html_content, base_url)

--- a/lizmap/resources/html/maptip_preview.html
+++ b/lizmap/resources/html/maptip_preview.html
@@ -1,0 +1,6 @@
+<head>
+    <link type="text/css" href="{css}" rel="stylesheet" />
+</head>
+<body>
+    {maptip}
+</body>

--- a/lizmap/resources/ui/ui_lizmap.ui
+++ b/lizmap/resources/ui/ui_lizmap.ui
@@ -1736,6 +1736,13 @@ This is different to the map maximum extent (defined in QGIS project properties,
                             </widget>
                            </item>
                            <item>
+                            <widget class="QPushButton" name="button_maptip_preview">
+                             <property name="text">
+                              <string notr="true">PREVIEW</string>
+                             </property>
+                            </widget>
+                           </item>
+                           <item>
                             <spacer name="horizontalSpacer_2">
                              <property name="orientation">
                               <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
* Quite slow to use the native HTML maptip in QGIS over the map
* The native display in QGIS is narrow and truncated vertically
* Even with the new feature in QGIS 3.32 https://changelog.qgis.org/en/qgis/version/3.32/#map-tip-preview
* This viewer has the Lizmap bootstrap CSS included


![preview](https://github.com/3liz/lizmap-plugin/assets/1609292/3879c0fe-1fa4-47bd-b8a1-f862f9c845f9)
