### PR TITLE
Two new scales when zooming : max scale for points or other geom

### DIFF
--- a/lizmap/dialogs/main.py
+++ b/lizmap/dialogs/main.py
@@ -1017,6 +1017,7 @@ class LizmapDialog(QDialog, FORM_CLASS):
             self.group_local_layers,
             self.group_project_status,
             self.group_links,
+            self.group_box_max_scale_zoom,
         )
         for widget in q_group_box:
             widget.setStyleSheet(COMPLETE_STYLE_SHEET)

--- a/lizmap/lizmap_api/config.py
+++ b/lizmap/lizmap_api/config.py
@@ -55,6 +55,12 @@ class LizmapConfig:
             'maxScale': {
                 'wType': 'text', 'type': 'integer', 'default': 1000000000
             },
+            'max_scale_points': {
+                'wType': 'scale', 'type': 'float', 'default': 5000.0
+            },
+            'max_scale_lines_polygons': {
+                'wType': 'scale', 'type': 'float', 'default': 5000.0
+            },
             'use_native_zoom_levels': {
                 'wType': 'checkbox', 'type': 'boolean', 'default': True,
                 'always_export': True, 'use_proper_boolean': True,
@@ -169,6 +175,7 @@ class LizmapConfig:
                     ),
                 ],
             },
+            # Deprecated, it has been removed in LWC 3.8
             'zoomHistory': {
                 'wType': 'checkbox', 'type': 'boolean', 'default': False
             },

--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -458,6 +458,7 @@ class Lizmap:
             self.dlg.automatic_permalink,
         ]
         self.lwc_versions[LwcVersions.Lizmap_3_9] = [
+            self.dlg.group_box_max_scale_zoom,
         ]
         self.lwc_versions[LwcVersions.Lizmap_3_10] = [
         ]
@@ -473,6 +474,8 @@ class Lizmap:
         # self.global_options['mapScales']['widget'] = self.dlg.list_map_scales
         # self.global_options['minScale']['widget'] = self.dlg.minimum_scale
         # self.global_options['maxScale']['widget'] = self.dlg.maximum_scale
+        self.global_options['max_scale_points']['widget'] = self.dlg.max_scale_points
+        self.global_options['max_scale_lines_polygons']['widget'] = self.dlg.max_scale_lines_polygons
         self.global_options['hide_numeric_scale_value']['widget'] = self.dlg.hide_scale_value
         self.global_options['acl']['widget'] = self.dlg.inAcl
         self.global_options['initialExtent']['widget'] = self.dlg.widget_initial_extent
@@ -1862,6 +1865,16 @@ class Lizmap:
                     item['widget'].setChecked(item['default'])
                     if key in json_options:
                         item['widget'].setChecked(to_bool(json_options[key]))
+
+                if item['wType'] == 'scale':
+                    item['widget'].setShowCurrentScaleButton(True)
+                    item['widget'].setMapCanvas(self.iface.mapCanvas())
+                    item['widget'].setAllowNull(False)
+                    value = json_options.get(key)
+                    if value:
+                        item['widget'].setScale(value)
+                    else:
+                        item['widget'].setScale(item['default'])
 
                 if item['wType'] in ('text', 'textarea'):
                     if isinstance(item['default'], (list, tuple)):
@@ -3719,6 +3732,12 @@ class Lizmap:
                 # Get field value depending on widget type
                 if item['wType'] == 'text':
                     input_value = item['widget'].text().strip(' \t')
+
+                if item['wType'] == 'scale':
+                    input_value = item['widget'].scale()
+                    if input_value == item['default']:
+                        # Only save if different from the default value
+                        continue
 
                 if item['wType'] == 'wysiwyg':
                     input_value = item['widget'].html_content().strip(' \t')

