### PR TITLE
Fix: used dummy varaible _print_layout

### DIFF
--- a/lizmap/forms/layout_edition.py
+++ b/lizmap/forms/layout_edition.py
@@ -74,9 +74,9 @@ class LayoutEditionDialog(BaseEditionDialog, CLASS):
 
         atlas_layout = None
         if layout.layoutType() == QgsMasterLayoutInterface.Type.PrintLayout:
-            for _print_layout in manager.printLayouts():
-                if _print_layout.name() == self.layout.text():
-                    atlas_layout = _print_layout
+            for print_layout in manager.printLayouts():
+                if print_layout.name() == self.layout.text():
+                    atlas_layout = print_layout
                     break
 
         if not atlas_layout:

--- a/lizmap/table_manager/base.py
+++ b/lizmap/table_manager/base.py
@@ -431,9 +431,9 @@ class TableManager:
 
                     atlas_layout = None
                     if layout.layoutType() == QgsMasterLayoutInterface.Type.PrintLayout:
-                        for _print_layout in manager.printLayouts():
-                            if _print_layout.name() == value:
-                                atlas_layout = _print_layout
+                        for print_layout in manager.printLayouts():
+                            if print_layout.name() == value:
+                                atlas_layout = print_layout
                                 break
 
                     if not atlas_layout:


### PR DESCRIPTION
[RUF052](https://docs.astral.sh/ruff/rules/used-dummy-variable/) checks for "dummy variables" (variables that are named as if to indicate they are unused) that are in fact used. By default, "dummy variables" are any variables with names that start with leading underscores. `_print_layout` is considered as dummy varaible and it is used.

To fix it, `_print_layout` has been updated to `print_layout`.