### PR TITLE
CFG - Add new key for default-background-color

### DIFF
--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -2432,6 +2432,9 @@ class Lizmap:
     @staticmethod
     def existing_group(root_group: QgsLayerTree, label: str) -> Optional[QgsLayerTreeGroup]:
         """ Return the existing group in the legend if existing. """
+        if not root_group:
+            return None
+
         groups = root_group.findGroups()
         for qgis_group in groups:
             qgis_group: QgsLayerTreeGroup
@@ -3478,6 +3481,11 @@ class Lizmap:
         if self.drag_drop_dataviz:
             # In tests, we don't have the variable set
             liz2json['options']['dataviz_drag_drop'] = self.drag_drop_dataviz.to_json()
+
+        if self.existing_group(
+                self.existing_group(
+                    self.project.layerTreeRoot(), GroupNames.BaseLayers), GroupNames.BackgroundColor):
+            liz2json["options"]["default_background_color"] = True
 
         if not isinstance(self.layerList, dict):
             # Wierd bug when the dialog was not having a server at the beginning

--- a/lizmap/test/test_postgresql.py
+++ b/lizmap/test/test_postgresql.py
@@ -42,7 +42,7 @@ except ImportError:
     PG_USER = ''
     PG_DATABASE = ''
 
-if CREDENTIALS:
+if CREDENTIALS and not os.getenv("CI"):
     # Because on Desktop
     from qgis.testing import start_app
     start_app()

--- a/lizmap/test/test_ui.py
+++ b/lizmap/test/test_ui.py
@@ -89,6 +89,8 @@ class TestUiLizmapDialog(unittest.TestCase):
         self.assertEqual(output['layers']['legend_displayed_startup']['legend_image_option'], 'expand_at_startup')
         self.assertIsNone(output['layers']['legend_displayed_startup'].get('noLegendImage'))
 
+        self.assertIsNone(output['options'].get('default_background_color'))
+
         # For LWC 3.5
         output = lizmap.project_config_file(LwcVersions.Lizmap_3_5, with_gui=False, check_server=False, ignore_error=True)
         self.assertIsNone(output['layers']['legend_displayed_startup'].get('legend_image_option'))
@@ -191,6 +193,7 @@ class TestUiLizmapDialog(unittest.TestCase):
         self.assertEqual(output['layers']['baselayers']['abstract'], '')
         self.assertListEqual(output['layers']['project-background-color']['group_visibility'], [])
         self.assertEqual(output['layers']['project-background-color']['abstract'], '')
+        self.assertTrue(output['options'].get('default_background_color'))
 
         # Test a false value as a string which shouldn't be there by default
         self.assertIsNone(output['layers']['lines'].get('externalWmsToggle'))


### PR DESCRIPTION
Because we don't know the layer tree in the CFG about where is `default-background-color`,  to make the life easier

```json
"options": {"default_background_color" : True}
```