### PR TITLE
Only compute extent/CRS for spatial layers; fall back silently to 0,0,0,0 when the extent is null, empty or non-finite

### DIFF
--- a/lizmap/plugin/project.py
+++ b/lizmap/plugin/project.py
@@ -620,7 +620,7 @@ class ProjectManager(LizmapProtocol):
                 # Default extent and CRS values
                 layer_options["extent"] = [0, 0, 0, 0]
                 layer_options["crs"] = ""
-                
+
                 if layer.isSpatial():
                     # only update for spatial layers
                     layer_options["crs"] = layer.crs().authid()

--- a/lizmap/plugin/project.py
+++ b/lizmap/plugin/project.py
@@ -617,7 +617,30 @@ class ProjectManager(LizmapProtocol):
 
             # extent
             if layer:
-                extent = layer.extent()
+                # Default extent and CRS values
+                layer_options["extent"] = [0, 0, 0, 0]
+                layer_options["crs"] = ""
+                
+                if layer.isSpatial():
+                    # only update for spatial layers
+                    layer_options["crs"] = layer.crs().authid()
+                    # Check extent
+                    extent = layer.extent()
+                    if extent.isNull() or extent.isEmpty():
+                        logger.info(f"Layer '{layer.name()}' has null or empty extent.")
+                    if not extent.isNull() and not extent.isEmpty() and extent.isFinite():
+                        layer_options["extent"] = [
+                            extent.xMinimum(),
+                            extent.yMinimum(),
+                            extent.xMaximum(),
+                            extent.yMaximum(),
+                        ]
+                    if any(isnan(x) for x in layer_options["extent"]):
+                        # https://github.com/3liz/lizmap-plugin/issues/571
+                        if 33600 <= Qgis.versionInt() < 33603:
+                            ...
+                        else:
+                            ...
                 if extent.isNull() or extent.isEmpty() or not extent.isFinite():
                     # A valid but empty layer (e.g. a new PostgreSQL layer) reports a
                     # null/non-finite extent. This is not an error, use a default silently.

--- a/lizmap/plugin/project.py
+++ b/lizmap/plugin/project.py
@@ -618,46 +618,50 @@ class ProjectManager(LizmapProtocol):
             # extent
             if layer:
                 extent = layer.extent()
-                if extent.isNull() or extent.isEmpty():
-                    logger.info(f"Layer '{layer.name()}' has null or empty extent.")
-                layer_options["extent"] = [
-                    extent.xMinimum(),
-                    extent.yMinimum(),
-                    extent.xMaximum(),
-                    extent.yMaximum(),
-                ]
-                if any(isnan(x) for x in layer_options["extent"]):
-                    if layer.isSpatial():
-                        # https://github.com/3liz/lizmap-plugin/issues/571
-                        if 33600 <= Qgis.versionInt() < 33603:
-                            msg = tr(
-                                "A bug has been identified with QGIS 3.36.0 to 3.36.2 included, "
-                                "please change."
-                            )
-                        else:
-                            msg = ""
-                        QMessageBox.warning(
-                            self.dlg,
-                            "Lizmap",
-                            msg
-                            + tr(
-                                'Please check your layer extent for "{}" with the ID "{}".'
-                                "The extent does not seem valid."
-                            ).format(layer.name(), layer.id())
-                            + "\n\n"
-                            + tr(
-                                "You can visit vector layer properties → Information tab → Information "
-                                "from provider → Extent."
-                            )
-                            + "\n\n"
-                            + tr(
-                                'Then in the "Source" tab, you can recompute the extent or check your '
-                                "logs in QGIS."
-                            )
-                            + "\n\n"
-                            + tr("The extent has been set to a default value 0,0,0,0."),
-                        )
+                if extent.isNull() or extent.isEmpty() or not extent.isFinite():
+                    # A valid but empty layer (e.g. a new PostgreSQL layer) reports a
+                    # null/non-finite extent. This is not an error, use a default silently.
+                    logger.info(f"Layer '{layer.name()}' has no valid extent, using 0,0,0,0.")
                     layer_options["extent"] = [0, 0, 0, 0]
