### PR TITLE
Fix typo in metadata key for LWC version detection

### DIFF
--- a/lizmap/dialogs/main.py
+++ b/lizmap/dialogs/main.py
@@ -771,7 +771,7 @@ class LizmapDialog(QDialog, FORM_CLASS):
         metadata = self.current_server_info(ServerComboData.JsonMetadata.value)
         # In tests, we might not have metadata in the combobox
         if metadata and metadata.get('info'):
-            version_str = metadata["info"].get("versions")
+            version_str = metadata["info"].get("version")
             if version_str:
                 return LwcVersions.find(version_str)
 


### PR DESCRIPTION
The release 5.0.0-alpha.1 wrongly displays the "Current Lizmap Web Client branch selected" as always 3.11 - there is a small typo which this PR fixes.

<img width="853" height="663" alt="grafik" src="https://github.com/user-attachments/assets/6deacd72-1666-4863-885d-74450af76695" />

