### PR TITLE
Enable again the embedded text input widget if the layer is in "baselayers"

### DIFF
--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -2542,7 +2542,6 @@ class Lizmap:
                 self.dlg.group_layer_tree_options.setEnabled(False)
                 self.dlg.checkbox_popup.setEnabled(False)
                 self.dlg.frame_layer_popup.setEnabled(False)
-                self.dlg.group_layer_embedded.setEnabled(False)
 
             elif self._current_item_predefined_group() in (
                     PredefinedGroup.Overview.value,


### PR DESCRIPTION
Fix #601


It has been tested successfully by @mind84
@rldhont @mdouchin Any drawbacks ?