### PR TITLE
feat: add snap_on_start checkbox for edition layers

### DIFF
--- a/lizmap/definitions/edition.py
+++ b/lizmap/definitions/edition.py
@@ -119,6 +119,13 @@ class EditionDefinitions(BaseDefinitions):
             'tooltip': tr('Snapping tolerance for intersections.'),
             'version': LwcVersions.Lizmap_3_4,
         }
+        self._layer_config['snap_on_start'] = {
+            'type': InputType.CheckBox,
+            'header': tr('Activate snapping when editing starts'),
+            'default': False,
+            'tooltip': tr('If snapping should be activated automatically when editing starts.'),
+            'version': LwcVersions.Lizmap_3_10,
+        }
         self._layer_config['provider'] = {
             'type': InputType.Text,
             'read_only': True,

--- a/lizmap/forms/edition_edition.py
+++ b/lizmap/forms/edition_edition.py
@@ -50,6 +50,7 @@ class EditionLayerDialog(BaseEditionDialog, CLASS):
         self.config.add_layer_widget('snap_vertices_tolerance', self.vertices_tolerance)
         self.config.add_layer_widget('snap_segments_tolerance', self.segments_tolerance)
         self.config.add_layer_widget('snap_intersections_tolerance', self.intersections_tolerance)
+        self.config.add_layer_widget('snap_on_start', self.snap_on_start)
         self.config.add_layer_widget('provider', self.provider)
 
         self.config.add_layer_label('layerId', self.label_layer)
@@ -60,6 +61,7 @@ class EditionLayerDialog(BaseEditionDialog, CLASS):
         self.config.add_layer_label('deleteFeature', self.label_delete)
         self.config.add_layer_label('acl', self.label_allowed_groups)
         self.config.add_layer_label('snap_layers', self.label_layers_snapping)
+        self.config.add_layer_label('snap_on_start', self.label_snap_on_start)
         self.config.add_layer_label('provider', self.label_provider)
 
         self.layer.layerChanged.connect(self.layer_changed)
@@ -76,6 +78,10 @@ class EditionLayerDialog(BaseEditionDialog, CLASS):
         self.lwc_versions[LwcVersions.Lizmap_3_6] = [
             self.button_wizard_group,
         ]
+        self.lwc_versions[LwcVersions.Lizmap_3_10] = [
+            self.snap_on_start,
+            self.label_snap_on_start,
+        ]
 
         # Wizard ACL group
         icon = QIcon(resources_path('icons', 'user_group.svg'))
@@ -85,6 +91,9 @@ class EditionLayerDialog(BaseEditionDialog, CLASS):
         self.button_wizard_group.setToolTip(tr("Open the group wizard"))
 
         self.setup_ui()
+        # Default to checked for new layers; legacy layers without the key
+        # get False from the definition default during from_json loading.
+        self.snap_on_start.setChecked(True)
         self.check_layer_wfs()
         self.layer_changed()
 

--- a/lizmap/resources/ui/ui_form_edition.ui
+++ b/lizmap/resources/ui/ui_form_edition.ui
@@ -152,6 +152,27 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
+       <layout class="QHBoxLayout" name="snap_on_start_layout">
+        <item>
+         <widget class="QLabel" name="label_snap_on_start">
+          <property name="text">
+           <string>Activate snapping when editing starts</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="snap_on_start">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
        <widget class="QLabel" name="label_layers_snapping">
         <property name="text">
          <string>Layers</string>


### PR DESCRIPTION
Add per-layer option to control whether snapping auto-activates when editing starts. Defaults to checked for new layers but unchecked for legacy configs missing the key (backward compatible). Targets LWC 3.10 - this PR is needed here:  https://github.com/3liz/lizmap-web-client/pull/6603

![Auto-Snap](https://github.com/user-attachments/assets/f300c6c1-8f10-48b4-ab7f-d17da503fb37)

