### PR TITLE
Fix: Tooltip validate for display layer style

### DIFF
--- a/lizmap/forms/tooltip_edition.py
+++ b/lizmap/forms/tooltip_edition.py
@@ -142,7 +142,7 @@ class ToolTipEditionDialog(BaseEditionDialog, CLASS):
         # Allow display layer style only for point
         # LWC 3.10
         # Could be changed in future version
-        if layer.geometryType() != QgsWkbTypes.PointGeometry:
+        if self.display_layer_style.isChecked() and layer.geometryType() != QgsWkbTypes.PointGeometry:
             return tr(
                 "At present, the option 'Display layer feature'"
                 " is only available for point layers."


### PR DESCRIPTION
The display layer style is only available for point, but the validate method only checks the layer geometry and not if the display layer style is checked.

Fixes #722