### PR TITLE
Check - Look for duplicated label within the legend, mainly rule base renderer

### DIFF
--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -136,6 +136,7 @@ from lizmap.project_checker_tools import (
     PREVENT_OTHER_DRIVE,
     PREVENT_SERVICE,
     count_legend_items,
+    duplicated_label_legend,
     duplicated_layer_name_or_group,
     duplicated_layer_with_filter_legend,
     duplicated_rule_key_legend,
@@ -3088,6 +3089,37 @@ class Lizmap:
                         self.dlg.log_panel.append(layer.name(), Html.Td)
                         self.dlg.log_panel.append(rule, Html.Td)
                         self.dlg.log_panel.append(count, Html.Td)
+                        self.dlg.log_panel.end_row()
+                        i += 1
+
+                self.dlg.log_panel.end_table()
+
+            results = duplicated_label_legend(self.project)
+            if results:
+                self.dlg.log_panel.append(tr("Duplicated labels in the legend"), Html.H2)
+                self.dlg.log_panel.append("<br>")
+                self.dlg.log_panel.start_table()
+                self.dlg.log_panel.append(
+                    "<tr><th>{}</th><th>{}</th></tr>".format(tr('Layer'), tr('Label'))
+                )
+
+                i = 0
+                for layer_id, rules in results.items():
+                    layer = self.project.mapLayer(layer_id)
+                    # Add one error per layer is enough
+                    self.dlg.check_results.add_error(
+                        Error(
+                            layer.name(),
+                            checks.DuplicatedRuleKeyLabelLegend,
+                            source_type=SourceLayer(layer.name(), layer.id()),
+                        )
+                    )
+
+                    # But explain inside each layer which keys are duplicated
+                    for rule in rules:
+                        self.dlg.log_panel.add_row(i)
+                        self.dlg.log_panel.append(layer.name(), Html.Td)
+                        self.dlg.log_panel.append(rule, Html.Td)
                         self.dlg.log_panel.end_row()
                         i += 1
 

--- a/lizmap/widgets/check_project.py
+++ b/lizmap/widgets/check_project.py
@@ -538,6 +538,27 @@ class Checks:
             Severities().important,
             QIcon(':/images/themes/default/rendererRuleBasedSymbol.svg'),
         )
+        self.DuplicatedRuleKeyLabelLegend = Check(
+            'duplicated_rule_key_label_legend',
+            tr('The layer has some duplicated "label" in its legend'),
+            tr(
+                "The layer should not have duplicated labels within its own legend. This is limitation on QGIS Server."
+            ), (
+                '<ul>'
+                '<li>{}</li>'
+                '<li>{}</li>'
+                '</ul>'
+            ).format(
+                tr(
+                    'Open the last tab in this panel, to have raw HTML logs, '
+                    'you have a table showing all duplicated keys'
+                ),
+                tr('Make these labels unique'),
+            ),
+            Levels.Layer,
+            Severities().important,
+            QIcon(':/images/themes/default/legend.svg'),
+        )
         self.DuplicatedLayerFilterLegend = Check(
             'duplicated_layers_with_different_filters',
             tr('Many layers next to each other having different filters.'),


### PR DESCRIPTION
A GetLegendGraphic as JSON is "flatten" within a layer.

This is causing duplicated rulekey.

See https://github.com/3liz/qgis-lizmap-server-plugin/pull/70

![image](https://github.com/3liz/lizmap-plugin/assets/1609292/c77124bd-6fb0-41ec-938f-24a70a52e28f)

