### PR TITLE
Add new setting about layer primary key field

### DIFF
--- a/lizmap/dialogs/main.py
+++ b/lizmap/dialogs/main.py
@@ -1042,6 +1042,7 @@ class LizmapDialog(QDialog, FORM_CLASS):
             self.gb_generalOptions,
             self.gb_interface,
             self.gb_baselayersOptions,
+            self.group_box_primary_key,
             self.predefined_groups_legend,
             self.predefined_groups,
             self.predefined_baselayers,

--- a/lizmap/forms/base_edition_dialog.py
+++ b/lizmap/forms/base_edition_dialog.py
@@ -23,7 +23,7 @@ from lizmap.dialogs.main import LizmapDialog
 from lizmap.dialogs.wizard_group import WizardGroupDialog
 from lizmap.qt_style_sheets import NEW_FEATURE_COLOR, NEW_FEATURE_CSS
 from lizmap.toolbelt.i18n import tr
-from lizmap.toolbelt.layer import is_database_layer
+from lizmap.widgets.primary_key_field import enable_primary_key_field
 from lizmap.widgets.project_tools import is_layer_published_wfs
 
 
@@ -472,46 +472,11 @@ class BaseEditionDialog(QDialog):
         """ Enable or not the primary key widget.
 
         For a database based layer (PG, SQLite, GPKG) the widget is disabled."""
-        if not self.layer:
-            self.primary_key_valid = None
-            return
         if not self.primary_key:
             self.primary_key_valid = None
             return
 
-        tooltip = self.primary_key.toolTip()
-        extra_tooltip = tr('The primary key is defined by the dataprovider only for layer stored in a database.')
-        self.primary_key.setToolTip('{} {}'.format(tooltip, extra_tooltip))
-
-        layer = self.layer.currentLayer()
-        if not is_database_layer(layer):
-            self.primary_key.setEnabled(True)
-            self.primary_key.setAllowEmptyFieldName(False)
-            self.primary_key_valid = None
-            return
-
-        # We trust the datasource
-        # And we do not trust the legacy CFG
-        self.primary_key.setEnabled(False)
-        self.primary_key.setAllowEmptyFieldName(True)
-        pks = layer.primaryKeyAttributes()
-        if len(pks) == 0:
-            # Must be an issue for the user to validate the form, because the widget is disabled
-            # The datasource must be fixed
-            self.primary_key_valid = False
-            return
-
-        if len(pks) >= 2:
-            # As well, the user must add a PK and an unicity constraint
-            # Not possible to validate the form
-            self.primary_key_valid = False
-            return
-
-        # Single field as a primary key
-        # We do not trust the CFG anymore, let's go datasource
-        name = layer.fields().at(pks[0]).name()
-        self.primary_key.setField(name)
-        self.primary_key_valid = True
+        self.primary_key_valid = enable_primary_key_field(self.primary_key, self.layer.currentLayer())
 
     def open_wizard_dialog(self, helper: str):
         """ Internal function to open the wizard ACL. """

