### PR TITLE
Tooltip - Add LWC 3.10 new feature 'Display layer features with QGIS symbology

### DIFF
--- a/lizmap/definitions/tooltip.py
+++ b/lizmap/definitions/tooltip.py
@@ -46,6 +46,19 @@ class ToolTipDefinitions(BaseDefinitions):
             'default': '',
             'tooltip': tr('The color to use for displaying the geometry.')
         }
+        self._layer_config['displayLayerStyle'] = {
+            'type': InputType.CheckBox,
+            'header': tr('Display layer features'),
+            'default': False,
+            'tooltip': tr(
+                'If checked, the layer features will be displayed in the map'
+                ' with a symbology as close as possible to the layer symbology.'
+                ' The conversion from QGIS symbology is not always perfect '
+                ' since it relies on the SLD standard.'
+                ' SVG and PNG files must be embedded in the symbology properties.'
+            ),
+            'version': LwcVersions.Lizmap_3_10,
+        }
 
     @staticmethod
     def primary_keys() -> tuple:

--- a/lizmap/resources/ui/ui_form_tooltip.ui
+++ b/lizmap/resources/ui/ui_form_tooltip.ui
@@ -79,7 +79,14 @@
           </widget>
          </item>
          <item>
-          <widget class="HtmlEditorWidget" name="html_template" native="true"/>
+          <widget class="HtmlEditorWidget" name="html_template" native="true">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>300</height>
+            </size>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -119,13 +126,6 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_color">
-       <property name="text">
-        <string>Color</string>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="1">
       <widget class="QgsColorButton" name="color">
        <property name="sizePolicy">
@@ -133,6 +133,27 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_color">
+       <property name="text">
+        <string>Color</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_display_layer_style">
+       <property name="text">
+        <string>Display layer features</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QCheckBox" name="display_layer_style">
+       <property name="text">
+        <string/>
        </property>
       </widget>
      </item>
@@ -175,15 +196,15 @@
    <header>qgis.gui</header>
   </customwidget>
   <customwidget>
-   <class>ListFieldsSelection</class>
-   <extends>QListWidget</extends>
-   <header>lizmap.widgets.list_fields_selection</header>
-  </customwidget>
-  <customwidget>
    <class>HtmlEditorWidget</class>
    <extends>QWidget</extends>
    <header>lizmap.widgets.html_editor</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ListFieldsSelection</class>
+   <extends>QListWidget</extends>
+   <header>lizmap.widgets.list_fields_selection</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Publish and share your QGIS maps on the Web via Lizmap Web Client
 authors = [
     { name = "3Liz", email = "info@3liz.com" }
 ]
-version = "5.0.0-alpha.3-pre"
+version = "5.0.0-alpha.3+pre"
 requires-python = ">= 3.9"
 license = "GPL-2.0-only"
 license-files = ["LICENSE"]

--- a/tests/test_dxf_export.py
+++ b/tests/test_dxf_export.py
@@ -10,7 +10,6 @@ from qgis.PyQt.QtWidgets import QTableWidget
 
 from lizmap.table_manager.dxf_export import TableManagerDxfExport
 from lizmap.toolbelt.convert import ambiguous_to_bool
-from lizmap.widgets.project_tools import is_layer_published_wfs
 
 from .compat import TestCase
 
@@ -50,8 +49,9 @@ class TestTableManagerDxfExport(TestCase):
 
     def test_initialization(self):
         """Test table manager initialization."""
+        # Initialize manager
         table = QTableWidget()
-        manager = TableManagerDxfExport(table)
+        TableManagerDxfExport(table)
 
         # Check table is configured correctly
         self.assertEqual(table.columnCount(), 2)

--- a/tests/test_table_manager.py
+++ b/tests/test_table_manager.py
@@ -909,6 +909,7 @@ class TestTableManager(TestCase):
                 "template": '<p>[% "nom" %]</p>\n',
                 "displayGeom": "False",
                 "colorGeom": "",
+                "displayLayerStyle": "False",
                 "layerId": layer.id(),
                 "order": 0,
             }

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -474,8 +474,8 @@ class TestUiLizmapDialog(TestCase):
 
         # map tools
         self.assertFalse(output["options"].get("measure"))
-        self.assertIsNone(output["options"].get("print")) # The checkbox is removed since LWC 3.7.0
-        self.assertIsNone(output["options"].get("zoomHistory")) # The checkbox is removed since LWC 3.8.0
+        self.assertIsNone(output["options"].get("print"))  # The checkbox is removed since LWC 3.7.0
+        self.assertIsNone(output["options"].get("zoomHistory"))  # The checkbox is removed since LWC 3.8.0
         self.assertFalse(output["options"].get("geolocation"))
         # self.assertIsNone(output["options"].get("geolocationPrecision")) # Added since LWC 3.10.0
         # self.assertIsNone(output["options"].get("geolocationDirection")) # Added since LWC 3.10.0
@@ -526,7 +526,7 @@ class TestUiLizmapDialog(TestCase):
         self.assertIsNone(output["options"].get("datavizTemplate"))
         self.assertIsNone(output["options"].get("dataviz_drag_drop"))
         self.assertEqual("dock", output["options"].get("datavizLocation"))
-        self.assertIsNone(output["options"].get("theme")) # default value "dark" is not set
+        self.assertIsNone(output["options"].get("theme"))  # default value "dark" is not set
 
         # Time manager page
         self.assertEqual(10, output["options"].get("tmTimeFrameSize"))
@@ -554,8 +554,8 @@ class TestUiLizmapDialog(TestCase):
         self.assertIsNone(output["options"].get("print"))  # The checkbox is removed since LWC 3.7.0
         self.assertIsNone(output["options"].get("zoomHistory"))  # The checkbox is removed since LWC 3.8.0
         self.assertFalse(output["options"].get("geolocation"))
-        self.assertTrue(output["options"].get("geolocationPrecision")) # Added since LWC 3.10.0
-        self.assertFalse(output["options"].get("geolocationDirection")) # Added since LWC 3.10.0
+        self.assertTrue(output["options"].get("geolocationPrecision"))  # Added since LWC 3.10.0
+        self.assertFalse(output["options"].get("geolocationDirection"))  # Added since LWC 3.10.0
         self.assertFalse(output["options"].get("draw"))
         self.assertIsNone(output["options"].get("externalSearch"))
         self.assertEqual(25, output["options"].get("pointTolerance"))

--- a/uv.lock
+++ b/uv.lock
@@ -337,7 +337,7 @@ wheels = [
 
 [[package]]
 name = "lizmap"
-version = "5.0.0"
+version = "5.0.0a3+pre"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
* **Funded by**: Conseil départemental du Gard (https://sig.gard.fr)
* **Description**:
  * Add UI to configure the new feature "Display layer features" in the tooltip tool. See https://github.com/3liz/lizmap-web-client/pull/5768

<img width="658" height="628" alt="image" src="https://github.com/user-attachments/assets/6ff85e58-cf69-48f1-92ae-8f6065eba546" />
