### PR TITLE
Qt6 - Change Qt.UserRole to Qt.ItemDataRole.UserRole

### DIFF
--- a/lizmap/definitions/definitions.py
+++ b/lizmap/definitions/definitions.py
@@ -168,30 +168,30 @@ class Html(Enum):
 @unique
 class ServerComboData(Enum):
     """ The server combobox. """
-    AuthId = Qt.UserRole  # String with the authentication ID
-    ServerUrl = Qt.UserRole + 1  # String with the server URL
-    JsonMetadata = Qt.UserRole + 2  # JSON from the server, raw
-    # LwcVersion = Qt.UserRole + 3  # Enum item with the LWC version
-    LwcBranchStatus = Qt.UserRole + 4  # Enum item about the release status at that time.
-    MarkDown = Qt.UserRole + 5  # Markdown for the server
+    AuthId = Qt.ItemDataRole.UserRole  # String with the authentication ID
+    ServerUrl = Qt.ItemDataRole.UserRole + 1  # String with the server URL
+    JsonMetadata = Qt.ItemDataRole.UserRole + 2  # JSON from the server, raw
+    # LwcVersion = Qt.ItemDataRole.UserRole + 3  # Enum item with the LWC version
+    LwcBranchStatus = Qt.ItemDataRole.UserRole + 4  # Enum item about the release status at that time.
+    MarkDown = Qt.ItemDataRole.UserRole + 5  # Markdown for the server
 
 
 @unique
 class RepositoryComboData(Enum):
     """ The repository combobox. """
-    Id = Qt.UserRole  # ID of the repository
-    Path = Qt.UserRole + 1  # Path on the server
+    Id = Qt.ItemDataRole.UserRole  # ID of the repository
+    Path = Qt.ItemDataRole.UserRole + 1  # Path on the server
 
 
 @unique
 class PredefinedGroup(Enum):
     """ The list of predefined group in LWC. """
-    No = Qt.UserRole                    # 256
-    Hidden = Qt.UserRole + 1            # 257
-    Baselayers = Qt.UserRole + 2        # 258 The group `baselayers`
-    BackgroundColor = Qt.UserRole + 3   # 259
-    Overview = Qt.UserRole + 4          # 260
-    BaselayerItem = Qt.UserRole + 5     # 261 Layer or group in the `baselayers`, which will be an item in the combobox
+    No = Qt.ItemDataRole.UserRole                    # 256
+    Hidden = Qt.ItemDataRole.UserRole + 1            # 257
+    Baselayers = Qt.ItemDataRole.UserRole + 2        # 258 The group `baselayers`
+    BackgroundColor = Qt.ItemDataRole.UserRole + 3   # 259
+    Overview = Qt.ItemDataRole.UserRole + 4          # 260
+    BaselayerItem = Qt.ItemDataRole.UserRole + 5     # 261 Layer or group in the `baselayers`, which will be an item in the combobox
 
 
 class GroupNames:

--- a/lizmap/dialogs/main.py
+++ b/lizmap/dialogs/main.py
@@ -105,7 +105,7 @@ class LizmapDialog(QDialog, FORM_CLASS):
         self.label_lizmap_logo.setText('')
         pixmap = QPixmap(resources_path('icons', 'logo.png'))
         # noinspection PyUnresolvedReferences
-        pixmap = pixmap.scaled(100, 100, Qt.KeepAspectRatio)
+        pixmap = pixmap.scaled(100, 100, Qt.AspectRatioMode.KeepAspectRatio)
         self.label_lizmap_logo.setPixmap(pixmap)
 
         # Initial extent widget
@@ -697,7 +697,7 @@ class LizmapDialog(QDialog, FORM_CLASS):
         url = self.server_combo.itemData(index, ServerComboData.ServerUrl.value)
         metadata = self.server_combo.itemData(index, ServerComboData.JsonMetadata.value)
         if not metadata or not metadata.get('info'):
-            self.server_combo.setItemData(index, tr('No metadata about this server'), Qt.ToolTipRole)
+            self.server_combo.setItemData(index, tr('No metadata about this server'), Qt.ItemDataRole.ToolTipRole)
             return
 
         target_version = LwcVersions.find_from_metadata(metadata)
@@ -710,7 +710,7 @@ class LizmapDialog(QDialog, FORM_CLASS):
             '<b>URL</b> {}<br>'
             '<b>Target branch</b> {}'
         ).format(url, target_version)
-        self.server_combo.setItemData(index, msg, Qt.ToolTipRole)
+        self.server_combo.setItemData(index, msg, Qt.ItemDataRole.ToolTipRole)
 
     def refresh_combo_repositories(self):
         """ Refresh the combobox about repositories. """
@@ -766,7 +766,7 @@ class LizmapDialog(QDialog, FORM_CLASS):
             self.repository_combo.setItemData(
                 index,
                 "ID : {}<br>Path : {}".format(repository_id, repository_data['path']),
-                Qt.ToolTipRole)
+                Qt.ItemDataRole.ToolTipRole)
             self.repository_combo.setItemData(index, repository_data['path'], RepositoryComboData.Path.value)
 
         # Dirty hack to trigger webdav check in plugin.py
@@ -1201,13 +1201,13 @@ class LizmapDialog(QDialog, FORM_CLASS):
 
             if i in (Panels.Information, Panels.Settings, Panels.Training):
                 # These panels are always accessible
-                item.setFlags(item.flags() | Qt.ItemIsEnabled)
+                item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEnabled)
                 continue
 
             if allow_navigation:
-                item.setFlags(item.flags() | Qt.ItemIsEnabled)
+                item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEnabled)
             else:
-                item.setFlags(item.flags() & ~ Qt.ItemIsEnabled)
+                item.setFlags(item.flags() & ~ Qt.ItemFlag.ItemIsEnabled)
 
         if allow_navigation:
             self.label_warning_project.setVisible(False)
@@ -1271,7 +1271,7 @@ class LizmapDialog(QDialog, FORM_CLASS):
     def fix_project_ssl(self):
         """ Fix the current project about SSL. """
         self.enabled_ssl_button(False)
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             count = fix_ssl(self.project, force=False)
 
         if count >= 2:
@@ -1283,7 +1283,7 @@ class LizmapDialog(QDialog, FORM_CLASS):
     def fix_project_estimated_md(self):
         """ Fix the current project about estimated metadata. """
         self.enabled_estimated_md_button(False)
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             count = len(use_estimated_metadata(self.project, fix=True))
 
         if count >= 2:
@@ -1301,7 +1301,7 @@ class LizmapDialog(QDialog, FORM_CLASS):
     def fix_simplify_geom_provider(self):
         """ Fix the current layers simplify geom. """
         self.enabled_simplify_geom(False)
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             count = len(simplify_provider_side(self.project, fix=True))
 
         if count >= 2:

