### PR TITLE
add per-layer excludeFromSingleWMS option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Feature: per-layer option to exclude a layer from the single WMS request stack ([#6631](https://github.com/3liz/lizmap-web-client/issues/6631))
+
 ## 5.0.0-beta.2 - 2026-04-22
 
 * Simplify the module plugin.py https://github.com/3liz/lizmap-plugin/pull/716

--- a/lizmap/config/layer_options.py
+++ b/lizmap/config/layer_options.py
@@ -37,6 +37,7 @@ class LayerOptionDefinitions(TypedDict):
     metatileSize: ModelItem
     clientCacheExpiration: ModelItem
     externalWmsToggle: ModelItem
+    excludeFromSingleWMS: ModelItem
     sourceRepository: ModelItem
     sourceProject: ModelItem
 
@@ -230,6 +231,12 @@ layerOptionDefinitions = {
     "metatileSize": {"wType": "text", "type": "string", "default": ""},
     "clientCacheExpiration": {"wType": "spinbox", "type": "integer", "default": 300},
     "externalWmsToggle": {"wType": "checkbox", "type": "boolean", "default": False},
+    "excludeFromSingleWMS": {
+        "wType": "checkbox",
+        "type": "boolean",
+        "default": False,
+        "min_version": LwcVersions.Lizmap_3_11,
+    },
     "sourceRepository": {"wType": "text", "type": "string", "default": "", "_api": False},
     "sourceProject": {"wType": "text", "type": "string", "default": "", "_api": False},
 }

--- a/lizmap/plugin/layer_tree.py
+++ b/lizmap/plugin/layer_tree.py
@@ -115,6 +115,12 @@ class LayerTreeManager(LizmapProtocol):
         self.dlg.layer_tree.itemCollapsed.connect(self._on_layer_tree_group_state_changed)
         self.dlg.layer_search_input.textChanged.connect(self._on_layer_search_changed)
 
+        # Per-layer "exclude from single WMS" checkbox is only relevant when the
+        # project-level "Load layers as a single WMS layer" option is enabled.
+        self.dlg.checkbox_wms_single_request_all_layers.toggled.connect(
+            self._update_exclude_from_single_wms_enabled
+        )
+
         # Group helper
         self.dlg.add_group_hidden.setToolTip(
             tr(
@@ -527,6 +533,9 @@ class LayerTreeManager(LizmapProtocol):
                                     # Raise TypeError if the object was not connected
                                     self.dlg.cbExternalWms.toggled.disconnect(self.external_wms_toggled)
 
+                    if key == "excludeFromSingleWMS":
+                        self._update_exclude_from_single_wms_enabled()
+
             layer = self._current_selected_layer()  # It can be a layer or a group
 
             # Disable popup configuration for groups and raster
@@ -634,6 +643,16 @@ class LayerTreeManager(LizmapProtocol):
     def external_wms_toggled(self):
         """Disable the format combobox is the checkbox third party WMS is checked."""
         self.dlg.liImageFormat.setEnabled(not self.dlg.cbExternalWms.isChecked())
+
+    def _update_exclude_from_single_wms_enabled(self, *_args):
+        """Enable the per-layer "exclude from single WMS" checkbox only when the
+        project-level "Load layers as a single WMS layer" option is enabled.
+
+        The user's per-layer choice is preserved when disabled — only the widget's
+        enabled state changes, not its checked state.
+        """
+        project_option_enabled = self.dlg.checkbox_wms_single_request_all_layers.isChecked()
+        self.dlg.cbExcludeFromSingleWMS.setEnabled(project_option_enabled)
 
     def enable_popup_source_button(self):
         """Enable or not the "Configure" button according to the popup source."""

--- a/lizmap/plugin/options.py
+++ b/lizmap/plugin/options.py
@@ -135,6 +135,7 @@ def layer_options(
     layer_options_list["metatileSize"]["widget"] = dlg.inMetatileSize
     layer_options_list["clientCacheExpiration"]["widget"] = dlg.inClientCacheExpiration
     layer_options_list["externalWmsToggle"]["widget"] = dlg.cbExternalWms
+    layer_options_list["excludeFromSingleWMS"]["widget"] = dlg.cbExcludeFromSingleWMS
     layer_options_list["sourceRepository"]["widget"] = dlg.inSourceRepository
     layer_options_list["sourceProject"]["widget"] = dlg.inSourceProject
 

--- a/lizmap/resources/ui/ui_lizmap.ui
+++ b/lizmap/resources/ui/ui_lizmap.ui
@@ -2252,6 +2252,43 @@ This is different to the map maximum extent (defined in QGIS project properties,
                           </layout>
                          </item>
                          <item>
+                          <layout class="QHBoxLayout" name="horizontalLayout_exclude_single_wms">
+                           <item>
+                            <widget class="QCheckBox" name="cbExcludeFromSingleWMS">
+                             <property name="toolTip">
+                              <string>When the project-level option &quot;Load layers as a single WMS layer&quot; is enabled, exclude this layer from the bundled request. The layer will be requested individually (directly from its WMS server if &quot;Get images directly from WMS Server&quot; is checked). Only available when the project-level option is enabled.</string>
+                             </property>
+                             <property name="text">
+                              <string/>
+                             </property>
+                            </widget>
+                           </item>
+                           <item>
+                            <widget class="QLabel" name="label_exclude_from_single_wms">
+                             <property name="text">
+                              <string>Exclude this layer from the single WMS request stack</string>
+                             </property>
+                             <property name="wordWrap">
+                              <bool>true</bool>
+                             </property>
+                            </widget>
+                           </item>
+                           <item>
+                            <spacer name="horizontalSpacer_exclude_single_wms">
+                             <property name="orientation">
+                              <enum>Qt::Horizontal</enum>
+                             </property>
+                             <property name="sizeHint" stdset="0">
+                              <size>
+                               <width>40</width>
+                               <height>20</height>
+                              </size>
+                             </property>
+                            </spacer>
+                           </item>
+                          </layout>
+                         </item>
+                         <item>
                           <widget class="QCheckBox" name="cbSingleTile">
                            <property name="toolTip">
                             <string>If Lizmap must call this layer as a single tile. This is incompatible with server tile cache.</string>
@@ -6001,6 +6038,7 @@ This is different to the map maximum extent (defined in QGIS project properties,
   <tabstop>liImageFormat</tabstop>
   <tabstop>inClientCacheExpiration</tabstop>
   <tabstop>cbExternalWms</tabstop>
+  <tabstop>cbExcludeFromSingleWMS</tabstop>
   <tabstop>cbSingleTile</tabstop>
   <tabstop>checkbox_server_cache</tabstop>
   <tabstop>inCacheExpiration</tabstop>


### PR DESCRIPTION
UI checkbox for the new per-layer flag consumed by lizmap-web-client (LWC 3.11). Only enabled when the project-level 'Load layers as a single WMS layer' option is on; reacts live to that toggle. The user's per-layer choice is preserved when disabled.

Refs https://github.com/3liz/lizmap-web-client/issues/6631