--- a/lizmap/lizmap_api/config.py
+++ b/lizmap/lizmap_api/config.py
@@ -266,6 +266,9 @@ class LizmapConfig:
 
         # We want to translate some items, do not make this variable static
         self.layerOptionDefinitions = {
+            'primary_key': {
+                'wType': 'list', 'type': 'field', 'default': '',
+            },
             'title': {
                 'wType': 'text', 'type': 'string', 'default': '', 'isMetadata': True
             },

--- a/lizmap/plugin.py
+++ b/lizmap/plugin.py
@@ -163,6 +163,7 @@ from lizmap.table_manager.dataviz import TableManagerDataviz
 from lizmap.table_manager.layouts import TableManagerLayouts
 from lizmap.toolbelt.convert import cast_to_group, cast_to_layer
 from lizmap.widgets.check_project import Check, SourceField
+from lizmap.widgets.primary_key_field import enable_primary_key_field
 from lizmap.widgets.project_tools import (
     empty_baselayers,
     is_layer_published_wfs,
@@ -529,6 +530,7 @@ class Lizmap:
 
         self.layer_options_list = lizmap_config.layerOptionDefinitions
         # Add widget information
+        self.layer_options_list['primary_key']['widget'] = self.dlg.primary_key
         self.layer_options_list['title']['widget'] = self.dlg.inLayerTitle
         self.layer_options_list['abstract']['widget'] = self.dlg.teLayerAbstract
         self.layer_options_list['link']['widget'] = self.dlg.inLayerLink
@@ -699,23 +701,30 @@ class Lizmap:
 
         # Connect widget signals to setLayerProperty method depending on widget type
         for key, item in self.layer_options_list.items():
-            if item.get('widget'):
-                control = item['widget']
-                slot = partial(self.save_value_layer_group_data, key)
-                if item['wType'] in ('text', 'spinbox'):
-                    control.editingFinished.connect(slot)
-                elif item['wType'] == 'textarea':
-                    control.textChanged.connect(slot)
-                elif item['wType'] == 'checkbox':
-                    control.stateChanged.connect(slot)
-                elif item['wType'] == 'radio':
-                    control.toggled.connect(slot)
-                elif item['wType'] == 'list':
-                    control.currentIndexChanged.connect(slot)
-                elif item['wType'] == 'layers':
-                    control.layerChanged.connect(slot)
-                elif item['wType'] == 'fields':
+            control = item.get('widget')
+            if not isinstance(control, QWidget):
+                # Be careful, big waste of time if control is not checked to be a QWidget for QgsFieldComboBox
+                # https://github.com/qgis/QGIS/issues/62317
+                continue
+
+            slot = partial(self.save_value_layer_group_data, key)
+            if item['wType'] in ('text', 'spinbox'):
+                control.editingFinished.connect(slot)
+            elif item['wType'] == 'textarea':
+                control.textChanged.connect(slot)
+            elif item['wType'] == 'checkbox':
+                control.stateChanged.connect(slot)
+            elif item['wType'] == 'radio':
+                control.toggled.connect(slot)
+            elif item['wType'] == 'list':
+                if item['type'] == 'field':
                     control.fieldChanged.connect(slot)
+                else:
+                    control.currentIndexChanged.connect(slot)
+            elif item['wType'] == 'layers':
+                control.layerChanged.connect(slot)
+            elif item['wType'] == 'fields':
+                control.fieldChanged.connect(slot)
 
         self.crs_3857_base_layers_list = {
             'osm-mapnik': self.dlg.cbOsmMapnik,
@@ -2250,9 +2259,13 @@ class Lizmap:
                                     self.myDic[item_key][key] = json_layers[json_key][key]
                         # lists
                         elif item['wType'] == 'list':
-                            # New way with data, label, tooltip and icon
-                            datas = [j[0] for j in item['list']]
-                            if json_layers[json_key][key] in datas:
+                            if item.get('list'):
+                                # New way with data, label, tooltip and icon
+                                datas = [j[0] for j in item['list']]
+                                if json_layers[json_key][key] in datas:
+                                    self.myDic[item_key][key] = json_layers[json_key][key]
+                            else:
+                                # The list is managed by the layer and function enable_primary_key_field()
                                 self.myDic[item_key][key] = json_layers[json_key][key]
 
                 else:
@@ -2421,6 +2434,8 @@ class Lizmap:
         #     if val.get('widget'):
         #         val.get('widget').setEnabled(True)
 
+        self.dlg.group_box_primary_key.setVisible(False)
+
         i_key = self._current_selected_item_in_config()
         if i_key:
             self.enable_check_box_in_layer_tab(True)
@@ -2508,6 +2523,11 @@ class Lizmap:
             self.dlg.button_generate_html_table.setEnabled(is_vector)
             self.layer_options_list['popupSource']['widget'].setEnabled(is_vector)
 
+            if is_vector:
+                self.dlg.primary_key.setLayer(layer)
+                enable_primary_key_field(self.dlg.primary_key, layer)
+            self.dlg.group_box_primary_key.setVisible(is_vector)
+
             if self.current_lwc_version() >= LwcVersions.Lizmap_3_7 and not self.dlg.cbLayerIsBaseLayer.isChecked():
                 # Starting from LWC 3.7, this checkbox is deprecated
                 self.dlg.cbLayerIsBaseLayer.setEnabled(False)
@@ -2561,10 +2581,13 @@ class Lizmap:
                     elif val['wType'] in ('checkbox', 'radio'):
                         val['widget'].setChecked(val['default'])
                     elif val['wType'] == 'list':
-
-                        # New way with data, label, tooltip and icon
-                        index = val['widget'].findData(val['default'])
-                        val['widget'].setCurrentIndex(index)
+                        if layer_option.get('list'):
+                            # New way with data, label, tooltip and icon
+                            index = val['widget'].findData(val['default'])
+                            val['widget'].setCurrentIndex(index)
+                        else:
+                            # The list is managed by the layer and function enable_primary_key_field()
+                            val['widget'].setCurrentIndex(0)
 
         self.enable_popup_source_button()
         self.dlg.follow_map_theme_toggled()
@@ -2815,9 +2838,13 @@ class Lizmap:
                     if self.layer_options_list[children]['widget'].isChecked():
                         self.layer_options_list[children]['widget'].setChecked(False)
         elif layer_option['wType'] == 'list':
-            # New way with data, label, tooltip and icon
-            datas = [j[0] for j in layer_option['list']]
-            self.layerList[layer_or_group_text][key] = datas[layer_option['widget'].currentIndex()]
+            if layer_option.get('list'):
+                # New way with data, label, tooltip and icon
+                datas = [j[0] for j in layer_option['list']]
+                self.layerList[layer_or_group_text][key] = datas[layer_option['widget'].currentIndex()]
+            else:
+                # The list is managed by the layer and function enable_primary_key_field()
+                self.layerList[layer_or_group_text][key] = layer_option['widget'].currentField()
 
         # Deactivate the "exclude" widget if necessary
         if 'exclude' in layer_option \

--- a/lizmap/resources/ui/ui_lizmap.ui
+++ b/lizmap/resources/ui/ui_lizmap.ui
@@ -1559,6 +1559,28 @@ This is different to the map maximum extent (defined in QGIS project properties,
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_9">
                       <item>
+                       <widget class="QGroupBox" name="group_box_primary_key">
+                        <property name="title">
+                         <string>Datasource</string>
+                        </property>
+                        <layout class="QFormLayout" name="formLayout_11">
+                         <item row="0" column="0">
+                          <widget class="QLabel" name="label_55">
+                           <property name="text">
+                            <string>Primary key</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="0" column="1">
+                          <widget class="QgsFieldComboBox" name="primary_key"/>
+                         </item>
+                        </layout>
+                       </widget>
+                      </item>
+                      <item>
+                       <layout class="QFormLayout" name="formLayout_10"/>
+                      </item>
+                      <item>
                        <widget class="QgsCollapsibleGroupBox" name="group_layer_metadata">
                         <property name="title">
                          <string>Metadata</string>

--- a/lizmap/widgets/primary_key_field.py
+++ b/lizmap/widgets/primary_key_field.py
@@ -1,0 +1,49 @@
+__copyright__ = 'Copyright 2025, 3Liz'
+__license__ = 'GPL version 3'
+__email__ = 'info@3liz.org'
+
+from typing import Optional
+
+from qgis.core import QgsVectorLayer
+from qgis.gui import QgsFieldComboBox
+
+from lizmap.toolbelt.i18n import tr
+from lizmap.toolbelt.layer import is_database_layer
+
+
+def enable_primary_key_field(primary_key: QgsFieldComboBox, layer: Optional[QgsVectorLayer]) -> Optional[bool]:
+    """ Enable or not the primary key widget.
+    For a database based layer (PG, SQLite, GPKG) the widget is disabled."""
+    if not layer:
+        return None
+
+    tooltip = primary_key.toolTip()
+    extra_tooltip = tr('The primary key is defined by the dataprovider only for layer stored in a database.')
+    if extra_tooltip not in tooltip:
+        primary_key.setToolTip('{} {}'.format(tooltip, extra_tooltip))
+
+    if not is_database_layer(layer):
+        primary_key.setEnabled(True)
+        primary_key.setAllowEmptyFieldName(False)
+        return None
+
+    # We trust the datasource
+    # And we do not trust the legacy CFG
+    primary_key.setEnabled(False)
+    primary_key.setAllowEmptyFieldName(True)
+    pks = layer.primaryKeyAttributes()
+    if len(pks) == 0:
+        # Must be an issue for the user to validate the form, because the widget is disabled
+        # The datasource must be fixed
+        return False
+
+    if len(pks) >= 2:
+        # As well, the user must add a PK and an unicity constraint
+        # Not possible to validate the form
+        return False
+
+    # Single field as a primary key
+    # We do not trust the CFG anymore, let's go datasource
+    name = layer.fields().at(pks[0]).name()
+    primary_key.setField(name)
+    return True

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -84,6 +84,10 @@ class TestUiLizmapDialog(TestCase):
             "hide_at_startup", lizmap.myDic.get("legend_hidden_startup_layer_id").get("legend_image_option")
         )
 
+        # self.assertEqual(
+        #     'id', lizmap.myDic.get('legend_hidden_startup_layer_id').get('primary_key')
+        # )
+
         # For LWC 3.6
         output = lizmap.project_config_file(
             LwcVersions.Lizmap_3_6,
@@ -168,6 +172,11 @@ class TestUiLizmapDialog(TestCase):
         # Click the first line
         lizmap.dlg.layer_tree.setCurrentItem(lizmap.dlg.layer_tree.topLevelItem(0))
 
+        # Primary key
+        # self.assertTrue(lizmap.dlg.group_box_primary_key.isVisible())
+        self.assertTrue(lizmap.dlg.primary_key.isEnabled())
+        self.assertFalse(lizmap.dlg.primary_key.allowEmptyFieldName())
+
         # Fill the ACL field
         self.assertTrue(lizmap.dlg.list_group_visibility.isEnabled())
         acl_layer = "a_group_id"
@@ -219,6 +228,7 @@ class TestUiLizmapDialog(TestCase):
         )
 
         # Layers
+        self.assertEqual(output["layers"]["lines"]["primary_key"], 'id')
         self.assertListEqual(output["layers"]["lines"]["group_visibility"], [acl_layer])
         self.assertEqual(output["layers"]["lines"]["abstract"], html_abstract)
         # Predefined groups, still in the CFG


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ec6528f4-ec62-42c4-9f1b-19d7555e51de)

Temporary


It adds a new key in the broad `layers` config `"primary_key": "",`

_not ready for now_

Linked to https://github.com/3liz/lizmap-web-client/issues/5782

Based on @Gustry works https://github.com/3liz/lizmap-plugin/pull/638