### PR TITLE
Use native QGIS widget for extent, follow project projection

### DIFF
--- a/lizmap/dialogs/dock_html_preview.py
+++ b/lizmap/dialogs/dock_html_preview.py
@@ -28,6 +28,7 @@ from qgis.utils import iface
 
 from lizmap.qgis_plugin_tools.tools.i18n import tr
 from lizmap.qgis_plugin_tools.tools.resources import resources_path
+from lizmap.tools import qgis_version
 
 try:
     from qgis.PyQt.QtWebKitWidgets import QWebView
@@ -103,8 +104,9 @@ class HtmlPreview(QDockWidget):
         self.feature.featureChanged.connect(self.update_html)
         self.feature.setShowBrowserButtons(True)
 
-        # We don't have a better signal to listen to
-        QgsProject.instance().dirtySet.connect(self.update_html)
+        if qgis_version() >= 32000:
+            # We don't have a better signal to listen to
+            QgsProject.instance().dirtySet.connect(self.update_html)
 
         self.update_html()
 

--- a/lizmap/dialogs/main.py
+++ b/lizmap/dialogs/main.py
@@ -95,6 +95,15 @@ class LizmapDialog(QDialog, FORM_CLASS):
         pixmap = pixmap.scaled(100, 100, Qt.KeepAspectRatio)
         self.label_lizmap_logo.setPixmap(pixmap)
 
+        # Initial extent widget
+        if qgis_version() >= 31800:
+            self.widget_initial_extent.setMapCanvas(iface.mapCanvas(), False)
+        else:
+            self.widget_initial_extent.setMapCanvas(iface.mapCanvas())
+        self.widget_initial_extent.setOutputCrs(self.project.crs())
+        self.widget_initial_extent.setOriginalExtent(iface.mapCanvas().extent(), self.project.crs())
+        self.project.crsChanged.connect(self.project_crs_changed)
+
         if WEBKIT_AVAILABLE:
             self.dataviz_viewer = QWebView()
         else:
@@ -339,6 +348,10 @@ class LizmapDialog(QDialog, FORM_CLASS):
     @property
     def check_results(self) -> TableCheck:
         return self.table_checks
+
+    def project_crs_changed(self):
+        """ When the project CRS has changed.   """
+        self.widget_initial_extent.setOutputCrs(self.project.crs())
 
     @staticmethod
     def open_pg_service_help():

--- a/lizmap/lizmap_api/config.py
+++ b/lizmap/lizmap_api/config.py
@@ -62,7 +62,7 @@ class LizmapConfig:
                 'wType': 'text', 'type': 'list', 'default': []
             },
             'initialExtent': {
-                'wType': 'text', 'type': 'floatlist', 'default': []
+                'wType': 'extent', 'type': 'floatlist', 'default': []
             },
             'googleKey': {
                 'wType': 'text', 'type': 'string', 'default': ''

--- a/lizmap/resources/ui/ui_lizmap.ui
+++ b/lizmap/resources/ui/ui_lizmap.ui
@@ -1084,49 +1084,10 @@ This is different to the map maximum extent (defined in QGIS project properties,
                    </widget>
                   </item>
                   <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_20">
-                    <item>
-                     <widget class="QLabel" name="label_24">
-                      <property name="text">
-                       <string>Extent</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLineEdit" name="inInitialExtent">
-                      <property name="readOnly">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
+                   <widget class="QgsExtentWidget" name="widget_initial_extent" native="true"/>
                   </item>
                   <item>
                    <layout class="QHBoxLayout" name="horizontalLayout_19">
-                    <item>
-                     <widget class="QLabel" name="label_62">
-                      <property name="text">
-                       <string>Set the extent from</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="btSetExtentFromProject">
-                      <property name="toolTip">
-                       <string>In the project properties, then QGIS server tab, WMS section, there is an advertised extent</string>
-                      </property>
-                      <property name="text">
-                       <string>project properties, QGIS server tab</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="btSetExtentFromCanvas">
-                      <property name="text">
-                       <string>map canvas</string>
-                      </property>
-                     </widget>
-                    </item>
                     <item>
                      <spacer name="horizontalSpacer_17">
                       <property name="orientation">
@@ -1139,6 +1100,16 @@ This is different to the map maximum extent (defined in QGIS project properties,
                        </size>
                       </property>
                      </spacer>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="btSetExtentFromProject">
+                      <property name="toolTip">
+                       <string>In the project properties, then QGIS server tab, WMS section, there is an advertised extent</string>
+                      </property>
+                      <property name="text">
+                       <string>Set the extent from project properties, QGIS server tab</string>
+                      </property>
+                     </widget>
                     </item>
                    </layout>
                   </item>
@@ -5094,6 +5065,12 @@ This is different to the map maximum extent (defined in QGIS project properties,
    <extends>QTableWidget</extends>
    <header>lizmap.widgets.check_project</header>
   </customwidget>
+  <customwidget>
+   <class>QgsExtentWidget</class>
+   <extends>QWidget</extends>
+   <header>qgis.gui</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mOptionsListWidget</tabstop>
@@ -5113,9 +5090,7 @@ This is different to the map maximum extent (defined in QGIS project properties,
   <tabstop>inMapScales</tabstop>
   <tabstop>inMinScale</tabstop>
   <tabstop>inMaxScale</tabstop>
-  <tabstop>inInitialExtent</tabstop>
   <tabstop>btSetExtentFromProject</tabstop>
-  <tabstop>btSetExtentFromCanvas</tabstop>
   <tabstop>cbHideHeader</tabstop>
   <tabstop>cbHideMenu</tabstop>
   <tabstop>cbHideLegend</tabstop>

--- a/lizmap/test/test_ui.py
+++ b/lizmap/test/test_ui.py
@@ -101,7 +101,7 @@ class TestUiLizmapDialog(unittest.TestCase):
         # as it will be called by read_cfg_file and also the UI is set in read_cfg_file
         config = lizmap.read_cfg_file(skip_tables=True)
 
-        lizmap.set_initial_extent_from_canvas()
+        lizmap.dlg.widget_initial_extent.setOutputExtentFromLayer(layer)
 
         # Config is empty in the CFG file because it's a new project
         self.assertDictEqual({}, config)


### PR DESCRIPTION
After the previous PR #534 we can now use the native QGIS widget for the extent

The output CRS will automatically follow QGIS project projection

The user will have more options to set the initial extent

