### PR TITLE
Place text widget in right list

### DIFF
--- a/lizmap/tooltip.py
+++ b/lizmap/tooltip.py
@@ -211,7 +211,8 @@ class Tooltip:
                     a += h
                     continue
                 # If it is root children, store html in the right list
-                if isinstance(n, QgsAttributeEditorField):
+                if isinstance(n, QgsAttributeEditorField) or (isinstance(n, QgsAttributeEditorElement) and n.type() == 6):
+                    # TODO QGIS_VERSION_INT 3.30.0 Change the integer with the QGIS enum `Qgis.AttributeEditorType.TextElement`
                     if not headers:
                         before_tabs.append(h)
                     else:


### PR DESCRIPTION

* **Funded by**: Faunalia
* **Description**:
  If text widget is configured as a root children then it is stored in the `content_tabs` list instead of in `before_tabs` or `after_tabs` lists. On client side, if tabs are configured, then users see the text widget in all tabs as consequence.
