### PR TITLE
Tooltip (popup autogenerated HTML from drag&drop designer) - Improve legend UI (Bootstrap 5)

### DIFF
--- a/lizmap/tooltip.py
+++ b/lizmap/tooltip.py
@@ -4,6 +4,7 @@
 # This file MUST BE an exact copy between
 # Desktop lizmap/tooltip.py
 # Server lizmap_server/tooltip.py
+# Except the CSS for LWC <= 3.7 and newer versions
 
 from __future__ import annotations
 
@@ -197,7 +198,7 @@ class Tooltip:
 
             if lvl > 1:
                 a += "\n" + SPACES * lvl + f'<fieldset class="{visibility}">'
-                a += "\n" + SPACES * lvl + f"<legend>{node.name()}</legend>"
+                a += "\n" + SPACES * lvl + f'<legend class="float-none">{node.name()}</legend>'
                 a += "\n" + SPACES * lvl + "<div>"
 
             # In case of root children


### PR DESCRIPTION
* **Funded by**: 3Liz
* **Description**:
  * The <legend> HTML components used for form groups were not rendered correctly since the migration to Bootstrap 5 (under the group border instead of over the top border)

Related to https://github.com/3liz/lizmap-web-client/issues/4861