### PR TITLE
fix: skip GDAL virtual filesystem paths in project PreventParentFolder safeguards check

### DIFF
--- a/lizmap/project_checker_tools.py
+++ b/lizmap/project_checker_tools.py
@@ -118,6 +118,9 @@ def project_safeguards_checks(
 
         layer_path = Path(components['path'])
 
+        if str(layer_path).startswith('/vsi') or str(layer_path).lower().startswith('\\vsi'):
+            continue  # online layer via GDAL virtual filesystem (COG, S3, GCS, Azure...)
+
         try:
             relative_path = relpath(layer_path, project_home)
         except ValueError:

--- a/lizmap/project_checker_tools.py
+++ b/lizmap/project_checker_tools.py
@@ -118,7 +118,8 @@ def project_safeguards_checks(
 
         layer_path = Path(components['path'])
 
-        if str(layer_path).startswith('/vsi') or str(layer_path).lower().startswith('\\vsi'):
+        _layer_path_lower = str(layer_path).lower()
+        if _layer_path_lower.startswith('/vsi') or _layer_path_lower.startswith('\\vsi'):
             continue  # online layer via GDAL virtual filesystem (COG, S3, GCS, Azure...)
 
         try:

--- a/lizmap/project_checker_tools.py
+++ b/lizmap/project_checker_tools.py
@@ -118,8 +118,8 @@ def project_safeguards_checks(
 
         layer_path = Path(components['path'])
 
-        _layer_path_lower = str(layer_path).lower()
-        if _layer_path_lower.startswith('/vsi') or _layer_path_lower.startswith('\\vsi'):
+        layer_path_lower = str(layer_path).lower()
+        if layer_path_lower.startswith('/vsi') or layer_path_lower.startswith('\\vsi'):
             continue  # online layer via GDAL virtual filesystem (COG, S3, GCS, Azure...)
 
         try:

--- a/lizmap/project_checker_tools.py
+++ b/lizmap/project_checker_tools.py
@@ -119,7 +119,7 @@ def project_safeguards_checks(
         layer_path = Path(components['path'])
 
         layer_path_lower = str(layer_path).lower()
-        if layer_path_lower.startswith('/vsi') or layer_path_lower.startswith('\\vsi'):
+        if layer_path_lower.startswith(('/vsi', '\\vsi')):
             continue  # online layer via GDAL virtual filesystem (COG, S3, GCS, Azure...)
 
         try:

--- a/tests/test_project_checker_tools.py
+++ b/tests/test_project_checker_tools.py
@@ -266,17 +266,11 @@ class TestProjectTable(TestCase):
         ]
 
         for path_str in virtual_paths:
-            layer_path = Path(path_str)
-            is_virtual = (
-                str(layer_path).startswith('/vsi')
-                or str(layer_path).lower().startswith('\\vsi')
-            )
+            layer_path_lower = str(Path(path_str)).lower()
+            is_virtual = layer_path_lower.startswith('/vsi') or layer_path_lower.startswith('\\vsi')
             self.assertTrue(is_virtual, f"Expected '{path_str}' to be detected as a virtual path")
 
         for path_str in local_paths:
-            layer_path = Path(path_str)
-            is_virtual = (
-                str(layer_path).startswith('/vsi')
-                or str(layer_path).lower().startswith('\\vsi')
-            )
+            layer_path_lower = str(Path(path_str)).lower()
+            is_virtual = layer_path_lower.startswith('/vsi') or layer_path_lower.startswith('\\vsi')
             self.assertFalse(is_virtual, f"Expected '{path_str}' NOT to be detected as a virtual path")

--- a/tests/test_project_checker_tools.py
+++ b/tests/test_project_checker_tools.py
@@ -241,3 +241,42 @@ class TestProjectTable(TestCase):
 
         data = _duplicated_label_legend_layer(QgsRuleBasedRenderer(root_rule))
         self.assertDictEqual({"label-1": 1, "label": 2, "label-2": 1}, data)
+
+    def test_gdal_virtual_filesystem_path_detection(self):
+        """Guard condition: paths starting with /vsi are GDAL virtual filesystem (online) paths.
+
+        This is the condition added in project_safeguards_checks() to skip layers
+        such as COG (/vsicurl/), S3 (/vsis3/), GCS (/vsigs/), Azure (/vsiaz/).
+        Before the fix, these paths went through relpath() and produced '..'-filled
+        strings that triggered PreventParentFolder incorrectly.
+        """
+        virtual_paths = [
+            '/vsicurl/https://example.com/cog.tif',
+            '/vsicurl/http://tiles.example.org/dem.tif',
+            '/vsis3/mybucket/subfolder/file.tif',
+            '/vsigs/mybucket/file.tif',
+            '/vsiaz/mycontainer/file.tif',
+            '/vsiswift/container/file.tif',
+        ]
+        local_paths = [
+            '/home/user/data/raster.tif',
+            '/tmp/myproject/subdir/raster.tif',
+            '../parent_dir/raster.tif',
+            'relative/raster.tif',
+        ]
+
+        for path_str in virtual_paths:
+            layer_path = Path(path_str)
+            is_virtual = (
+                str(layer_path).startswith('/vsi')
+                or str(layer_path).lower().startswith('\\vsi')
+            )
+            self.assertTrue(is_virtual, f"Expected '{path_str}' to be detected as a virtual path")
+
+        for path_str in local_paths:
+            layer_path = Path(path_str)
+            is_virtual = (
+                str(layer_path).startswith('/vsi')
+                or str(layer_path).lower().startswith('\\vsi')
+            )
+            self.assertFalse(is_virtual, f"Expected '{path_str}' NOT to be detected as a virtual path")


### PR DESCRIPTION
* **Funded by**: GEOLAB
* **Description**: Project_safeguards_checks() raised a false PreventParentFolder error on raster layers whose source is a GDAL virtual filesystem path (e.g. COG via /vsicurl/https://...). Fix: Add a guard immediately after layer_path = Path(components['path']) that skips any path whose string representation starts with /vsi (Linux/macOS) or \vsi (Windows). This prefix is common to all GDAL virtual filesystem handlers (/vsicurl/, /vsis3/, /vsigs/, /vsiaz/, /vsiswift/…). BUG https://github.com/3liz/lizmap-plugin/issues/733
