### PR TITLE
Fix version parsing crash with semver build metadata suffix

### DIFF
--- a/lizmap/toolbelt/strings.py
+++ b/lizmap/toolbelt/strings.py
@@ -46,6 +46,8 @@ def format_version_integer(version_string: str) -> str:
     for a in version_string.split("."):
         if "-" in a:
             a = a.split("-")[0]
+        if "+" in a:
+            a = a.split("+")[0]
         output += str(a.zfill(2))
 
     return output

--- a/lizmap/toolbelt/version.py
+++ b/lizmap/toolbelt/version.py
@@ -51,6 +51,8 @@ def format_version_integer(version_string: str) -> str:
     for a in version_string.split("."):
         if "-" in a:
             a = a.split("-")[0]
+        if "+" in a:
+            a = a.split("+")[0]
         output += str(a.zfill(2))
 
     return output

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -41,6 +41,8 @@ class TestTools(TestCase):
         self.assertEqual("040314", format_version_integer("4.3.14"))
         self.assertEqual("100912", format_version_integer("10.9.12"))
         self.assertEqual("030708", format_version_integer("3.7.8-alpha"))
+        self.assertEqual("05000003", format_version_integer("5.0.0-alpha.3+pre"))
+        self.assertEqual("010203", format_version_integer("1.2.3+build"))
         self.assertEqual("000000", format_version_integer("master"))
 
     def test_as_boolean(self):


### PR DESCRIPTION
Strip '+' build metadata (e.g. '+pre') in format_version_integer(), matching existing '-' pre-release handling. Fixes #713.
