### PR TITLE
Sort plugin tables by clicking on a column header

### DIFF
--- a/lizmap/table_manager/base.py
+++ b/lizmap/table_manager/base.py
@@ -28,6 +28,11 @@ from lizmap.qt_style_sheets import NEW_FEATURE_CSS
 from lizmap.toolbelt.convert import as_boolean
 from lizmap.toolbelt.i18n import tr
 from lizmap.toolbelt.resources import plugin_name
+from lizmap.widgets.sortable_table import (
+    make_table_sortable,
+    reset_table_sort_indicator,
+    sort_table_by_column,
+)
 
 if TYPE_CHECKING:
     from lizmap.dialogs.main import LizmapDialog
@@ -95,6 +100,10 @@ class TableManager:
         self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.table.setAlternatingRowColors(True)
         self.table.cellDoubleClicked.connect(self.edit_existing_row)
+
+        # Allow sorting the rows by clicking on a column header, like the QGIS
+        # attribute table.
+        make_table_sortable(self.table)
 
         # This is a hack to get the layer and then field icons.
         self._layer = None
@@ -480,6 +489,18 @@ class TableManager:
 
         self.table.clearSelection()
 
+    def sort_by_column(self, column: int):
+        """Sort the rows by the clicked column header, toggling ascending/descending.
+
+        This performs a one-shot sort (QTableWidget.sortItems) so it does not
+        interfere with row population or the manual reordering buttons.
+        """
+        sort_table_by_column(self.table, column)
+
+    def _clear_sort_indicator(self):
+        """Reset the header sort indicator after a manual reorder."""
+        reset_table_sort_indicator(self.table)
+
     def move_layer_up(self):
         """Move the selected layer up."""
         row = self.table.currentRow()
@@ -491,6 +512,7 @@ class TableManager:
             self.table.setItem(row - 1, i, self.table.takeItem(row + 1, i))
             self.table.setCurrentCell(row - 1, column)
         self.table.removeRow(row + 1)
+        self._clear_sort_indicator()
 
     def move_layer_down(self):
         """Move the selected layer down."""
@@ -503,6 +525,7 @@ class TableManager:
             self.table.setItem(row + 2, i, self.table.takeItem(row, i))
             self.table.setCurrentCell(row + 2, column)
         self.table.removeRow(row)
+        self._clear_sort_indicator()
 
     def remove_selection(self):
         """Remove the selected row from the table."""

--- a/lizmap/table_manager/dxf_export.py
+++ b/lizmap/table_manager/dxf_export.py
@@ -7,6 +7,7 @@ from qgis.PyQt.QtWidgets import QTableWidgetItem
 
 from lizmap.toolbelt.convert import ambiguous_to_bool
 from lizmap.widgets.project_tools import is_layer_published_wfs
+from lizmap.widgets.sortable_table import make_table_sortable
 
 
 class TableManagerDxfExport:
@@ -23,6 +24,9 @@ class TableManagerDxfExport:
         self.table.horizontalHeader().setStretchLastSection(True)
         self.table.setSelectionBehavior(self.table.SelectionBehavior.SelectRows)
         self.table.setSelectionMode(self.table.SelectionMode.SingleSelection)