--- a/lizmap/dialogs/main.py
+++ b/lizmap/dialogs/main.py
@@ -859,135 +859,135 @@ class LizmapDialog(QDialog, FORM_CLASS):
         icon.addFile(resources_path('icons', '03-metadata-white'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', '03-metadata-dark'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.Information).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.Information).setData(Qt.UserRole, 'info')
+        self.mOptionsListWidget.item(Panels.Information).setData(Qt.ItemDataRole.UserRole, 'info')
 
         # Map options
         icon = QIcon()
         icon.addFile(resources_path('icons', '15-baselayer-white.png'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', '15-baselayer-dark.png'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.MapOptions).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.MapOptions).setData(Qt.UserRole, 'map-options')
+        self.mOptionsListWidget.item(Panels.MapOptions).setData(Qt.ItemDataRole.UserRole, 'map-options')
 
         # Layers
         icon = QIcon()
         icon.addFile(resources_path('icons', '02-switcher-white.png'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', '02-switcher-dark.png'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.Layers).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.Layers).setData(Qt.UserRole, 'layers')
+        self.mOptionsListWidget.item(Panels.Layers).setData(Qt.ItemDataRole.UserRole, 'layers')
 
         # Base layer
         icon = QIcon()
         icon.addFile(resources_path('icons', '02-switcher-white.png'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', '02-switcher-dark.png'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.Basemap).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.Basemap).setData(Qt.UserRole, 'base-layers')
+        self.mOptionsListWidget.item(Panels.Basemap).setData(Qt.ItemDataRole.UserRole, 'base-layers')
 
         # Attribute table
         icon = QIcon()
         icon.addFile(resources_path('icons', '11-attribute-white.png'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', '11-attribute-dark.png'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.AttributeTable).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.AttributeTable).setData(Qt.UserRole, 'attribute-table')
+        self.mOptionsListWidget.item(Panels.AttributeTable).setData(Qt.ItemDataRole.UserRole, 'attribute-table')
 
         # Layer editing
         icon = QIcon()
         icon.addFile(resources_path('icons', '10-edition-white.png'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', '10-edition-dark.png'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.Editing).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.Editing).setData(Qt.UserRole, 'layer-editing')
+        self.mOptionsListWidget.item(Panels.Editing).setData(Qt.ItemDataRole.UserRole, 'layer-editing')
 
         # Layouts
         icon = QIcon()
         icon.addFile(resources_path('icons', '08-print-white.png'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', '08-print-dark.png'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.Layouts).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.Layouts).setData(Qt.UserRole, 'layouts')
+        self.mOptionsListWidget.item(Panels.Layouts).setData(Qt.ItemDataRole.UserRole, 'layouts')
 
         # Filter data with form
         icon = QIcon()
         icon.addFile(resources_path('icons', 'filter-icon-white.png'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', 'filter-icon-dark.png'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.FormFiltering).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.FormFiltering).setData(Qt.UserRole, 'filter-data-form')
+        self.mOptionsListWidget.item(Panels.FormFiltering).setData(Qt.ItemDataRole.UserRole, 'filter-data-form')
 
         # Dataviz
         icon = QIcon()
         icon.addFile(resources_path('icons', 'dataviz-icon-white.png'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', 'dataviz-icon-dark.png'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.Dataviz).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.Dataviz).setData(Qt.UserRole, 'dataviz')
+        self.mOptionsListWidget.item(Panels.Dataviz).setData(Qt.ItemDataRole.UserRole, 'dataviz')
 
         # Filter layer by user
         icon = QIcon()
         icon.addFile(resources_path('icons', '12-user-white.png'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', '12-user-dark.png'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.FilteredLayers).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.FilteredLayers).setData(Qt.UserRole, 'filter-data-user')
+        self.mOptionsListWidget.item(Panels.FilteredLayers).setData(Qt.ItemDataRole.UserRole, 'filter-data-user')
 
         # Actions
         icon = QIcon()
         icon.addFile(resources_path('icons', 'actions-white.svg'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', 'actions-dark.svg'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.Actions).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.Actions).setData(Qt.UserRole, 'actions')
+        self.mOptionsListWidget.item(Panels.Actions).setData(Qt.ItemDataRole.UserRole, 'actions')
 
         # Time manager
         icon = QIcon()
         icon.addFile(resources_path('icons', '13-timemanager-white.png'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', '13-timemanager-dark.png'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.TimeManager).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.TimeManager).setData(Qt.UserRole, 'time-manager')
+        self.mOptionsListWidget.item(Panels.TimeManager).setData(Qt.ItemDataRole.UserRole, 'time-manager')
 
         # Atlas
         icon = QIcon()
         icon.addFile(resources_path('icons', 'atlas-icon-white.png'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', 'atlas-icon-dark.png'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.Atlas).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.Atlas).setData(Qt.UserRole, 'atlas')
+        self.mOptionsListWidget.item(Panels.Atlas).setData(Qt.ItemDataRole.UserRole, 'atlas')
 
         # Locate by layer
         icon = QIcon()
         icon.addFile(resources_path('icons', '04-locate-white.png'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', '04-locate-dark.png'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.LocateByLayer).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.LocateByLayer).setData(Qt.UserRole, 'locate-by-layer')
+        self.mOptionsListWidget.item(Panels.LocateByLayer).setData(Qt.ItemDataRole.UserRole, 'locate-by-layer')
 
         # Tooltip layer
         icon = QIcon()
         icon.addFile(resources_path('icons', '16-tooltip-white.png'), mode=QIcon.Mode.Normal)
         icon.addFile(resources_path('icons', '16-tooltip-dark.png'), mode=QIcon.Mode.Selected)
         self.mOptionsListWidget.item(Panels.ToolTip).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.ToolTip).setData(Qt.UserRole, 'tooltip-layer')
+        self.mOptionsListWidget.item(Panels.ToolTip).setData(Qt.ItemDataRole.UserRole, 'tooltip-layer')
 
         # Checks
         # noinspection PyCallByClass,PyArgumentList
         icon = QIcon(QIcon(':/geometrychecker/icons/geometrychecker.svg'))
         self.mOptionsListWidget.item(Panels.Checks).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.Checks).setData(Qt.UserRole, 'log')
+        self.mOptionsListWidget.item(Panels.Checks).setData(Qt.ItemDataRole.UserRole, 'log')
 
         # Auto-fix
         # noinspection PyCallByClass,PyArgumentList
         icon = QIcon(":images/themes/default/console/iconSettingsConsole.svg")
         self.mOptionsListWidget.item(Panels.AutoFix).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.AutoFix).setData(Qt.UserRole, 'auto-fix')
+        self.mOptionsListWidget.item(Panels.AutoFix).setData(Qt.ItemDataRole.UserRole, 'auto-fix')
 
         # Settings
         # noinspection PyCallByClass,PyArgumentList
         icon = QIcon(":/images/themes/default/propertyicons/settings.svg")
         self.mOptionsListWidget.item(Panels.Settings).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.Settings).setData(Qt.UserRole, 'settings')
+        self.mOptionsListWidget.item(Panels.Settings).setData(Qt.ItemDataRole.UserRole, 'settings')
 
         # Upload
         # noinspection PyCallByClass,PyArgumentList
         icon = QIcon(resources_path('icons', 'upload.svg'))
         self.mOptionsListWidget.item(Panels.Upload).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.Upload).setData(Qt.UserRole, 'upload')
+        self.mOptionsListWidget.item(Panels.Upload).setData(Qt.ItemDataRole.UserRole, 'upload')
 
         # Upload
         # noinspection PyCallByClass,PyArgumentList
         icon = QIcon(resources_path('icons', 'abc-block.png'))
         self.mOptionsListWidget.item(Panels.Training).setIcon(icon)
-        self.mOptionsListWidget.item(Panels.Training).setData(Qt.UserRole, 'training')
+        self.mOptionsListWidget.item(Panels.Training).setData(Qt.ItemDataRole.UserRole, 'training')
 
         # Set stylesheet for QGroupBox
         q_group_box = (

--- a/lizmap/dialogs/news.py
+++ b/lizmap/dialogs/news.py
@@ -30,7 +30,7 @@ class BaseNewsDialog(QDialog, FORM_CLASS):
         self.logo.setText('')
         pixmap = QPixmap(resources_path('icons', 'logo.png'))
         # noinspection PyUnresolvedReferences
-        pixmap = pixmap.scaled(100, 100, Qt.KeepAspectRatio)
+        pixmap = pixmap.scaled(100, 100, Qt.AspectRatioMode.KeepAspectRatio)
         self.logo.setPixmap(pixmap)
 
         self.open_link.clicked.connect(self.open_website)

--- a/lizmap/dialogs/scroll_message_box.py
+++ b/lizmap/dialogs/scroll_message_box.py
@@ -24,7 +24,7 @@ class ScrollMessageBox(QMessageBox):
         grid = self.findChild(QGridLayout)
         label = QLabel(children[1].text(), self)
         label.setWordWrap(True)
-        label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         scroll.setWidget(label)
         scroll.setMinimumSize(400, 200)
         grid.addWidget(scroll, 0, 1)

--- a/lizmap/dialogs/server_wizard.py
+++ b/lizmap/dialogs/server_wizard.py
@@ -23,8 +23,8 @@ from qgis.core import (
     QgsSettings,
 )
 from qgis.gui import QgsPasswordLineEdit
-from qgis.PyQt.QtCore import QRegExp, Qt, QUrl
-from qgis.PyQt.QtGui import QDesktopServices, QRegExpValidator
+from qgis.PyQt.QtCore import QRegularExpression, Qt, QUrl
+from qgis.PyQt.QtGui import QDesktopServices, QRegularExpressionValidator
 from qgis.PyQt.QtNetwork import QNetworkRequest
 from qgis.PyQt.QtWidgets import (
     QApplication,
@@ -646,8 +646,8 @@ class CreateNewFolderDavPage(QWizardPage):
         layout.addLayout(horizontal)
 
         self.custom_name = QLineEdit()
-        regexp = QRegExp("^[a-z0-9]+$")
-        validator = QRegExpValidator(regexp, self.custom_name)
+        regexp = QRegularExpression("^[a-z0-9]+$")
+        validator = QRegularExpressionValidator(regexp, self.custom_name)
         self.custom_name.setValidator(validator)
         layout.addWidget(self.custom_name)
         self.registerField("folder_name", self.custom_name)
@@ -678,7 +678,7 @@ class CreateNewFolderDavPage(QWizardPage):
         auth_id = parent_wizard.auth_id
 
         LOGGER.debug("Creating a folder called '{}' on {}".format(self.custom_name.text(), dav_url))
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             server_dav = WebDav(dav_url, auth_id)
             if parent_wizard._user:
                 # Only for tests, because authid is not available
@@ -752,7 +752,7 @@ class LizmapNewRepositoryPage(QWizardPage):
         network_request = QgsBlockingNetworkRequest()
         network_request.setAuthCfg(self.wizard().auth_id)
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             network_request.get(request)
 
         response = network_request.reply().content()
@@ -853,7 +853,7 @@ class ServerWizard(BaseWizard):
             self.page(WizardPages.UrlPage).result_url.setText('')
             self.currentPage().result_login_password.setText(tr("Fetching") + "…")
 
-            with OverrideCursor(Qt.WaitCursor):
+            with OverrideCursor(Qt.CursorShape.WaitCursor):
                 self.currentPage().progress.setMaximum(0)
 
                 flag, message, url_valid = self.request_check_url(

--- a/lizmap/dialogs/wizard_group.py
+++ b/lizmap/dialogs/wizard_group.py
@@ -73,7 +73,7 @@ class WizardGroupDialog(QDialog, FORM_CLASS):
             cell = QListWidgetItem()
             cell.setText(group_data['label'])
             cell.setData(Qt.ItemDataRole.UserRole, group_id)
-            cell.setData(Qt.ToolTipRole, group_id)
+            cell.setData(Qt.ItemDataRole.ToolTipRole, group_id)
             self.list.addItem(cell)
             if group_id in existing:
                 cell.setSelected(True)

--- a/lizmap/dialogs/wizard_group.py
+++ b/lizmap/dialogs/wizard_group.py
@@ -54,7 +54,7 @@ class WizardGroupDialog(QDialog, FORM_CLASS):
         for i in range(self.list.count()):
             item = self.list.item(i)
             if item.isSelected():
-                selection.append(item.data(Qt.UserRole))
+                selection.append(item.data(Qt.ItemDataRole.UserRole))
 
         more = self.additional.text()
         more = more.strip()
@@ -72,7 +72,7 @@ class WizardGroupDialog(QDialog, FORM_CLASS):
         for group_id, group_data in server_groups.items():
             cell = QListWidgetItem()
             cell.setText(group_data['label'])
-            cell.setData(Qt.UserRole, group_id)
+            cell.setData(Qt.ItemDataRole.UserRole, group_id)
             cell.setData(Qt.ToolTipRole, group_id)
             self.list.addItem(cell)
             if group_id in existing:

--- a/lizmap/drag_drop_dataviz_manager.py
+++ b/lizmap/drag_drop_dataviz_manager.py
@@ -72,7 +72,7 @@ class DragDropDatavizManager:
         text = self.combo_plots.itemText(index)
         icon = self.combo_plots.itemIcon(index)
         # noinspection PyUnresolvedReferences
-        uuid = self.combo_plots.itemData(index, Qt.UserRole)
+        uuid = self.combo_plots.itemData(index, Qt.ItemDataRole.UserRole)
         self._add_plot_in_tree(text, icon, uuid)
 
     def metadata_from_uuid(self, uuid: str) -> Union[Tuple[None, None], Tuple[str, QIcon]]:
@@ -85,7 +85,7 @@ class DragDropDatavizManager:
             return 'plot name', QIcon()
 
         # noinspection PyUnresolvedReferences
-        index = self.combo_plots.findData(uuid, Qt.UserRole)
+        index = self.combo_plots.findData(uuid, Qt.ItemDataRole.UserRole)
         if index < 0:
             return None, None
 
@@ -97,7 +97,7 @@ class DragDropDatavizManager:
         """ Internal function to add a plot in the tree. """
         if name_parent:
             # noinspection PyUnresolvedReferences
-            parents = self.tree.findItems(name_parent, Qt.MatchContains | Qt.MatchRecursive, 0)
+            parents = self.tree.findItems(name_parent, Qt.MatchFlag.MatchContains | Qt.MatchFlag.MatchRecursive, 0)
             parent_item = parents[0]
             item = QTreeWidgetItem(parent_item)
         else:
@@ -110,15 +110,15 @@ class DragDropDatavizManager:
         item.setIcon(0, icon)
         # Row type
         # noinspection PyUnresolvedReferences
-        item.setData(0, Qt.UserRole, Container.Plot)
+        item.setData(0, Qt.ItemDataRole.UserRole, Container.Plot)
         # UUID
         # noinspection PyUnresolvedReferences
-        item.setData(0, Qt.UserRole + 1, uuid)
+        item.setData(0, Qt.ItemDataRole.UserRole + 1, uuid)
         # item.setBackground(0, QBrush(Qt.lightGray))
         # noinspection PyUnresolvedReferences
-        item.setFlags(item.flags() & ~ Qt.ItemIsDropEnabled)
+        item.setFlags(item.flags() & ~ Qt.ItemFlag.ItemIsDropEnabled)
         # noinspection PyUnresolvedReferences
-        item.setData(0, Qt.ToolTipRole, "Plot <b>{}</b><br>UUID {}".format(text, uuid))
+        item.setData(0, Qt.ItemDataRole.ToolTipRole, "Plot <b>{}</b><br>UUID {}".format(text, uuid))
         if name_parent:
             self.tree.addTopLevelItem(item)
             parent_item.setExpanded(True)
@@ -164,10 +164,10 @@ class DragDropDatavizManager:
             icon = self.table.item(row, icon_index).icon()
             title = self.table.item(row, title_index).text()
             # noinspection PyUnresolvedReferences
-            uuid = self.table.item(row, uuid_index).data(Qt.UserRole)
+            uuid = self.table.item(row, uuid_index).data(Qt.ItemDataRole.UserRole)
             self.combo_plots.addItem(icon, title, uuid)
             index = self.combo_plots.findData(uuid)
-            self.combo_plots.setItemData(index, uuid, Qt.ToolTipRole)
+            self.combo_plots.setItemData(index, uuid, Qt.ItemDataRole.ToolTipRole)
 
     def add_container(self):
         """ When the "add" container button is clicked, we add a new row in the tree widget. """
@@ -190,7 +190,7 @@ class DragDropDatavizManager:
 
         item = self.tree.itemFromIndex(selection[0])
         # noinspection PyUnresolvedReferences
-        if item.data(0, Qt.UserRole) == Container.Plot:
+        if item.data(0, Qt.ItemDataRole.UserRole) == Container.Plot:
             return
 
         new_name, ok = QInputDialog.getText(
@@ -225,7 +225,7 @@ class DragDropDatavizManager:
         box.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
         box.setDefaultButton(QMessageBox.StandardButton.No)
 
-        if current_item.data(0, Qt.UserRole) == Container.Container:
+        if current_item.data(0, Qt.ItemDataRole.UserRole) == Container.Container:
             box.setWindowTitle(tr('Remove the container'))
             if children:
                 box.setText(tr('Are you sure you want to remove the container and all elements inside?'))
@@ -264,7 +264,7 @@ class DragDropDatavizManager:
             child: QTreeWidgetItem
 
             # noinspection PyUnresolvedReferences
-            row_type = child.data(0, Qt.UserRole)
+            row_type = child.data(0, Qt.ItemDataRole.UserRole)
 
             if row_type == Container.Container:
                 tmp = {
@@ -280,7 +280,7 @@ class DragDropDatavizManager:
                     # The name is not used and mustn't be used for reading the CFG, it's just easier to debug the CFG
                     # instead of dealing with a UUID
                     '_name': child.text(0),
-                    'uuid': child.data(0, Qt.UserRole + 1),
+                    'uuid': child.data(0, Qt.ItemDataRole.UserRole + 1),
                 })
         return data
 
@@ -307,7 +307,7 @@ class DragDropDatavizManager:
                         "the drag&drop layout, only : {}.".format(
                             line["uuid"],
                             ','.join(
-                                [self.combo_plots.itemData(i, Qt.UserRole) for i in range(self.combo_plots.count())])
+                                [self.combo_plots.itemData(i, Qt.ItemDataRole.UserRole) for i in range(self.combo_plots.count())])
                         ))
                     continue
 
@@ -323,7 +323,7 @@ class DragDropDatavizManager:
         parent_item = None
         if name_parent:
             # noinspection PyUnresolvedReferences
-            parents = self.tree.findItems(name_parent, Qt.MatchContains | Qt.MatchRecursive, 0)
+            parents = self.tree.findItems(name_parent, Qt.MatchFlag.MatchContains | Qt.MatchFlag.MatchRecursive, 0)
             if not parents:
                 # Strange, it shouldn't happen.
                 return
@@ -331,18 +331,18 @@ class DragDropDatavizManager:
             parent_item = parents[0]
 
             item = QTreeWidgetItem(parent_item)
-            item.setBackground(0, QBrush(Qt.gray))
+            item.setBackground(0, QBrush(Qt.GlobalColor.gray))
 
         else:
             # At the top
             item = QTreeWidgetItem(self.tree.invisibleRootItem())
-            item.setBackground(0, QBrush(Qt.gray))
+            item.setBackground(0, QBrush(Qt.GlobalColor.gray))
 
         item.setText(0, name)
         # noinspection PyUnresolvedReferences
-        item.setData(0, Qt.UserRole, Container.Container)
+        item.setData(0, Qt.ItemDataRole.UserRole, Container.Container)
         # noinspection PyUnresolvedReferences
-        item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsDragEnabled | Qt.ItemIsDropEnabled)
+        item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsDragEnabled | Qt.ItemFlag.ItemIsDropEnabled)
         if name_parent:
             self.tree.addTopLevelItem(item)
             parent_item.setExpanded(True)

--- a/lizmap/forms/base_edition_dialog.py
+++ b/lizmap/forms/base_edition_dialog.py
@@ -66,7 +66,7 @@ class BaseEditionDialog(QDialog):
         """ Build the UI. """
         self.button_box.button(QDialogButtonBox.StandardButton.Help).setToolTip(
             tr('Open the online documentation for this feature.'))
-        self.error.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.error.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
 
         if not self.config.help_path():
             self.button_box.button(QDialogButtonBox.StandardButton.Help).setVisible(False)
@@ -100,7 +100,7 @@ class BaseEditionDialog(QDialog):
                             index = widget.findData(item.value['data'])
                             tooltip = item.value.get('tooltip')
                             if tooltip:
-                                widget.setItemData(index, tooltip, Qt.ToolTipRole)
+                                widget.setItemData(index, tooltip, Qt.ItemDataRole.ToolTipRole)
                         default = layer_config.get('default')
                         if default and not isinstance(default, (list, tuple)):
                             index = widget.findData(default.value['data'])
@@ -140,8 +140,8 @@ class BaseEditionDialog(QDialog):
                         # The tooltip is not showing
                         widget.setText(tr('Read only, check the tooltip on the label'))
                         widget.setStyleSheet("font: italic;")
-                        widget.setAttribute(Qt.WA_TransparentForMouseEvents)
-                        widget.setFocusPolicy(Qt.NoFocus)
+                        widget.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+                        widget.setFocusPolicy(Qt.FocusPolicy.NoFocus)
 
             if not layer_config.get('visible', True):
                 if widget is not None:
@@ -224,7 +224,7 @@ class BaseEditionDialog(QDialog):
                                 layer_config['widget'].findData(item.value.get('data'))
                             )
                             brush = QBrush()
-                            brush.setStyle(Qt.SolidPattern)
+                            brush.setStyle(Qt.BrushStyle.SolidPattern)
                             brush.setColor(QColor(NEW_FEATURE_COLOR))
                             item_combo.setBackground(brush)
 
@@ -378,7 +378,7 @@ class BaseEditionDialog(QDialog):
                 if definition.get('multiple_selection', False):
                     for val in value:
                         index = definition['widget'].findData(val)
-                        definition['widget'].setItemCheckState(index, Qt.Checked)
+                        definition['widget'].setItemCheckState(index, Qt.CheckState.Checked)
                 else:
                     index = definition['widget'].findData(value)
                     definition['widget'].setCurrentIndex(index)

--- a/lizmap/forms/dataviz_edition.py
+++ b/lizmap/forms/dataviz_edition.py
@@ -140,7 +140,7 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
         values = list()
         for row in range(self.traces.rowCount()):
             item = self.traces.item(row, 0)
-            cell = item.data(Qt.UserRole)
+            cell = item.data(Qt.ItemDataRole.UserRole)
             values.append(cell)
         return values
 
@@ -162,7 +162,7 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
                     # Do not put if not item, it might be False
                     raise Exception('Cell is not initialized ({}, {})'.format(row, i))
 
-                cell = item.data(Qt.UserRole)
+                cell = item.data(Qt.ItemDataRole.UserRole)
                 if cell is None:
                     # Safeguard
                     # Do not put if not cell, it might be False
@@ -214,15 +214,15 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
             value = data.get(key)
             if not value:
                 cell.setText('')
-                cell.setData(Qt.UserRole, '')
+                cell.setData(Qt.ItemDataRole.UserRole, '')
                 self.traces.setItem(row, i, cell)
                 continue
 
             input_type = self.config.layer_config[key]['type']
             if input_type == InputType.Field:
                 cell.setText(value)
-                cell.setData(Qt.UserRole, value)
-                cell.setData(Qt.ToolTipRole, value)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
+                cell.setData(Qt.ItemDataRole.ToolTipRole, value)
 
                 # Get the icon for the field
                 if self.layer:
@@ -232,10 +232,10 @@ class DatavizEditionDialog(BaseEditionDialog, CLASS):
 
             elif input_type == InputType.Color:
                 cell.setText(value)
-                cell.setData(Qt.UserRole, value)
-                cell.setData(Qt.ToolTipRole, value)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
+                cell.setData(Qt.ItemDataRole.ToolTipRole, value)
                 if value:
-                    cell.setData(Qt.DecorationRole, QColor(value))
+                    cell.setData(Qt.ItemDataRole.DecorationRole, QColor(value))
 
             else:
                 raise Exception('InputType "{}" not implemented'.format(input_type))

--- a/lizmap/forms/layout_edition.py
+++ b/lizmap/forms/layout_edition.py
@@ -104,7 +104,7 @@ class LayoutEditionDialog(BaseEditionDialog, CLASS):
         if is_atlas:
             # Formats options
             for index, item in enumerate(self.config.layer_config.get('formats_available')['items']):
-                self.formats.setItemCheckState(index, Qt.Checked if item == FormatType.Pdf else Qt.Unchecked)
+                self.formats.setItemCheckState(index, Qt.CheckState.Checked if item == FormatType.Pdf else Qt.CheckState.Unchecked)
 
             # Default format
             index = self.default_format.findData(FormatType.Pdf.value['data'])
@@ -112,7 +112,7 @@ class LayoutEditionDialog(BaseEditionDialog, CLASS):
 
             # DPI options
             for index, item in enumerate(self.config.layer_config.get('dpi_available')['items']):
-                self.dpi.setItemCheckState(index, Qt.Checked if item == Dpi.Dpi100 else Qt.Unchecked)
+                self.dpi.setItemCheckState(index, Qt.CheckState.Checked if item == Dpi.Dpi100 else Qt.CheckState.Unchecked)
 
             # Default DPI
             index = self.default_dpi.findData(Dpi.Dpi100.value['data'])

--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -374,7 +374,7 @@ class Lizmap:
 
                 if tooltip:
                     # noinspection PyUnresolvedReferences
-                    item_info['widget'].setItemData(index, tooltip, Qt.ToolTipRole)
+                    item_info['widget'].setItemData(index, tooltip, Qt.ItemDataRole.ToolTipRole)
 
                 if icon:
                     if isinstance(icon, str):
@@ -1140,7 +1140,7 @@ class Lizmap:
                         # QComboBox
                         brush = QBrush()
                         # noinspection PyUnresolvedReferences
-                        brush.setStyle(Qt.SolidPattern)
+                        brush.setStyle(Qt.BrushStyle.SolidPattern)
                         brush.setColor(QColor(NEW_FEATURE_COLOR))
                         item.setBackground(brush)
             else:
@@ -1249,7 +1249,7 @@ class Lizmap:
 
         self.dock_html_preview = HtmlPreview(None)
         self.dock_html_preview.set_server_url(self.dlg.current_server_info(ServerComboData.ServerUrl.value))
-        self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dock_html_preview)
+        self.iface.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.dock_html_preview)
         self.dock_html_preview.setVisible(False)
         self.dlg.button_maptip_preview.setText('')
         self.dlg.button_maptip_preview.setToolTip(tr('Open the HTML Lizmap maptip popup preview dock'))
@@ -2302,10 +2302,10 @@ class Lizmap:
                     if self.myDic[child_id]['name'].lower() == 'overview':
                         predefined_group = PredefinedGroup.Overview.value
 
-                elif parent_node.data(0, Qt.UserRole + 1) == PredefinedGroup.Baselayers.value:
+                elif parent_node.data(0, Qt.ItemDataRole.UserRole + 1) == PredefinedGroup.Baselayers.value:
                     # Parent is "baselayers", children will be an item in the dropdown menu
                     predefined_group = PredefinedGroup.BaselayerItem.value
-                elif parent_node.data(0, Qt.UserRole + 1) != PredefinedGroup.No.value:
+                elif parent_node.data(0, Qt.ItemDataRole.UserRole + 1) != PredefinedGroup.No.value:
                     # Others will be in "hidden" or "overview".
                     # TODO fixme maybe ?
                     predefined_group = PredefinedGroup.Hidden.value
@@ -2321,7 +2321,7 @@ class Lizmap:
                     text = tr('Special group for Lizmap Web Client')
                     if self.is_dev_version:
                         # For debug purpose only about groups
-                        text += f'. Data group ID {Qt.UserRole} : {predefined_group}'  # NOQA E203
+                        text += f'. Data group ID {Qt.ItemDataRole.UserRole} : {predefined_group}'  # NOQA E203
                     item.setToolTip(0, self.myDic[child_id]['name'] + ' - ' + text)
                 elif is_layer_wms_excluded(self.project, self.myDic[child_id]['name']):
                     text = tr(
@@ -2332,7 +2332,7 @@ class Lizmap:
                 else:
                     item.setToolTip(0, self.myDic[child_id]['name'])
                 item.setIcon(0, child_icon)
-                item.setData(0, Qt.UserRole + 1, predefined_group)
+                item.setData(0, Qt.ItemDataRole.UserRole + 1, predefined_group)
                 self.myDic[child_id]['item'] = item
 
                 # Move group or layer to its parent node
@@ -2926,7 +2926,7 @@ class Lizmap:
         if text not in self.layerList:
             return None
 
-        return item.data(0, Qt.UserRole + 1)
+        return item.data(0, Qt.ItemDataRole.UserRole + 1)
 
     def _current_selected_item_in_config(self) -> Optional[str]:
         """ Either a group or a layer name. """
@@ -3078,7 +3078,7 @@ class Lizmap:
         lwc_version = self.current_lwc_version()
         # Let's trigger UI refresh according to latest releases, if it wasn't available on startup
         self.lwc_version_changed()
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             self.check_project(lwc_version)
 
     def check_project(
@@ -4348,7 +4348,7 @@ class Lizmap:
             new_project = NewConfigDialog()
             new_project.exec()
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             result = self.save_cfg_file()
 
         if not result:
@@ -4583,7 +4583,7 @@ class Lizmap:
 
         With a waiting cursor and sending messages to the message bar.
         """
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             result, _, url = self.send_webdav()
         return result, url
 
@@ -4611,7 +4611,7 @@ class Lizmap:
             # Maybe we are on a new server ?
             return False, '', ''
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             qgis_exists, error = self.webdav.check_exists_qgs()
         if error:
             self.iface.messageBar().pushMessage('Lizmap', error, level=Qgis.Critical, duration=DURATION_WARNING_BAR)
@@ -4637,7 +4637,7 @@ class Lizmap:
             if result == QMessageBox.StandardButton.No:
                 return False, '', ''
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             flag, error, url = self.webdav.send_all_project_files()
         if not flag:
             # Error while sending files
@@ -4663,7 +4663,7 @@ class Lizmap:
         if not directory:
             return
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             result, msg = self.webdav.file_stats_media()
         if result is not None:
             self.dlg.display_message_bar(
@@ -4749,7 +4749,7 @@ class Lizmap:
             )
             return
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             result, message = self.webdav.send_media(current_file)
         if not result and message:
             self.dlg.display_message_bar('Lizmap', message, level=Qgis.Critical, duration=DURATION_WARNING_BAR)
@@ -4766,7 +4766,7 @@ class Lizmap:
 
     def upload_thumbnail(self):
         """ Upload the thumbnail on the server. """
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             result, message = self.webdav.send_thumbnail()
         if not result and message:
             self.dlg.display_message_bar('Lizmap', message, level=Qgis.Critical, duration=DURATION_WARNING_BAR)
@@ -4798,7 +4798,7 @@ class Lizmap:
 
     def upload_action(self):
         """ Upload the action file on the server. """
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             result, error = self.webdav.send_action()
         if not result and error:
             self.dlg.display_message_bar('Lizmap', error, level=Qgis.Critical, duration=DURATION_WARNING_BAR)
@@ -4834,7 +4834,7 @@ class Lizmap:
         """ Remove a remote file. """
         if self._question_remove_remote_file():
             return
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             if 'qgs' in button.objectName():
                 self.webdav.remove_qgs()
                 self.check_latest_update_webdav()
@@ -4873,7 +4873,7 @@ class Lizmap:
         for row in range(self.dlg.table_files.rowCount()):
             self.dlg.table_files.file_status(row, tr("Work in progress"), tr("Work in progress"))
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             for row in range(self.dlg.table_files.rowCount()):
                 self.refresh_single_layer(row)
 
@@ -4882,7 +4882,7 @@ class Lizmap:
         for row in range(self.dlg.table_files.rowCount()):
             self.dlg.table_files.file_status(row, tr("Work in progress"), tr("Work in progress"))
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             for row in range(self.dlg.table_files.rowCount()):
                 relative_path_layer = self.dlg.table_files.item(row, 1).data(self.dlg.table_files.RELATIVE_PATH)
                 absolute_path_layer = self.dlg.table_files.item(row, 1).data(self.dlg.table_files.ABSOLUTE_PATH)
@@ -4904,7 +4904,7 @@ class Lizmap:
 
     def _refresh_cfg(self):
         """ Refresh CFG. """
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             directory = self.dlg.current_repository()
             self.dlg.line_cfg_date.setText("")
             result, error = self.webdav.file_stats_cfg()
@@ -4918,7 +4918,7 @@ class Lizmap:
 
     def _refresh_thumbnail(self):
         """ Refresh thumbnail. """
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             directory = self.dlg.current_repository()
             self.dlg.line_thumbnail_date.setText("")
             result, error = self.webdav.file_stats_thumbnail()
@@ -4936,7 +4936,7 @@ class Lizmap:
 
     def _refresh_action(self):
         """ Refresh action. """
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             self.dlg.line_action_date.setText("")
             result, error = self.webdav.file_stats_action()
             if result:
@@ -4954,7 +4954,7 @@ class Lizmap:
 
         # Media
         self.dlg.line_media_date.setText("")
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             result, error = self.webdav.file_stats_media()
             if result:
                 self.dlg.line_media_date.setText(result.last_modified_pretty)
@@ -4963,7 +4963,7 @@ class Lizmap:
 
     def check_latest_update_webdav(self):
         """ Check the latest date about QGS file on the server. """
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             self.dlg.line_qgs_date.setText("")
             result, error = self.webdav.file_stats_qgs()
             if result:
@@ -5129,7 +5129,7 @@ class Lizmap:
         if self.dock_html_preview.isVisible():
             return
 
-        self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dock_html_preview)
+        self.iface.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.dock_html_preview)
         self.dock_html_preview.setVisible(True)
 
     def check_training_panel(self):
@@ -5213,7 +5213,7 @@ class Lizmap:
         else:
             downloader.downloadCompleted.connect(self.download_completed_zip)
         downloader.startDownload()
-        QApplication.setOverrideCursor(Qt.WaitCursor)
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
         loop.exec()
 
     @staticmethod
@@ -5262,7 +5262,7 @@ class Lizmap:
     def download_completed(self):
         """ Show the success bar, for both kind of workshops. """
         QApplication.restoreOverrideCursor()
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             self.dlg.display_message_bar(
                 CLOUD_NAME,
                 tr("Download and extract OK about the training project"),
@@ -5343,14 +5343,14 @@ class Lizmap:
         if not file_path:
             return
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             self.project.read(project_path)
             # Rename the project
             self.project.writeEntry("WMSServiceTitle", "/", user_project)
 
         # Enable the "Upload" panel
         item = self.dlg.mOptionsListWidget.item(Panels.Upload)
-        item.setFlags(item.flags() | Qt.ItemIsEnabled)
+        item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEnabled)
 
         variables = self.project.customVariables()
         if 'lizmap_user' in list(variables.keys()):

--- a/lizmap/plugin_manager.py
+++ b/lizmap/plugin_manager.py
@@ -50,7 +50,7 @@ class QgisPluginManager:
                 latest_stable_version = plugin_metadata['version_available']
                 latest_stable_date = QDateTime.fromString(
                     plugin_metadata['update_date'],
-                    Qt.ISODateWithMs
+                    Qt.DateFormat.ISODateWithMs
                 )
                 date_string = latest_stable_date.toString(QLocale().dateFormat(QLocale.ShortFormat))
 

--- a/lizmap/server_dav.py
+++ b/lizmap/server_dav.py
@@ -723,7 +723,7 @@ class WebDav:
 
         # Transform from UTC to local timezone
         qdate = QDateTime.fromString(last_modified, Qt.DateFormat.RFC2822Date)
-        qdate.setTimeSpec(Qt.UTC)
+        qdate.setTimeSpec(Qt.TimeSpec.UTC)
         qdate_locale = qdate.toLocalTime()
         date_string = qdate_locale.toString(QLocale().dateFormat(QLocale.ShortFormat))
         date_string += " "

--- a/lizmap/server_lwc.py
+++ b/lizmap/server_lwc.py
@@ -153,7 +153,7 @@ class ServerManager:
         self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.table.setAlternatingRowColors(True)
         self.table.cellDoubleClicked.connect(self.edit_row)
-        self.table.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.table.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.table.customContextMenuRequested.connect(self.context_menu_requested)
 
         # Headers
@@ -268,14 +268,14 @@ class ServerManager:
 
         # All rows must have a login
         for row in range(self.table.rowCount()):
-            login = self.table.item(row, TableCell.Login.value).data(Qt.DisplayRole)
+            login = self.table.item(row, TableCell.Login.value).data(Qt.ItemDataRole.DisplayRole)
             if not login:
                 # All rows must have a login
                 return False
 
         # For LWC ≥ 3.6, rows must have QGIS server version
         for row in range(self.table.rowCount()):
-            qgis_server = self.table.item(row, TableCell.QgisVersion.value).data(Qt.UserRole + 1)
+            qgis_server = self.table.item(row, TableCell.QgisVersion.value).data(Qt.ItemDataRole.UserRole + 1)
             if isinstance(qgis_server, bool):
                 # It means QGIS server is not configured correctly.
                 return False
@@ -285,7 +285,7 @@ class ServerManager:
     def check_lwc_version(self, version_check: str) -> bool:
         """ Check if the given LWC version is at least in the table. """
         for row in range(self.table.rowCount()):
-            lwc_version = self.table.item(row, TableCell.LizmapVersion.value).data(Qt.DisplayRole)
+            lwc_version = self.table.item(row, TableCell.LizmapVersion.value).data(Qt.ItemDataRole.DisplayRole)
             if lwc_version and lwc_version.startswith(version_check):
                 return True
 
@@ -301,7 +301,7 @@ class ServerManager:
 
         missing = False
         for row in range(self.table.rowCount()):
-            if not self.table.item(row, TableCell.Login.value).data(Qt.DisplayRole):
+            if not self.table.item(row, TableCell.Login.value).data(Qt.ItemDataRole.DisplayRole):
                 missing = True
 
         if not missing:
@@ -312,7 +312,7 @@ class ServerManager:
         # Maybe by loading again all logins, we can avoid the "false" return
         self.load_table()
         for row in range(self.table.rowCount()):
-            if not self.table.item(row, TableCell.Login.value).data(Qt.DisplayRole):
+            if not self.table.item(row, TableCell.Login.value).data(Qt.ItemDataRole.DisplayRole):
                 return False
 
         return True
@@ -345,9 +345,9 @@ class ServerManager:
         url_item = self.table.item(row, TableCell.Url.value)
         login_item = self.table.item(row, TableCell.Login.value)
         name_item = self.table.item(row, TableCell.Name.value)
-        url = url_item.data(Qt.UserRole)
-        auth_id = login_item.data(Qt.UserRole)
-        name = name_item.data(Qt.UserRole)
+        url = url_item.data(Qt.ItemDataRole.UserRole)
+        auth_id = login_item.data(Qt.ItemDataRole.UserRole)
+        name = name_item.data(Qt.ItemDataRole.UserRole)
         return url, auth_id, name
 
     def edit_row(self):
@@ -420,46 +420,46 @@ class ServerManager:
 
         # URL
         cell = QTableWidgetItem()
-        cell.setData(Qt.UserRole, server_url)
+        cell.setData(Qt.ItemDataRole.UserRole, server_url)
         self.table.setItem(row, TableCell.Url.value, cell)
 
         # Name
         cell = QTableWidgetItem()
         cell.setText(name)
-        cell.setData(Qt.ToolTipRole, tr(
+        cell.setData(Qt.ItemDataRole.ToolTipRole, tr(
             '<b>URL</b> {}<br>'
             '<b>Login</b> {}<br>'
             '<b>Password ID</b> {}').format(server_url, login, auth_id))
-        cell.setData(Qt.UserRole, name)
+        cell.setData(Qt.ItemDataRole.UserRole, name)
         self.table.setItem(row, TableCell.Name.value, cell)
 
         # Login
         cell = QTableWidgetItem()
         cell.setText(login)
-        cell.setData(Qt.UserRole, auth_id)
+        cell.setData(Qt.ItemDataRole.UserRole, auth_id)
         self.table.setItem(row, TableCell.Login.value, cell)
 
         # LWC Version
         cell = QTableWidgetItem()
         cell.setText('')
-        cell.setData(Qt.UserRole, None)
+        cell.setData(Qt.ItemDataRole.UserRole, None)
         self.table.setItem(row, TableCell.LizmapVersion.value, cell)
 
         # QGIS Version
         cell = QTableWidgetItem()
         cell.setText('')
-        cell.setData(Qt.UserRole, '')
+        cell.setData(Qt.ItemDataRole.UserRole, '')
         self.table.setItem(row, TableCell.QgisVersion.value, cell)
 
         # Action
         cell = QTableWidgetItem()
         cell.setText('')
-        cell.setData(Qt.UserRole, '')
+        cell.setData(Qt.ItemDataRole.UserRole, '')
         self.table.setItem(row, TableCell.Action.value, cell)
 
         # Action text, hidden
         cell = QTableWidgetItem()
-        cell.setData(Qt.UserRole, '')
+        cell.setData(Qt.ItemDataRole.UserRole, '')
         self.table.setItem(row, TableCell.ActionText.value, cell)
 
         self.table.clearSelection()
@@ -619,7 +619,7 @@ class ServerManager:
         lizmap_cell.setText(lizmap_version)
 
         # Reply is good at this step, let's save it in our cache
-        server_alias = self.table.item(row, TableCell.Name.value).data(Qt.UserRole)
+        server_alias = self.table.item(row, TableCell.Name.value).data(Qt.ItemDataRole.UserRole)
         json_file_content = json.dumps(
             content,
             sort_keys=False,
@@ -652,8 +652,8 @@ class ServerManager:
         markdown += lwc_version_txt
         markdown += f'* Lizmap plugin : {version()}\n'
         markdown += '* QGIS Desktop : {}\n'.format(Qgis.QGIS_VERSION.split('-')[0])
-        qgis_cell.setData(Qt.UserRole, markdown)
-        qgis_cell.setData(Qt.UserRole + 1, content)
+        qgis_cell.setData(Qt.ItemDataRole.UserRole, markdown)
+        qgis_cell.setData(Qt.ItemDataRole.UserRole + 1, content)
 
         # Only adding Lizmap saas if set to true
         if is_lizmap_cloud(content):
@@ -669,7 +669,7 @@ class ServerManager:
             self.update_action_version(lizmap_version, None, row, login)
             # Make a better warning to upgrade ASAP
             markdown += '* QGIS Server and plugins unknown status\n'
-            qgis_cell.setData(Qt.UserRole, markdown)
+            qgis_cell.setData(Qt.ItemDataRole.UserRole, markdown)
             return
 
         if qgis_server_info and "error" not in qgis_server_info.keys():
@@ -698,7 +698,7 @@ class ServerManager:
                 markdown += f'* QGIS Server plugin {plugin} : {plugin_version}\n'
 
             markdown += self.modules_to_markdown(content)
-            qgis_cell.setData(Qt.UserRole, markdown)
+            qgis_cell.setData(Qt.ItemDataRole.UserRole, markdown)
             self.update_action_version(
                 lizmap_version, qgis_server_version, row, login, lizmap_cloud=is_lizmap_cloud(content))
             return
@@ -712,7 +712,7 @@ class ServerManager:
             qgis_cell.setText(tr("Not possible"))
             qgis_cell.setToolTip(
                 tr("Not possible to determine QGIS Server version because you need at least Lizmap Web Client 3.5"))
-            qgis_cell.setData(Qt.UserRole, markdown)
+            qgis_cell.setData(Qt.ItemDataRole.UserRole, markdown)
             self.update_action_version(lizmap_version, None, row)
             return
 
@@ -721,7 +721,7 @@ class ServerManager:
             if not login:
                 # No admin login provided and running LWC >= 3.5
                 markdown += '* QGIS Server and plugins unknown status because no admin login provided\n'
-                qgis_cell.setData(Qt.UserRole, markdown)
+                qgis_cell.setData(Qt.ItemDataRole.UserRole, markdown)
 
                 font = qgis_cell.font()
                 font.setItalic(True)
@@ -739,7 +739,7 @@ class ServerManager:
                             '* QGIS Server and plugins unknown status because the login provided is not an '
                             'administrator\n'
                         )
-                        qgis_cell.setData(Qt.UserRole, markdown)
+                        qgis_cell.setData(Qt.ItemDataRole.UserRole, markdown)
                         self.update_action_version(lizmap_version, None, row, login, error=qgis_server_info['error'])
                         return
 
@@ -748,13 +748,13 @@ class ServerManager:
                         'please review your server settings in the Lizmap Web Client administration interface, '
                         'then in the "Server Information" panel.\n'
                     )
-                    qgis_cell.setData(Qt.UserRole, markdown)
+                    qgis_cell.setData(Qt.ItemDataRole.UserRole, markdown)
                     self.update_action_version(lizmap_version, None, row, login, error=qgis_server_info['error'])
                     return
 
         # Unknown
         markdown += '* QGIS Server and plugins unknown status\n'
-        qgis_cell.setData(Qt.UserRole, markdown)
+        qgis_cell.setData(Qt.ItemDataRole.UserRole, markdown)
         self.server_combo.setItemData(index, markdown, ServerComboData.MarkDown.value)
         self.update_action_version(lizmap_version, None, row)
 
@@ -895,7 +895,7 @@ class ServerManager:
             lizmap_version, qgis_server_version, login, version_file, self.qgis_desktop, error,
             lizmap_cloud=lizmap_cloud, is_dev=self.parent.is_dev_version)
         if isinstance(qgis_valid, bool) and not qgis_valid:
-            self.table.item(row, TableCell.QgisVersion.value).setData(False, Qt.UserRole + 1)
+            self.table.item(row, TableCell.QgisVersion.value).setData(False, Qt.ItemDataRole.UserRole + 1)
             self.table.item(row, TableCell.QgisVersion.value).setText(tr("Configuration error"))
 
         self.display_action(row, level, '\n'.join(messages))
@@ -1149,9 +1149,9 @@ class ServerManager:
             color = None
 
         if color:
-            cell.setData(Qt.ForegroundRole, QVariant(color))
+            cell.setData(Qt.ItemDataRole.ForegroundRole, QVariant(color))
         else:
-            cell.setData(Qt.ForegroundRole, None)
+            cell.setData(Qt.ItemDataRole.ForegroundRole, None)
         self.table.setItem(row, TableCell.Action.value, cell)
 
     def context_menu_requested(self, position: QPoint):
@@ -1168,13 +1168,13 @@ class ServerManager:
 
         open_url = menu.addAction(tr("Open home page URL") + "…")
         left_item = self.table.item(item.row(), TableCell.Url.value)
-        url = left_item.data(Qt.UserRole)
+        url = left_item.data(Qt.ItemDataRole.UserRole)
         slot = partial(QDesktopServices.openUrl, QUrl(url))
         open_url.triggered.connect(slot)
 
         open_server_info_url = menu.addAction(tr("Open server information URL") + "…")
         left_item = self.table.item(item.row(), TableCell.Url.value)
-        url = left_item.data(Qt.UserRole)
+        url = left_item.data(Qt.ItemDataRole.UserRole)
         slot = partial(QDesktopServices.openUrl, QUrl(ServerWizard.url_server_info(url)))
         open_server_info_url.triggered.connect(slot)
 
@@ -1186,46 +1186,46 @@ class ServerManager:
         if is_dev:
             open_url = menu.addAction(tr("Open raw JSON file URL") + "…")
             left_item = self.table.item(item.row(), TableCell.Url.value)
-            url = left_item.data(Qt.UserRole)
+            url = left_item.data(Qt.ItemDataRole.UserRole)
             slot = partial(QDesktopServices.openUrl, QUrl(ServerWizard.url_metadata(url)))
             open_url.triggered.connect(slot)
 
         action_item = self.table.item(item.row(), TableCell.Action.value)
-        action_data = action_item.data(Qt.DisplayRole)
-        action_required = action_item.data(Qt.ForegroundRole) in (Color.Advice.value, Color.Critical.value)
+        action_data = action_item.data(Qt.ItemDataRole.DisplayRole)
+        action_required = action_item.data(Qt.ItemDataRole.ForegroundRole) in (Color.Advice.value, Color.Critical.value)
 
         qgis_server_item = self.table.item(item.row(), TableCell.QgisVersion.value)
-        data = qgis_server_item.data(Qt.UserRole)
+        data = qgis_server_item.data(Qt.ItemDataRole.UserRole)
 
         show_all_versions = menu.addAction(tr("Display all versions") + "…")
         slot = partial(self.display_all_versions, data)
         show_all_versions.triggered.connect(slot)
 
         server_as_markdown = menu.addAction(tr("Copy versions in the clipboard for a support request"))
-        data = qgis_server_item.data(Qt.UserRole)
+        data = qgis_server_item.data(Qt.ItemDataRole.UserRole)
         slot = partial(self.copy_as_markdown, data, action_data, action_required)
         server_as_markdown.triggered.connect(slot)
 
-        webdav = webdav_properties(qgis_server_item.data(Qt.UserRole + 1))
+        webdav = webdav_properties(qgis_server_item.data(Qt.ItemDataRole.UserRole + 1))
         if webdav:
             login_item = self.table.item(item.row(), TableCell.Login.value)
-            auth_id = login_item.data(Qt.UserRole)
+            auth_id = login_item.data(Qt.ItemDataRole.UserRole)
             action_remote_repository = menu.addAction(tr("Create a remote Lizmap repository") + "…")
             qgis_dav = ServerWizard.trailing_slash(
                 ServerWizard.trailing_slash(webdav.get('url'))
                 + webdav.get('projects_path'))
             left_item = self.table.item(item.row(), TableCell.Url.value)
-            url = left_item.data(Qt.UserRole)
+            url = left_item.data(Qt.ItemDataRole.UserRole)
             slot = partial(self.create_remote_repository, auth_id, qgis_dav, url)
             action_remote_repository.triggered.connect(slot)
 
         show_fonts = menu.addAction(tr("Show fonts available on QGIS Server") + "…")
-        data = qgis_server_item.data(Qt.UserRole + 1).get('qgis_server_info')
+        data = qgis_server_item.data(Qt.ItemDataRole.UserRole + 1).get('qgis_server_info')
         fonts = data.get('fonts')
         if fonts is None:
             fonts = [tr('Upgrade your Lizmap server plugin to have the list of fonts.')]
         name_item = self.table.item(item.row(), TableCell.Name.value)
-        slot = partial(self.show_fonts, fonts, name_item.data(Qt.DisplayRole))
+        slot = partial(self.show_fonts, fonts, name_item.data(Qt.ItemDataRole.DisplayRole))
         show_fonts.triggered.connect(slot)
 
         # noinspection PyArgumentList

--- a/lizmap/table_manager/base.py
+++ b/lizmap/table_manager/base.py
@@ -136,7 +136,7 @@ class TableManager:
                     index = widget.findData(item.value['data'])
                     tooltip = item.value.get('tooltip')
                     if tooltip:
-                        widget.setItemData(index, tooltip, Qt.ToolTipRole)
+                        widget.setItemData(index, tooltip, Qt.ItemDataRole.ToolTipRole)
                 default = general_config.get('default')
                 default: enum
                 if default:
@@ -196,7 +196,7 @@ class TableManager:
                             # When saving the form, we will check if the current input is already in this list.
                             continue
 
-                        cell = item.data(Qt.UserRole)
+                        cell = item.data(Qt.ItemDataRole.UserRole)
                         if cell is None:
                             # Do not put if not cell, it might be False
                             raise Exception('Cell has no data ({}, {})'.format(row, i))
@@ -227,7 +227,7 @@ class TableManager:
 
         # Invalid layer
         cell = self.table.item(row, 0)
-        value = cell.data(Qt.UserRole + 1)
+        value = cell.data(Qt.ItemDataRole.UserRole + 1)
         if isinstance(value, bool) and not value:
             # value is a boolean = False
             # We can't edit a layer which is invalid,
@@ -237,7 +237,7 @@ class TableManager:
         data = dict()
         for i, key in enumerate(self.keys):
             cell = self.table.item(row, i)
-            value = cell.data(Qt.UserRole)
+            value = cell.data(Qt.ItemDataRole.UserRole)
             data[key] = value
 
         # We give the main UI of the plugin in the edition dialog
@@ -270,24 +270,24 @@ class TableManager:
 
             if input_type == InputType.Layer:
                 self._layer = self.project.mapLayer(value)
-                cell.setData(Qt.UserRole, value)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
                 if self._layer:
                     cell.setText(self._layer.name())
-                    cell.setData(Qt.ToolTipRole, '{} ({})'.format(self._layer.name(), self._layer.crs().authid()))
+                    cell.setData(Qt.ItemDataRole.ToolTipRole, '{} ({})'.format(self._layer.name(), self._layer.crs().authid()))
                     if self._layer.isValid():
                         cell.setIcon(QgsMapLayerModel.iconForLayer(self._layer))
-                        cell.setData(Qt.UserRole + 1, True)
+                        cell.setData(Qt.ItemDataRole.UserRole + 1, True)
 
                 if not self._layer or not self._layer.isValid():
                     # Layer is not correctly loading in QGIS
-                    cell.setData(Qt.UserRole + 1, False)
+                    cell.setData(Qt.ItemDataRole.UserRole + 1, False)
                     cell.setIcon(QIcon(":/images/themes/default/mIconWarning.svg"))
                     if self._layer:
                         tooltip_value = self._layer.name()
                     else:
                         tooltip_value = value
                     cell.setData(
-                        Qt.ToolTipRole,
+                        Qt.ItemDataRole.ToolTipRole,
                         tr(
                             'Layer {} is unavailable in QGIS, it\'s not possible to edit its configuration.'
                         ).format(tooltip_value)
@@ -302,13 +302,13 @@ class TableManager:
                             names.append(vector.name())
                 display = ' ,'.join(names)
                 cell.setText(display)
-                cell.setData(Qt.UserRole, value)
-                cell.setData(Qt.ToolTipRole, display)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
+                cell.setData(Qt.ItemDataRole.ToolTipRole, display)
 
             elif input_type in (InputType.Field, InputType.PrimaryKeyField):
                 cell.setText(value)
-                cell.setData(Qt.UserRole, value)
-                cell.setData(Qt.ToolTipRole, value)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
+                cell.setData(Qt.ItemDataRole.ToolTipRole, value)
 
                 # All field inputs are not required, so we might have an empty string
                 # Only check for icon if the field is defined
@@ -320,7 +320,7 @@ class TableManager:
                             cell.setIcon(self._layer.fields().iconForField(index))
                         else:
                             cell.setIcon(QIcon(":/images/themes/default/mIconWarning.svg"))
-                            cell.setData(Qt.ToolTipRole, tr(
+                            cell.setData(Qt.ItemDataRole.ToolTipRole, tr(
                                 'Field "{}" not found in the layer. You should check this configuration or fix your '
                                 'fields.'
                             ).format(value))
@@ -328,51 +328,51 @@ class TableManager:
                         # No layer
                         cell.setIcon(QIcon(":/images/themes/default/mIconWarning.svg"))
                         cell.setData(
-                            Qt.ToolTipRole,
+                            Qt.ItemDataRole.ToolTipRole,
                             tr("Not possible to check the field type if the layer is not loaded in QGIS").format(value)
                         )
 
             elif input_type == InputType.Fields:
                 cell.setText(value)
-                cell.setData(Qt.UserRole, value)
-                cell.setData(Qt.ToolTipRole, value)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
+                cell.setData(Qt.ItemDataRole.ToolTipRole, value)
 
             elif input_type == InputType.File:
                 cell.setText(value)
-                cell.setData(Qt.UserRole, value)
-                cell.setData(Qt.ToolTipRole, value)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
+                cell.setData(Qt.ItemDataRole.ToolTipRole, value)
 
             elif input_type == InputType.Color:
                 cell.setText(value)
-                cell.setData(Qt.UserRole, value)
-                cell.setData(Qt.ToolTipRole, value)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
+                cell.setData(Qt.ItemDataRole.ToolTipRole, value)
                 if value:
-                    cell.setData(Qt.DecorationRole, QColor(value))
+                    cell.setData(Qt.ItemDataRole.DecorationRole, QColor(value))
 
             elif input_type == InputType.CheckBox:
                 if value:
                     cell.setText('✓')
-                    cell.setData(Qt.UserRole, True)
-                    cell.setData(Qt.ToolTipRole, tr('True'))
+                    cell.setData(Qt.ItemDataRole.UserRole, True)
+                    cell.setData(Qt.ItemDataRole.ToolTipRole, tr('True'))
                 else:
                     cell.setText('')
-                    cell.setData(Qt.UserRole, False)
-                    cell.setData(Qt.ToolTipRole, tr('False'))
+                    cell.setData(Qt.ItemDataRole.UserRole, False)
+                    cell.setData(Qt.ItemDataRole.ToolTipRole, tr('False'))
                 cell.setTextAlignment(Qt.AlignCenter)
 
             elif input_type == InputType.Json:
                 if value:
                     cell.setText(json.dumps(value))
-                    cell.setData(Qt.UserRole, value)
-                    cell.setData(Qt.ToolTipRole, value)
+                    cell.setData(Qt.ItemDataRole.UserRole, value)
+                    cell.setData(Qt.ItemDataRole.ToolTipRole, value)
                 else:
                     cell.setText('')
-                    cell.setData(Qt.UserRole, '')
-                    cell.setData(Qt.ToolTipRole, '')
+                    cell.setData(Qt.ItemDataRole.UserRole, '')
+                    cell.setData(Qt.ItemDataRole.ToolTipRole, '')
 
             elif input_type in (InputType.List, InputType.CheckBoxAsDropdown):
-                cell.setData(Qt.UserRole, value)
-                cell.setData(Qt.ToolTipRole, value)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
+                cell.setData(Qt.ItemDataRole.ToolTipRole, value)
                 items = self.definitions.layer_config[key].get('items')
                 multiple_selection = self.definitions.layer_config[key].get('multiple_selection', False)
                 if items:
@@ -413,8 +413,8 @@ class TableManager:
                 else:
                     display = '{}'.format(value)
                 cell.setText(display)
-                cell.setData(Qt.UserRole, value)
-                cell.setData(Qt.ToolTipRole, value)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
+                cell.setData(Qt.ItemDataRole.ToolTipRole, value)
 
             elif input_type == InputType.Text:
                 separator = self.definitions.layer_config[key].get('separator', ',')
@@ -423,8 +423,8 @@ class TableManager:
 
                 # TODO check why value is type 'function'
                 cell.setText(value)
-                cell.setData(Qt.UserRole, value)
-                cell.setData(Qt.ToolTipRole, value)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
+                cell.setData(Qt.ItemDataRole.ToolTipRole, value)
 
                 if self.definitions.key() == 'layouts' and key == 'layout':
                     manager = QgsProject.instance().layoutManager()
@@ -449,20 +449,20 @@ class TableManager:
 
             elif input_type == InputType.MultiLine:
                 cell.setText(value)
-                cell.setData(Qt.UserRole, value)
-                cell.setData(Qt.ToolTipRole, value)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
+                cell.setData(Qt.ItemDataRole.ToolTipRole, value)
 
             elif input_type == InputType.HtmlWysiwyg:
                 cell.setText(value)
-                cell.setData(Qt.UserRole, value)
-                cell.setData(Qt.ToolTipRole, value)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
+                cell.setData(Qt.ItemDataRole.ToolTipRole, value)
 
             elif input_type == InputType.Collection:
                 json_dump = json.dumps(value)
                 cell.setText(json_dump)
-                cell.setData(Qt.UserRole, value)
+                cell.setData(Qt.ItemDataRole.UserRole, value)
                 function = self.definitions.layer_config[key]['represent_value']
-                cell.setData(Qt.ToolTipRole, function(value))
+                cell.setData(Qt.ItemDataRole.ToolTipRole, function(value))
 
             else:
                 raise Exception('InputType "{}" not implemented'.format(input_type))
@@ -520,7 +520,7 @@ class TableManager:
                 if not cell:
                     continue
 
-                value = cell.data(Qt.UserRole)
+                value = cell.data(Qt.ItemDataRole.UserRole)
                 if value == layer_id:
                     self.table.removeRow(i)
                     LOGGER.info("Removing '{}' from table {}".format(layer_id, self.definitions.key()))
@@ -590,7 +590,7 @@ class TableManager:
                     # Do not put if not item, it might be False
                     raise Exception('Cell is not initialized ({}, {})'.format(row, i))
 
-                cell = item.data(Qt.UserRole)
+                cell = item.data(Qt.ItemDataRole.UserRole)
                 if cell is None:
                     # Do not put if not cell, it might be False
                     raise Exception('Cell has no data ({}, {})'.format(row, i))
@@ -1148,7 +1148,7 @@ class TableManager:
         layers = {}
         for row in range(self.table.rowCount()):
             cell = self.table.item(row, index_layer)
-            layer_id = cell.data(Qt.UserRole)
+            layer_id = cell.data(Qt.ItemDataRole.UserRole)
 
             if layer_id not in layers.keys():
                 layers[layer_id] = []
@@ -1162,7 +1162,7 @@ class TableManager:
 
             for i in index_fields:
                 cell = self.table.item(row, i)
-                field_text = cell.data(Qt.UserRole)
+                field_text = cell.data(Qt.ItemDataRole.UserRole)
                 if not field_text:
                     # Some field input are not required
                     continue
@@ -1173,7 +1173,7 @@ class TableManager:
 
             for i in index_list_fields:
                 cell = self.table.item(row, i)
-                field_text = cell.data(Qt.UserRole)
+                field_text = cell.data(Qt.ItemDataRole.UserRole)
                 if not field_text:
                     # Some field input are not required
                     continue
@@ -1184,7 +1184,7 @@ class TableManager:
 
             if index_traces is not None:
                 cell = self.table.item(row, index_traces)
-                field_json = cell.data(Qt.UserRole)
+                field_json = cell.data(Qt.ItemDataRole.UserRole)
                 for trace in field_json:
                     fields = ('y_field', 'z_field', 'colorfield')
                     for f in fields:

--- a/lizmap/table_manager/dataviz.py
+++ b/lizmap/table_manager/dataviz.py
@@ -196,7 +196,7 @@ class TableManagerDataviz(TableManager):
 
         doc = QJsonDocument.fromJson(json_object.encode('utf8'))
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             error = request.post(network_request, QByteArray(doc.toJson()))
 
         if error != QgsBlockingNetworkRequest.NoError:

--- a/lizmap/table_manager/layouts.py
+++ b/lizmap/table_manager/layouts.py
@@ -114,7 +114,7 @@ class TableManagerLayouts(TableManager):
             if not cell:
                 continue
 
-            lizmap_layouts.append(cell.data(Qt.UserRole))
+            lizmap_layouts.append(cell.data(Qt.ItemDataRole.UserRole))
 
         qgis_layouts = []
         for layout in QgsProject.instance().layoutManager().printLayouts():
@@ -139,10 +139,10 @@ class TableManagerLayouts(TableManager):
             if not cell:
                 continue
 
-            value = cell.data(Qt.UserRole)
+            value = cell.data(Qt.ItemDataRole.UserRole)
             if value == old_name:
                 LOGGER.info("Renaming layout from '{}' to '{}'".format(old_name, new_name))
-                cell.setData(Qt.UserRole, new_name)
+                cell.setData(Qt.ItemDataRole.UserRole, new_name)
                 cell.setText(new_name)
                 break
 

--- a/lizmap/test/test_ui.py
+++ b/lizmap/test/test_ui.py
@@ -138,7 +138,7 @@ class TestUiLizmapDialog(unittest.TestCase):
         self.assertEqual(item.text(0), 'lines')
         self.assertTrue(item.text(1).startswith('lines_'))
         self.assertEqual(item.text(2), 'layer')
-        self.assertEqual(item.data(0, Qt.UserRole + 1), PredefinedGroup.No.value)
+        self.assertEqual(item.data(0, Qt.ItemDataRole.UserRole + 1), PredefinedGroup.No.value)
         self.assertEqual(item.text(3), '')  # Not used, just to test
 
         self.assertFalse(lizmap.dlg.list_group_visibility.isEnabled())
@@ -158,27 +158,27 @@ class TestUiLizmapDialog(unittest.TestCase):
         lizmap.save_value_layer_group_data('abstract')
 
         # Click the group base-layers
-        group_item = lizmap.dlg.layer_tree.findItems('baselayers', Qt.MatchContains | Qt.MatchRecursive, 0)[0]
+        group_item = lizmap.dlg.layer_tree.findItems('baselayers', Qt.MatchFlag.MatchContains | Qt.MatchFlag.MatchRecursive, 0)[0]
         lizmap.dlg.layer_tree.setCurrentItem(group_item)
         self.assertFalse(lizmap.dlg.panel_layer_all_settings.isEnabled())
 
         # Click the group project-background-color
         group_item = lizmap.dlg.layer_tree.findItems(
-            'project-background-color', Qt.MatchContains | Qt.MatchRecursive, 0)[0]
+            'project-background-color', Qt.MatchFlag.MatchContains | Qt.MatchFlag.MatchRecursive, 0)[0]
         lizmap.dlg.layer_tree.setCurrentItem(group_item)
         self.assertTrue(lizmap.dlg.panel_layer_all_settings.isEnabled())
         self.assertTrue(lizmap.dlg.group_layer_metadata.isEnabled())
         self.assertFalse(lizmap.dlg.group_layer_tree_options.isEnabled())
 
         # Click the group hidden
-        group_item = lizmap.dlg.layer_tree.findItems('hidden', Qt.MatchContains | Qt.MatchRecursive, 0)[0]
+        group_item = lizmap.dlg.layer_tree.findItems('hidden', Qt.MatchFlag.MatchContains | Qt.MatchFlag.MatchRecursive, 0)[0]
         lizmap.dlg.layer_tree.setCurrentItem(group_item)
         # It should work, maybe the test click and click in the UI is missing one thing
         # self.assertEqual(PredefinedGroup.Hidden.value, lizmap._current_item_predefined_group())
         # self.assertFalse(lizmap.dlg.panel_layer_all_settings.isEnabled())
 
         # Back to a layer outside of these groups
-        group_item = lizmap.dlg.layer_tree.findItems('lines', Qt.MatchContains | Qt.MatchRecursive, 0)[0]
+        group_item = lizmap.dlg.layer_tree.findItems('lines', Qt.MatchFlag.MatchContains | Qt.MatchFlag.MatchRecursive, 0)[0]
         lizmap.dlg.layer_tree.setCurrentItem(group_item)
         self.assertTrue(lizmap.dlg.list_group_visibility.isEnabled())
 

--- a/lizmap/test/test_wizard.py
+++ b/lizmap/test/test_wizard.py
@@ -30,7 +30,7 @@ class TestWizardGroupAclDialog(unittest.TestCase):
         self.assertEqual(2, dialog.list.count())
         selection = dialog.list.selectedItems()
         self.assertEqual(1, len(selection))
-        self.assertEqual("admins", selection[0].data(Qt.UserRole))
+        self.assertEqual("admins", selection[0].data(Qt.ItemDataRole.UserRole))
         self.assertEqual("foo,bar", dialog.additional.text())
         self.assertEqual("admins,foo,bar", dialog.preview.text())
 

--- a/lizmap/toolbelt/debug.py
+++ b/lizmap/toolbelt/debug.py
@@ -6,7 +6,7 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QComboBox
 
 
-def _debug_combobox(combo: QComboBox, data_start: int = Qt.UserRole, data_max: int = 0):
+def _debug_combobox(combo: QComboBox, data_start: int = Qt.ItemDataRole.UserRole, data_max: int = 0):
     """ Debug a QComboBox. """
     for i in range(combo.count()):
         print("=== NEW ITEM ===")

--- a/lizmap/toolbelt/plugin.py
+++ b/lizmap/toolbelt/plugin.py
@@ -36,4 +36,4 @@ def user_settings() -> Path:
 def plugin_date() -> QDateTime:
     """Return the version defined in metadata.txt."""
     date = metadata_config()["general"]["dateTime"]
-    return QDateTime().fromString(date, Qt.ISODate)
+    return QDateTime().fromString(date, Qt.DateFormat.ISODate)

--- a/lizmap/widgets/check_project.py
+++ b/lizmap/widgets/check_project.py
@@ -1048,7 +1048,7 @@ class TableCheck(QTableWidget):
     """ Subclassing of QTableWidget in the plugin. """
 
     # noinspection PyUnresolvedReferences
-    DATA = Qt.UserRole
+    DATA = Qt.ItemDataRole.UserRole
     JSON = DATA + 1
     EXPORT = JSON + 1
 
@@ -1132,7 +1132,7 @@ class TableCheck(QTableWidget):
         """ Export a sum up of warnings to Markdown. """
         result = {}
         for row in range(self.rowCount()):
-            error_name = self.item(row, 3).data(Qt.DisplayRole)
+            error_name = self.item(row, 3).data(Qt.ItemDataRole.DisplayRole)
             if error_name not in result.keys():
                 result[error_name] = 1
             else:

--- a/lizmap/widgets/list_fields_selection.py
+++ b/lizmap/widgets/list_fields_selection.py
@@ -29,7 +29,7 @@ class ListFieldsSelection(QListWidget):
                 cell.setText(field.name())
             else:
                 cell.setText("{} ({})".format(field.name(), alias))
-            cell.setData(Qt.UserRole, field.name())
+            cell.setData(Qt.ItemDataRole.UserRole, field.name())
             index = layer.fields().indexFromName(field.name())
             if index >= 0:
                 cell.setIcon(self.layer.fields().iconForField(index))
@@ -38,12 +38,12 @@ class ListFieldsSelection(QListWidget):
     def set_selection(self, fields: tuple):
         for i in range(self.count()):
             item = self.item(i)
-            item.setSelected(item.data(Qt.UserRole) in fields)
+            item.setSelected(item.data(Qt.ItemDataRole.UserRole) in fields)
 
     def selection(self) -> list:
         selection = []
         for i in range(self.count()):
             item = self.item(i)
             if item.isSelected():
-                selection.append(item.data(Qt.UserRole))
+                selection.append(item.data(Qt.ItemDataRole.UserRole))
         return selection

--- a/lizmap/widgets/list_layers_selection.py
+++ b/lizmap/widgets/list_layers_selection.py
@@ -31,19 +31,19 @@ class ListLayersSelection(QListWidget):
 
             cell = QListWidgetItem()
             cell.setText(layer.name())
-            cell.setData(Qt.UserRole, layer.id())
+            cell.setData(Qt.ItemDataRole.UserRole, layer.id())
             cell.setIcon(QgsMapLayerModel.iconForLayer(layer))
             self.addItem(cell)
 
     def set_selection(self, layers: tuple):
         for i in range(self.count()):
             item = self.item(i)
-            item.setSelected(item.data(Qt.UserRole) in layers)
+            item.setSelected(item.data(Qt.ItemDataRole.UserRole) in layers)
 
     def selection(self) -> list:
         selection = []
         for i in range(self.count()):
             item = self.item(i)
             if item.isSelected():
-                selection.append(item.data(Qt.UserRole))
+                selection.append(item.data(Qt.ItemDataRole.UserRole))
         return selection

--- a/lizmap/widgets/selectable_combobox.py
+++ b/lizmap/widgets/selectable_combobox.py
@@ -30,8 +30,8 @@ class CheckableComboBox:
             self.select_all.clicked.connect(self.select_all_clicked)
 
     def select_all_clicked(self):
-        for item in self.model.findItems("*", Qt.MatchWildcard):
-            item.setCheckState(Qt.Checked)
+        for item in self.model.findItems("*", Qt.MatchFlag.MatchWildcard):
+            item.setCheckState(Qt.CheckState.Checked)
 
     def append_row(self, item: QStandardItem):
         """Add an item to the combobox."""
@@ -46,15 +46,15 @@ class CheckableComboBox:
 
     def selected_items(self) -> list:
         checked_items = []
-        for item in self.model.findItems("*", Qt.MatchWildcard):
-            if item.checkState() == Qt.Checked:
+        for item in self.model.findItems("*", Qt.MatchFlag.MatchWildcard):
+            if item.checkState() == Qt.CheckState.Checked:
                 checked_items.append(item.data())
         return checked_items
 
     def set_selected_items(self, items):
-        for item in self.model.findItems("*", Qt.MatchWildcard):
+        for item in self.model.findItems("*", Qt.MatchFlag.MatchWildcard):
             checked = item.data() in items
-            item.setCheckState(Qt.Checked if checked else Qt.Unchecked)
+            item.setCheckState(Qt.CheckState.Checked if checked else Qt.CheckState.Unchecked)
 
     def text_changed(self, text):
         """Update the preview with all selected items, separated by a comma."""

--- a/lizmap/widgets/table_files.py
+++ b/lizmap/widgets/table_files.py
@@ -44,7 +44,7 @@ class TableFiles(QTableWidget):
     """ Subclassing of QTableWidget in the plugin. """
 
     # noinspection PyUnresolvedReferences
-    ABSOLUTE_PATH = Qt.UserRole
+    ABSOLUTE_PATH = Qt.ItemDataRole.UserRole
     RELATIVE_PATH = ABSOLUTE_PATH + 1
 
     val_Changed = pyqtSignal(int, str, name='valChanged')


### PR DESCRIPTION
Hopefully, it will fix #616 

@nicogodet Can you try this fix ?

It was a hard search and replace from `Qt.UserRole` to `Qt.ItemDataRole.UserRole`

If so, I will edit the wiki https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6 and raise the issue about the migrating script.


Thanks for your early testing.