### PR TITLE
Check for inverted axis in project CRS

### DIFF
--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -2885,6 +2885,11 @@ class Lizmap:
             if to_bool(use_layer_id, False):
                 self.dlg.check_results.add_error(Error(Path(self.project.fileName()).name, checks.WmsUseLayerIds))
 
+        if lwc_version >= LwcVersions.Lizmap_3_7:
+            if self.project.crs().hasAxisInverted():
+                # https://github.com/3liz/lizmap-web-client/issues/4191
+                self.dlg.check_results.add_error(Error(Path(self.project.fileName()).name, checks.CrsInvertedAxis))
+
         target_status = self.dlg.server_combo.currentData(ServerComboData.LwcBranchStatus.value)
         if not target_status:
             target_status = ReleaseStatus.Unknown

--- a/lizmap/widgets/check_project.py
+++ b/lizmap/widgets/check_project.py
@@ -440,6 +440,24 @@ class Checks:
             Severities().blocking,
             QIcon(':/images/themes/default/mIconNoPyramid.svg'),
         )
+        self.CrsInvertedAxis = Check(
+            'crs_has_inverted_axis',
+            tr('The project CRS has inverted axis'),
+            tr(
+                "The current project CRS has inverted axis. Due to a bug in the stack between QGIS Server, Proj4js, "
+                "OpenLayers 8 and Lizmap Web Client ≥ 3.7, using a CRS with inverted axis is discouraged. Tiles might "
+                "be transparent."),
+            (
+                '<ul>'
+                '<li>{}</li>'
+                '</ul>'
+            ).format(
+                tr('Switch to a CRS having not inverted axis.'),
+            ),
+            Levels.Project,
+            Severities().important,
+            QIcon(':/images/themes/default/propertyicons/CRS.svg'),
+        )
         self.MissingWfsLayer = Check(
             'layer_not_in_wfs',
             tr('Layer not published in the WFS'),


### PR DESCRIPTION
Until the regression is identified, it's better to warn users having inverted axis

Linked to https://github.com/3liz/lizmap-web-client/issues/4191

When the bug is fixed, this check will be removed

CC @aeduard