### PR TITLE
Make filter form title field mandatory

### DIFF
--- a/lizmap/forms/filter_by_form_edition.py
+++ b/lizmap/forms/filter_by_form_edition.py
@@ -189,6 +189,9 @@ class FilterByFormEditionDialog(BaseEditionDialog, CLASS):
         if upstream:
             return upstream
 
+        if not self.title.text().strip():
+            return tr('The title is mandatory.')
+
         layer = self.layer.currentLayer()
         not_in_wfs = self.is_layer_in_wfs(layer)
         if not_in_wfs:


### PR DESCRIPTION
Validate that the title field is not empty in the filter by form dialog, as a blank title causes the filter to not appear in the Lizmap web interface.

Fixing issue #556
