### PR TITLE
Fix blocking I/O on unavailable network drives during project checks

### DIFF
--- a/lizmap/project_checker_tools.py
+++ b/lizmap/project_checker_tools.py
@@ -107,18 +107,14 @@ def project_safeguards_checks(
             # The layer is not file base.
             continue
 
-        layer_path = Path(components['path'])
-        try:
-            if not layer_path.exists():
-                # Let's skip, QGIS is already warning this layer
-                # Or the file might be a COG on Linux :
-                # /vsicurl/https://demo.snap.lizmap.com/lizmap_3_6/cog/...
-                continue
-        except OSError:
-            # Ticket https://github.com/3liz/lizmap-plugin/issues/541
-            # OSError: [WinError 123] La syntaxe du nom de fichier, de répertoire ou de volume est incorrecte:
-            # '\\vsicurl\\https:\\XXX.lizmap.com\\YYY\\cog\\ZZZ.tif'
+        # Use QGIS's already-resolved validity rather than probing the filesystem.
+        # A fresh layer_path.exists() call blocks the main thread for the full OS
+        # network timeout (~20-30s) on Windows when the layer source is on an
+        # unavailable mapped or network drive.
+        if not layer.isValid():
             continue
+
+        layer_path = Path(components['path'])
 
         try:
             relative_path = relpath(layer_path, project_home)


### PR DESCRIPTION
Calling layer_path.exists() on the main thread causes a 20-30s freeze on Windows when a layer source points to a mapped or network drive that is currently unreachable (e.g. VPN disconnected). Python's Path.exists() blocks for the full OS network timeout before returning False.

Replace the filesystem probe with layer.isValid(), which reads QGIS's validity state already resolved at project load time — zero additional I/O. The OSError guard for malformed VSI/COG paths (issue #541) is also no longer needed since QGIS marks such layers invalid when it cannot open them.

This fixes what @guenterw reported on [discourse](https://discourse.osgeo.org/t/lizmap-plugin-4-5-9-35-sec-startup-delay-on-windows-11-no-qpm-timeout/152781) (after he found out the reason of that behaviour)