+                else:
+                    layer_options["extent"] = [
+                        extent.xMinimum(),
+                        extent.yMinimum(),
+                        extent.xMaximum(),
+                        extent.yMaximum(),
+                    ]
+                    if any(isnan(x) for x in layer_options["extent"]):
+                        if layer.isSpatial():
+                            # https://github.com/3liz/lizmap-plugin/issues/571
+                            if 33600 <= Qgis.versionInt() < 33603:
+                                msg = tr(
+                                    "A bug has been identified with QGIS 3.36.0 to 3.36.2 included, "
+                                    "please change."
+                                )
+                            else:
+                                msg = ""
+                            QMessageBox.warning(
+                                self.dlg,
+                                "Lizmap",
+                                msg
+                                + tr(
+                                    'Please check your layer extent for "{}" with the ID "{}".'
+                                    "The extent does not seem valid."
+                                ).format(layer.name(), layer.id())
+                                + "\n\n"
+                                + tr(
+                                    "You can visit vector layer properties → Information tab → Information "
+                                    "from provider → Extent."
+                                )
+                                + "\n\n"
+                                + tr(
+                                    'Then in the "Source" tab, you can recompute the extent or check your '
+                                    "logs in QGIS."
+                                )
+                                + "\n\n"
+                                + tr("The extent has been set to a default value 0,0,0,0."),
+                            )
+                        layer_options["extent"] = [0, 0, 0, 0]
                 layer_options["crs"] = layer.crs().authid()
 
             # styles

--- a/lizmap/plugin/project.py
+++ b/lizmap/plugin/project.py
@@ -638,54 +638,34 @@ class ProjectManager(LizmapProtocol):
                     if any(isnan(x) for x in layer_options["extent"]):
                         # https://github.com/3liz/lizmap-plugin/issues/571
                         if 33600 <= Qgis.versionInt() < 33603:
-                            ...
-                        else:
-                            ...
-                if extent.isNull() or extent.isEmpty() or not extent.isFinite():
-                    # A valid but empty layer (e.g. a new PostgreSQL layer) reports a
-                    # null/non-finite extent. This is not an error, use a default silently.
-                    logger.info(f"Layer '{layer.name()}' has no valid extent, using 0,0,0,0.")
-                    layer_options["extent"] = [0, 0, 0, 0]
-                else:
-                    layer_options["extent"] = [
-                        extent.xMinimum(),
-                        extent.yMinimum(),
-                        extent.xMaximum(),
-                        extent.yMaximum(),
-                    ]
-                    if any(isnan(x) for x in layer_options["extent"]):
-                        if layer.isSpatial():
-                            # https://github.com/3liz/lizmap-plugin/issues/571
-                            if 33600 <= Qgis.versionInt() < 33603:
-                                msg = tr(
-                                    "A bug has been identified with QGIS 3.36.0 to 3.36.2 included, "
-                                    "please change."
-                                )
-                            else:
-                                msg = ""
-                            QMessageBox.warning(
-                                self.dlg,
-                                "Lizmap",
-                                msg
-                                + tr(
-                                    'Please check your layer extent for "{}" with the ID "{}".'
-                                    "The extent does not seem valid."
-                                ).format(layer.name(), layer.id())
-                                + "\n\n"
-                                + tr(
-                                    "You can visit vector layer properties → Information tab → Information "
-                                    "from provider → Extent."
-                                )
-                                + "\n\n"
-                                + tr(
-                                    'Then in the "Source" tab, you can recompute the extent or check your '
-                                    "logs in QGIS."
-                                )
-                                + "\n\n"
-                                + tr("The extent has been set to a default value 0,0,0,0."),
+                            msg = tr(
+                                "A bug has been identified with QGIS 3.36.0 to 3.36.2 included, "
+                                "please change."
                             )
+                        else:
+                            msg = ""
+                        QMessageBox.warning(
+                            self.dlg,
+                            "Lizmap",
+                            msg
+                            + tr(
+                                'Please check your layer extent for "{}" with the ID "{}".'
+                                "The extent does not seem valid."
+                            ).format(layer.name(), layer.id())
+                            + "\n\n"
+                            + tr(
+                                "You can visit vector layer properties → Information tab → Information "
+                                "from provider → Extent."
+                            )
+                            + "\n\n"
+                            + tr(
+                                'Then in the "Source" tab, you can recompute the extent or check your '
+                                "logs in QGIS."
+                            )
+                            + "\n\n"
+                            + tr("The extent has been set to a default value 0,0,0,0."),
+                        )
                         layer_options["extent"] = [0, 0, 0, 0]
-                layer_options["crs"] = layer.crs().authid()
 
             # styles
             if isinstance(layer, QgsMapLayer):


### PR DESCRIPTION
An empty vector layer legitimately has a null/NaN extent, which triggered a modal warning about an invalid layer extent. Skip the warning when the layer has zero features; the extent still falls back to 0,0,0,0 silently.
