### PR TITLE
Fix QGIS crash when opening project with invalid/unreachable layers

### DIFF
--- a/lizmap/dialogs/dock_html_preview.py
+++ b/lizmap/dialogs/dock_html_preview.py
@@ -149,7 +149,16 @@ class HtmlPreview(QDockWidget):
 
     def current_layer_changed(self):
         """ When the layer has changed. """
-        self.feature.setLayer(self.layer.currentLayer())
+        layer = self.layer.currentLayer()
+        # Passing an invalid layer to QgsFeaturePickerWidget triggers a
+        # QgsFeaturePickerModel reload via QTimer.  When the timer fires
+        # QGIS creates a QgsVectorLayerFeatureSource on the broken
+        # provider and crashes (access violation).  Skip invalid layers
+        # (e.g. PostGIS with unreachable server) — issue #642.
+        if layer is not None and layer.isValid():
+            self.feature.setLayer(layer)
+        else:
+            self.feature.setLayer(None)
 
     # noinspection PyArgumentList
     def update_html(self):

--- a/lizmap/table_manager/dataviz.py
+++ b/lizmap/table_manager/dataviz.py
@@ -307,10 +307,16 @@ class TableManagerDataviz(TableManager):
         # We use only the first field.
         field = parent_layer.fields().at(field[0])
 
-        # Set the layer in the feature combobox if not set or if it's a different one
+        # Set the layer in the feature combobox if not set or if it's a different one.
+        # Guard against invalid layers (e.g. unreachable PostGIS) — same crash
+        # class as issue #642: QgsFeaturePickerWidget.setLayer() schedules a
+        # QgsFeaturePickerModel reload that crashes on an invalid provider.
         previous_layer = self.parent.dataviz_feature_picker.layer()
         if (previous_layer and previous_layer.id() != layer.id()) or not previous_layer:
-            self.parent.dataviz_feature_picker.setLayer(child_layer)
+            if child_layer is not None and child_layer.isValid():
+                self.parent.dataviz_feature_picker.setLayer(child_layer)
+            else:
+                self.parent.dataviz_feature_picker.setLayer(None)
 
         # Make widget visible
         self.parent.dataviz_feature_picker.setVisible(True)


### PR DESCRIPTION
QgsFeaturePickerWidget.setLayer() schedules a QgsFeaturePickerModel reload via QTimer. When the timer fires inside a QDialog::exec loop, QGIS constructs QgsVectorLayerFeatureSource on a broken provider (e.g. PostGIS with unreachable server) causing a Windows access violation.

Guard both call sites with layer.isValid() before passing a layer to the feature picker, consistent with the approach used in #727.

Fixes #642