+
+        # Allow sorting by clicking on a column header, like the QGIS attribute table.
+        make_table_sortable(self.table)
 
     def load_wfs_layers(self, data: dict):
         """ Load all WFS-enabled layers into the table with checkboxes.

--- a/lizmap/widgets/check_project.py
+++ b/lizmap/widgets/check_project.py
@@ -18,6 +18,7 @@ from lizmap.definitions.lizmap_cloud import CLOUD_MAX_PARENT_FOLDER, CLOUD_NAME
 from lizmap.definitions.online_help import pg_service_help
 from lizmap.definitions.qgis_settings import Settings
 from lizmap.toolbelt.i18n import tr
+from lizmap.widgets.sortable_table import make_table_sortable
 
 # 10 000 * 10 000
 RASTER_COUNT_CELL = 100000000
@@ -1012,8 +1013,9 @@ class TableCheck(QTableWidget):
         self.setAlternatingRowColors(True)
         self.horizontalHeader().setStretchLastSection(True)
         self.horizontalHeader().setVisible(True)
-        # Bug, same as self.sort()
-        # self.setSortingEnabled(True)
+        # One-shot sort on header click, to avoid the row corruption caused by
+        # QTableWidget.setSortingEnabled() while the table is being populated.
+        make_table_sortable(self)
 
         headers = Headers()
         self.setColumnCount(len(headers.members))

--- a/lizmap/widgets/sortable_table.py
+++ b/lizmap/widgets/sortable_table.py
@@ -1,0 +1,58 @@
+"""Helper to sort a QTableWidget by clicking on a column header."""
+
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import QTableWidget
+
+__copyright__ = "Copyright 2024, 3Liz"
+__license__ = "GPL version 3"
+__email__ = "info@3liz.org"
+
+# Dynamic attributes stored on the table widget to remember the current sort.
+_SORT_COLUMN = "_lizmap_sort_column"
+_SORT_ORDER = "_lizmap_sort_order"
+
+
+def make_table_sortable(table: QTableWidget):
+    """Enable sorting the rows by clicking on a column header.
+
+    Behaves like the QGIS attribute table: a click sorts by that column,
+    a second click on the same column reverses the order.
+
+    We do not use QTableWidget.setSortingEnabled() on purpose. That property
+    would sort the table on load (destroying any saved row order) and re-sort
+    on every insertion (which corrupts the row content while it is being
+    populated). Instead we trigger a one-shot sort only when the user clicks
+    on a header.
+    """
+    setattr(table, _SORT_COLUMN, None)
+    setattr(table, _SORT_ORDER, Qt.SortOrder.AscendingOrder)
+    header = table.horizontalHeader()
+    header.setSectionsClickable(True)
+    header.setSortIndicatorShown(True)
+    header.sectionClicked.connect(lambda column: sort_table_by_column(table, column))
+
+
+def sort_table_by_column(table: QTableWidget, column: int):
+    """Sort the rows by the given column, toggling ascending/descending."""
+    if column < 0:
+        return
+
+    if getattr(table, _SORT_COLUMN, None) == column \
+            and getattr(table, _SORT_ORDER, Qt.SortOrder.AscendingOrder) == Qt.SortOrder.AscendingOrder:
+        order = Qt.SortOrder.DescendingOrder
+    else:
+        order = Qt.SortOrder.AscendingOrder
+
+    setattr(table, _SORT_COLUMN, column)
+    setattr(table, _SORT_ORDER, order)
+    table.horizontalHeader().setSortIndicator(column, order)
+    table.sortItems(column, order)
+
+
+def reset_table_sort_indicator(table: QTableWidget):
+    """Reset the header sort indicator, e.g. after a manual row reorder.
+
+    The rows no longer match any column sort, so we hide the indicator.
+    """
+    setattr(table, _SORT_COLUMN, None)
+    table.horizontalHeader().setSortIndicator(-1, Qt.SortOrder.AscendingOrder)

--- a/tests/test_table_manager.py
+++ b/tests/test_table_manager.py
@@ -5,7 +5,12 @@ from pathlib import Path
 import pytest
 
 from qgis.core import QgsProject, QgsVectorLayer
-from qgis.PyQt.QtWidgets import QComboBox, QTableWidget, QTreeWidget
+from qgis.PyQt.QtWidgets import (
+    QComboBox,
+    QTableWidget,
+    QTableWidgetItem,
+    QTreeWidget,
+)
 
 from lizmap.definitions.atlas import AtlasDefinitions
 from lizmap.definitions.attribute_table import AttributeTableDefinitions
@@ -23,6 +28,11 @@ from lizmap.drag_drop_dataviz_manager import DragDropDatavizManager
 from lizmap.forms.atlas_edition import AtlasEditionDialog
 from lizmap.table_manager.base import TableManager
 from lizmap.table_manager.layouts import TableManagerLayouts
+from lizmap.widgets.sortable_table import (
+    make_table_sortable,
+    reset_table_sort_indicator,
+    sort_table_by_column,
+)
 
 from .compat import TestCase
 
@@ -35,6 +45,42 @@ def layer(data: Path) -> None:
     QgsProject.instance().addMapLayer(layer)
     yield layer
     QgsProject.instance().clear()
+
+
+class TestSortableTable(TestCase):
+    def test_sortable_table_helper(self):
+        """Test the generic sortable table helper on a plain QTableWidget."""
+        table = QTableWidget()
+        table.setColumnCount(1)
+        table.setRowCount(3)
+        for row, text in enumerate(("banana", "apple", "cherry")):
+            table.setItem(row, 0, QTableWidgetItem(text))
+
+        make_table_sortable(table)
+
+        def column_values():
+            return [table.item(row, 0).text() for row in range(table.rowCount())]
+
+        # Populating does not sort, the insertion order is kept
+        self.assertEqual(column_values(), ["banana", "apple", "cherry"])
+
+        # First click sorts ascending
+        sort_table_by_column(table, 0)
+        self.assertEqual(column_values(), ["apple", "banana", "cherry"])
+        self.assertEqual(table.horizontalHeader().sortIndicatorSection(), 0)
+
+        # Second click on the same column reverses the order
+        sort_table_by_column(table, 0)
+        self.assertEqual(column_values(), ["cherry", "banana", "apple"])
+
+        # A negative column (e.g. clicking outside any section) is a no-op
+        sort_table_by_column(table, -1)
+        self.assertEqual(column_values(), ["cherry", "banana", "apple"])
+
+        # Resetting the indicator hides it, without changing the row order
+        reset_table_sort_indicator(table)
+        self.assertEqual(table.horizontalHeader().sortIndicatorSection(), -1)
+        self.assertEqual(column_values(), ["cherry", "banana", "apple"])
 
 
 class TestTableManager(TestCase):
@@ -1438,6 +1484,56 @@ class TestTableManager(TestCase):
         # We select first row and we edit it
         # table.selectRow(0)
         # self.assertEqual(table_manager.edit_existing_row(), QDialog.Accepted)
+
+    def test_sort_by_column(self, layer: QgsVectorLayer):
+        """Test sorting the table rows by clicking on a column header."""
+        table = QTableWidget()
+        definitions = AtlasDefinitions()
+        definitions._use_single_row = False
+        table_manager = TableManager(None, definitions, AtlasEditionDialog, table, None, None, None, None)
+
+        layer_1 = {
+            "layer": layer.id(),
+            "primaryKey": "id",
+            "displayLayerDescription": "False",
+            "featureLabel": "name",
+            "sortField": "name",
+            "highlightGeometry": "True",
+            "zoom": "center",
+            "duration": 5,
+            "displayPopup": "True",
+            "triggerFilter": "True",
+        }
+        layer_2 = dict(layer_1)
+        layer_2["sortField"] = "id"
+        table_manager.from_json({"layers": [layer_1, layer_2]})
+        self.assertEqual(table_manager.table.rowCount(), 2)
+
+        # The rows are displayed in their insertion order for now
+        data = table_manager.to_json(LwcVersions.latest())
+        self.assertDictEqual(data, {"layers": [layer_1, layer_2]})
+
+        column = table_manager.keys.index("sortField")
+
+        # First click on the header sorts ascending: "id" before "name"
+        table_manager.sort_by_column(column)
+        data = table_manager.to_json(LwcVersions.latest())
+        self.assertDictEqual(data, {"layers": [layer_2, layer_1]})
+
+        # Second click on the same header toggles to descending
+        table_manager.sort_by_column(column)
+        data = table_manager.to_json(LwcVersions.latest())
+        self.assertDictEqual(data, {"layers": [layer_1, layer_2]})
+
+        # The header sort indicator points to the sorted column
+        self.assertEqual(table.horizontalHeader().sortIndicatorSection(), column)
+
+        # A manual reorder resets the sort indicator
+        table.setCurrentCell(1, 0)
+        table_manager.move_layer_up()
+        self.assertEqual(table.horizontalHeader().sortIndicatorSection(), -1)
+        data = table_manager.to_json(LwcVersions.latest())
+        self.assertDictEqual(data, {"layers": [layer_2, layer_1]})
 
     def test_atlas_missing_json_parameter(self, layer: QgsVectorLayer):
         """Test if we can load CFG file with missing parameter."""


### PR DESCRIPTION
The layer tables could only be reordered with the up/down arrow buttons. Clicking a column header now sorts the rows by that column, toggling ascending/descending, like the QGIS attribute table.

The sorting logic lives in a reusable helper (lizmap/widgets/sortable_table.py) and is applied to every table where it is safe and useful. A one-shot QTableWidget.sortItems() is used instead of setSortingEnabled(): the latter sorts on load (destroying the saved layer order) and re-sorts on every row insertion (corrupting the row content while populating). A manual reorder with the arrow buttons resets the sort indicator.

Affected tables:

| Table                                        | Sortable | Reason                                                       |
|----------------------------------------------|----------|-------------------------------------------------------------|
| Layer config tables (via base TableManager)  | yes      | Covers edition, atlas, dataviz, layouts, filters, etc.      |
| DXF export layer table                       | yes      | Plain data table                                            |
| Project validation table (check_project)     | yes      | Fixes rows corrupted by the old setSortingEnabled()         |
| Remote files table (TableFiles)              | no       | Delete button bound to a fixed row index via setCellWidget  |
| Server list (server_lwc)                     | no       | Async per-row callbacks; server order is meaningful         |
| Dataviz traces / portfolio folios            | no       | Order-sensitive editors; the up/down order is the data      |
| Drag & drop dataviz tree                     | no       | Layout tree; order is fundamental                           |