### PR TITLE
Sort snapping layers list alphabetically

### DIFF
--- a/lizmap/widgets/list_layers_selection.py
+++ b/lizmap/widgets/list_layers_selection.py
@@ -22,7 +22,11 @@ class ListLayersSelection(QListWidget):
 
         self.clear()
 
-        for layer in self.project.mapLayers().values():
+        layers = sorted(
+            self.project.mapLayers().values(),
+            key=lambda layer: layer.name().lower(),
+        )
+        for layer in layers:
             if layer.type() != QgsMapLayer.LayerType.VectorLayer:
                 continue
 


### PR DESCRIPTION
The list of layers available for snapping in the editing layer configuration was shown in QGIS map layer registry order. Sort it alphabetically (case-insensitive) by layer name so it is easier to find a layer.

