### PR TITLE
Fix/popup tab switching bootstrap5

### DIFF
--- a/lizmap/plugin/config.py
+++ b/lizmap/plugin/config.py
@@ -103,7 +103,7 @@ class ConfigFileManager(LizmapProtocol):
                                 manager.from_json(data)
 
                         if key == "datavizLayers":
-                            self.dataviz_mngr.read_cfg(sjson)
+                            self.read_cfg(sjson)
 
             except Exception as e:
                 if self.is_dev_version:

--- a/lizmap/tooltip.py
+++ b/lizmap/tooltip.py
@@ -169,10 +169,10 @@ class Tooltip:
                 if bootstrap_5:
                     h += (
                         f'<li class="nav-item">'
-                        f'<button class="nav-link {active}" data-bs-toggle="tab" '
-                        f'data-bs-target="#popup_dd_[% $id %]_{id_tab}">'
+                        f'<a class="nav-link {active}" data-bs-toggle="tab" data-toggle="tab" '
+                        f'href="#popup_dd_[% $id %]_{id_tab}" role="tab">'
                         f'{node.name()}'
-                        f'</button>'
+                        f'</a>'
                         f'</li>'
                     )
                 else:


### PR DESCRIPTION
The Bootstrap 5 branch generated `<button data-bs-toggle data-bs-target>` elements, but LWC's popup tab handler (map.js) only selects a` [data-toggle="tab"]` and relies on jQuery's `.tab('show')`. Buttons were never caught, so only the first tab was ever visible.
Switch to `<a href data-toggle data-bs-toggle>` so the LWC handler matches the element and Bootstrap 5's Tab jQuery interface can resolve the target panel via href.

Needed to fix https://github.com/3liz/lizmap-web-client/issues/6749