### PR TITLE
[BUGFIX] python error when getting metadata of corrupted qgis layer

### DIFF
--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -2161,9 +2161,17 @@ class Lizmap:
         # DEFAULT VALUES : layers have got more precise data
         keep_metadata = False
         if item_type == 'layer':
+            layer = self.get_qgis_layer_by_id(item_key)
+            
+            # layer corrupted ?
+            if layer is None:
+                error_msg = tr(
+                    "The layer '{}' seems invalid. Check the layer configuration."
+                ).format(item_key)
+                self.display_error(error_msg)
+                raise Exception(error_msg)
 
             # layer name
-            layer = self.get_qgis_layer_by_id(item_key)
             self.myDic[item_key]['name'] = layer.name()
             # title and abstract
             self.myDic[item_key]['title'] = layer.name()


### PR DESCRIPTION
Sometime the get_qgis_layer_by_id return a None result in populate_layer_tree. 
In my case it happened because the layer got corrupted in the QGIS project (layer exist as legendlayer and layer-tree-group but not as maplayer for some reasons, propably linked to bad QGIS version used by some of our users)

Any case, it's a good idea to check the result of this function and warn the user if there is a problem.

Two solution are possible, i'm not sure what is the best

1. either return on fail and display an error message, layer metadata are not updated and the project loads normally
2. either raise on fail (after displaying an error message). An python error warning is displayed (unwanted) but the lizmap windows is not displayed, forcing the user to correct the qgis project. 

I've implemented solution 1 but both seems ok to me. 

* **Funded by**: Festival Balélec - Téo Goddet
* **Description**: Check if a given layer is corrupted in the QGIS project before extracting its metadata to avoid uncatched and unhelpful python errors preventing the lizmap window opening.