--- a/lizmap/resources/ui/ui_lizmap.ui
+++ b/lizmap/resources/ui/ui_lizmap.ui
@@ -1132,6 +1132,20 @@ QListWidget::item::selected {
                   <string>Scales</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_3">
+                  <item row="2" column="0">
+                   <widget class="QCheckBox" name="use_native_scales">
+                    <property name="text">
+                     <string>Use native scales according to the project CRS (better display)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QCheckBox" name="hide_scale_value">
+                    <property name="text">
+                     <string>Hide numeric scale value</string>
+                    </property>
+                   </widget>
+                  </item>
                   <item row="0" column="0">
                    <widget class="QLabel" name="label_17">
                     <property name="text">
@@ -1139,12 +1153,8 @@ QListWidget::item::selected {
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="0">
-                   <widget class="QCheckBox" name="use_native_scales">
-                    <property name="text">
-                     <string>Use native scales according to the project CRS (better display)</string>
-                    </property>
-                   </widget>
+                  <item row="4" column="0">
+                   <widget class="WarningWidget" name="scales_warning" native="true"/>
                   </item>
                   <item row="7" column="0">
                    <layout class="QFormLayout" name="formLayout_6">
@@ -1236,14 +1246,41 @@ QListWidget::item::selected {
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="0">
-                   <widget class="WarningWidget" name="scales_warning" native="true"/>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QCheckBox" name="hide_scale_value">
-                    <property name="text">
-                     <string>Hide numeric scale value</string>
+                  <item row="8" column="0">
+                   <widget class="QGroupBox" name="group_box_max_scale_zoom">
+                    <property name="title">
+                     <string>Maximum scale when zooming on a feature</string>
                     </property>
+                    <layout class="QFormLayout" name="formLayout_9">
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="label_max_scale_points">
+                       <property name="text">
+                        <string>Points</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="1">
+                      <widget class="QgsScaleWidget" name="max_scale_points">
+                       <property name="showCurrentScaleButton">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QLabel" name="label_max_scale_polygons">
+                       <property name="text">
+                        <string>Lines/polygons</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <widget class="QgsScaleWidget" name="max_scale_lines_polygons">
+                       <property name="showCurrentScaleButton">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
                    </widget>
                   </item>
                  </layout>
@@ -5512,6 +5549,11 @@ This is different to the map maximum extent (defined in QGIS project properties,
   <customwidget>
    <class>QgsMapLayerComboBox</class>
    <extends>QComboBox</extends>
+   <header>qgis.gui</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScaleWidget</class>
+   <extends>QWidget</extends>
    <header>qgis.gui</header>
   </customwidget>
   <customwidget>

--- a/lizmap/test/test_ui.py
+++ b/lizmap/test/test_ui.py
@@ -198,6 +198,24 @@ class TestUiLizmapDialog(unittest.TestCase):
         self.assertIsNone(output['layers']['lines'].get('externalWmsToggle'))
         self.assertIsNone(output['layers']['lines'].get('metatileSize'))
 
+    def test_max_scale_lwc_3_7(self):
+        """ Test about maximum scale when zooming. """
+        lizmap = self._setup_empty_project(LwcVersions.Lizmap_3_6)
+
+        self.assertEqual(5000.0, lizmap.dlg.max_scale_points.scale())
+        self.assertEqual(5000.0, lizmap.dlg.max_scale_lines_polygons.scale())
+
+        # Max scale when zoomin
+        # Only points with a different value
+        lizmap.dlg.max_scale_points.setScale(1000.0)
+
+        # Check new values in the output config
+        output = lizmap.project_config_file(LwcVersions.latest(), check_server=False, ignore_error=True)
+
+        # Check scales in the CFG
+        self.assertEqual(1000.0, output['options']['max_scale_points'])
+        self.assertIsNone(output['options'].get('max_scale_lines_polygons'))
+
     def test_general_scales_properties_lwc_3_6(self):
         """ Test some UI settings about general properties with LWC 3.6. """
         lizmap = self._setup_empty_project(LwcVersions.Lizmap_3_6)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e81c4291-89e3-4d43-9364-8960b4a1a0ec)

* **Funded by**: [CC Bièvre Est](https://www.bievre-est.fr/)
* **Description**:
  * Two new scales when zooming : max scale for points or other geom


If the value in the widget is the same as the default, it's not written in the CFG file, to avoid not needed keys.
@nboisteault What do you think 5000.0 ?
