### PR TITLE
Fix (set)TrustLayerMetadata deprecation

### DIFF
--- a/lizmap/dialogs/main.py
+++ b/lizmap/dialogs/main.py
@@ -60,7 +60,7 @@ from lizmap.project_checker_tools import (
     PREVENT_ECW,
     PREVENT_OTHER_DRIVE,
     PREVENT_SERVICE,
-    project_trust_layer_metadata,
+    set_project_trust_layer_metadata,
     simplify_provider_side,
     use_estimated_metadata,
 )
@@ -1417,7 +1417,7 @@ class LizmapDialog(QDialog, FORM_CLASS):
     def fix_project_trust(self):
         """ Fix the current project trust metadata. """
         self.enabled_trust_project(False)
-        project_trust_layer_metadata(self.project, True)
+        set_project_trust_layer_metadata(self.project)
         self.display_message_bar(tr("Trust project"), tr('Trust project is enabled'), Qgis.MessageLevel.Success)
 
     def fix_simplify_geom_provider(self):

--- a/lizmap/plugin/core.py
+++ b/lizmap/plugin/core.py
@@ -87,7 +87,7 @@ from lizmap.forms.portfolio_edition import PortfolioEditionDialog
 from lizmap.forms.time_manager_edition import TimeManagerEditionDialog
 from lizmap.forms.tooltip_edition import ToolTipEditionDialog
 from lizmap.project_checker_tools import (  # duplicated_layer_with_filter_legend,
-    project_trust_layer_metadata,
+    set_project_trust_layer_metadata,
 )
 from lizmap.saas import is_lizmap_cloud
 from lizmap.table_manager.base import TableManager
@@ -1413,7 +1413,7 @@ class Lizmap(
         if not self.dlg.check_cfg_file_exists():
             # Convenient option for users, for new CFG file only : project trust,
             # and add geometry to GetFeatureInfo
-            project_trust_layer_metadata(self.project, True)
+            set_project_trust_layer_metadata(self.project)
             self.project.writeEntryBool("WMSAddWktGeometry", "/", True)
 
             new_project = NewConfigDialog()

--- a/lizmap/plugin/project.py
+++ b/lizmap/plugin/project.py
@@ -79,6 +79,7 @@ from lizmap.project_checker_tools import (  # duplicated_layer_with_filter_legen
     project_safeguards_checks,
     project_tos_layers,
     project_trust_layer_metadata,
+    set_project_trust_layer_metadata,
     simplify_provider_side,
     trailing_layer_group_name,
     use_estimated_metadata,
@@ -1270,7 +1271,7 @@ class ProjectManager(LizmapProtocol):
 
         if not self.dlg.mOptionsListWidget.item(Panels.Training).isHidden():
             # Make the life easier a little bit for short workshops.
-            project_trust_layer_metadata(self.project, True)
+            set_project_trust_layer_metadata(self.project)
         elif not project_trust_layer_metadata(self.project):
             self.dlg.check_results.add_error(Error(Path(self.project.fileName()).name, checks.TrustProject))
             self.dlg.enabled_trust_project(True)

--- a/lizmap/project_checker_tools.py
+++ b/lizmap/project_checker_tools.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from psycopg2 import connect, sql
 from qgis.core import (
+    Qgis,
     QgsAbstractDatabaseProviderConnection,
     QgsDataSourceUri,
     QgsFeatureRenderer,
@@ -422,13 +423,19 @@ def use_estimated_metadata(project: QgsProject, fix: bool = False) -> list[Sourc
     return results
 
 
-def project_trust_layer_metadata(project: QgsProject, fix: bool = False) -> bool:
-    """ Trust layer metadata at the project level. """
-    if not fix:
+def project_trust_layer_metadata(project: QgsProject) -> bool:
+    if Qgis.versionInt() < 34000:
         return project.trustLayerMetadata()
 
-    project.setTrustLayerMetadata(True)
-    return True
+    return project.flags() & Qgis.ProjectFlag.TrustStoredLayerStatistics
+
+
+def set_project_trust_layer_metadata(project: QgsProject):
+    """ Trust layer metadata at the project level. """
+    if Qgis.versionInt() < 34000:
+        project.setTrustLayerMetadata(True)
+    else:
+        project.setFlag(Qgis.ProjectFlag.TrustStoredLayerStatistics)
 
 
 def count_legend_items(layer_tree: QgsLayerTreeNode, project: QgsProject, list_qgs: list) -> list:


### PR DESCRIPTION
Fix deprecation of `setTrustLayerMetadata` and  `setTrustLayerMetadata` for QGIS 3.40+.

Fixes:
    * Replace `project.trustLayerMetadata` with `project.flags() & Qgis.ProjectFlag.TrustStoredLayerStatistics`
    * Replace `project.setTrustLayerMetadata(true)` with  ` project.setFlag(Qgis.ProjectFlag.TrustStoredLayerStatistics)`
    * Simplify `project_trust_layer_metadata(QgsProject, bool)` with `project_trust_layer_metadata(QgsProject) -> bool` and
       `set_project_trust_layer_metadata(QgsProject): separate getter/setter for code simplification.