### PR TITLE
Use QgsProviderMetadata::sidecarFilesForUri with layer files scanning

### DIFF
--- a/lizmap/table_manager/upload_files.py
+++ b/lizmap/table_manager/upload_files.py
@@ -2,15 +2,16 @@ __copyright__ = "Copyright 2024, 3Liz"
 __license__ = "GPL version 3"
 __email__ = "info@3liz.org"
 
-from os.path import relpath
 from pathlib import Path
 
 from qgis._core import QgsMapLayerModel
-from qgis.core import QgsProviderRegistry
 from qgis.PyQt.QtWidgets import QDialog, QPushButton
 
 from lizmap.definitions.lizmap_cloud import UPLOAD_EXTENSIONS, UPLOAD_MAX_SIZE
 from lizmap.widgets.table_files import TableFiles
+
+from .. import logger
+from ..toolbelt.layer_files import scan_layer_files
 
 
 class TableFilesManager:
@@ -26,75 +27,42 @@ class TableFilesManager:
         """Scan all files"""
         self.table.setRowCount(0)
 
-        unique_files = []
-        unique_icons = {}
+        project = self.parent.project
 
-        project_home = Path(self.parent.project.absolutePath())
+        project_home = Path(project.absolutePath())
         self.parent.label_current_folder.setText(f"<strong>{project_home}</strong>")
 
-        # Qgis.versionInt() 32200 :
-        # Use QgsOgrProviderMetadata::sidecarFilesForUri
-        for layer in self.parent.project.mapLayers().values():
-            components = QgsProviderRegistry.instance().decodeUri(layer.dataProvider().name(), layer.source())
-            if "path" not in components:
-                # The layer is not file base.
+        files = {}
+
+        for layer, layer_path, sidecar_files in scan_layer_files(project):
+            if layer_path in files:
+                # A layer can be used many times, with different filters
                 continue
 
-            layer_path = Path(components["path"])
-            try:
-                if not layer_path.exists():
-                    # Let's skip, QGIS is already warning this layer
-                    # Or the file might be a COG on Linux :
-                    # /vsicurl/https://demo.snap.lizmap.com/lizmap_3_8/cog/...
-                    continue
-            except OSError:
-                # Ticket https://github.com/3liz/lizmap-plugin/issues/541
-                # OSError: [WinError 123] La syntaxe du nom de fichier, de répertoire ou de volume est incorrecte:
-                # '\\vsicurl\\https:\\XXX.lizmap.com\\YYY\\cog\\ZZZ.tif'
-                continue
-
-            try:
-                relative_path = relpath(layer_path, project_home)
-            except ValueError:
-                # https://docs.python.org/3/library/os.path.html#os.path.relpath
-                # On Windows, ValueError is raised when path and start are on different drives.
-                # For instance, H: and C:
-
-                # Not sure what to do for now...
-                # We can't compute a relative path, but the user didn't enable the safety check, so we must still skip
-                continue
-
-            if ".." in relative_path:
-                # Not supported for now
-                continue
-
-            if layer_path.stat().st_size > UPLOAD_MAX_SIZE:
-                # Not supported for now
+            if not layer_path.is_relative_to(project_home):
+                # Discard files outside of project path
+                logger.warning(
+                    "%s is outside project path (%s) and will not be uploaded", layer_path, project_home
+                )
                 continue
 
             if layer_path.suffix.lower().replace(".", "") not in UPLOAD_EXTENSIONS:
                 # Not supported for now
+                logger.warning("%s is not supported for uploading", layer_path)
                 continue
 
-            if layer_path in unique_files:
-                # A layer can be used many times, with different filters
+            if layer_path.stat().st_size > UPLOAD_MAX_SIZE:
+                # Not supported for now
+                # FIXME: This must by dynamic and definitely not set in the client !!!!!
+                logger.warning("%s exceed the allowed UPLOAD_MAX_SIZE ", layer_path)
                 continue
 
-            # TODO check if number of sub-folder ?
+            if sidecar_files:
+                # FIXME: ATM sidecar files are not supported !!!!!
+                logger.warning("File %s has sidecars files: %s, this is not supported ATM")
 
-            # TODO switch the other method
-            # try:
-            #     relative_path = layer_path.relative_to(project_home)
-            # except ValueError:
-            #     # It shouldn't happen at this stage
-            #     continue
+            files[layer_path] = QgsMapLayerModel.iconForLayer(layer)
 
-            # print(type(relative_path))
-            # for dir_parent in relative_path.parents:
-            #     print(dir_parent)
-
-            unique_icons[layer_path] = QgsMapLayerModel.iconForLayer(layer)
-            # unique_files.append(layer_path)
-
-        for file_path, icon in unique_icons.items():
+        # Add to table
+        for file_path, icon in files.items():
             self.table.add_file(file_path, icon)

--- a/lizmap/toolbelt/layer_files.py
+++ b/lizmap/toolbelt/layer_files.py
@@ -1,0 +1,105 @@
+#
+# QGis sidecar files utilities
+#
+from pathlib import Path
+from typing import (
+    Iterator,
+    Set,
+)
+
+from qgis.core import (
+    QgsMapLayer,
+    QgsProject,
+    QgsProviderMetadata,
+    QgsProviderRegistry,
+)
+
+NETWORK_VSI_PREFIXES = (
+    "/vsicurl/",
+    "/vsicurl_streaming/",
+    "/vsis3/",
+    "/vsigs/",
+    "/vsiaz/",
+    "/vsiadls/",
+    "/vsioss/",
+    "/vsiswift/",
+    "/vsihdfs/",
+    "/vsiwebhdfs/",
+)
+
+
+def layer_local_path(
+    registry: QgsProviderRegistry,
+    layer: QgsMapLayer,
+    provider_name: str,
+) -> tuple[Path, QgsProviderMetadata] | None:
+    """Check if the layer is local file based"""
+    md = registry.providerMetadata(provider_name)
+
+    if md is None or not (md.providerCapabilities() & QgsProviderMetadata.ProviderCapability.FileBasedUris):
+        return None
+
+    components = registry.decodeUri(provider_name, layer.source())
+    path = components.get("path")
+    if not path:
+        return None
+
+    if components.get("vsiPrefix", "") in NETWORK_VSI_PREFIXES:
+        return None
+
+    if "://" in path:
+        # Plain remote URL handed to GDAL, no /vsicurl/ prefix
+        return None
+
+    try:
+        path = Path(path)
+        if path.is_file():
+            # Connection string (PG:, MySQL:), or a missing file QGIS already warns about
+            return (path, md)
+    except OSError:
+        # https://github.com/3liz/lizmap-plugin/issues/541 — WinError 123
+        pass
+
+    return None
+
+
+def scan_layer_files(
+    project: QgsProject,
+    *,
+    included_provider: Set[str] | None = None,
+    excluded_providers: Set[str] | None = None,
+) -> Iterator[tuple[QgsMapLayer, Path, list[Path]]]:
+    """Return an iterator over layer file resourc path
+    and the list of sidecar files associated
+
+    Only valid for file based layers.
+    """
+    registry = QgsProviderRegistry.instance()
+
+    for layer in project.mapLayers().values():
+        provider = layer.dataProvider()
+        if provider is None:
+            continue
+
+        provider_name = provider.name()
+
+        if included_provider is not None and provider_name not in included_provider:
+            continue
+
+        if excluded_providers is not None and provider_name in excluded_providers:
+            continue
+
+        if (local_path_data := layer_local_path(registry, layer, provider_name)) is not None:
+            path, md = local_path_data
+
+            # gdal provider always provide the same bunch of unecessary auxiliary files
+            # *.vat.dbf, *.aux.xml, *.ovr, *.wld
+            if provider_name == "gdal":
+                yield (layer, path, [])
+                continue
+
+            yield (
+                layer,
+                path,
+                [p for file in md.sidecarFilesForUri(str(path)) if (p := Path(file)).is_file()],
+            )

--- a/tests/test_layer_files.py
+++ b/tests/test_layer_files.py
@@ -1,0 +1,295 @@
+"""Tests for the sidecar files utilities in lizmap.toolbelt.layer_files."""
+
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+
+from qgis.core import (
+    Qgis,
+    QgsCoordinateTransformContext,
+    QgsProject,
+    QgsProviderRegistry,
+    QgsRasterLayer,
+    QgsVectorFileWriter,
+    QgsVectorLayer,
+)
+
+from lizmap.toolbelt.layer_files import layer_local_path, scan_layer_files
+
+
+@pytest.fixture()
+def registry() -> QgsProviderRegistry:
+    return QgsProviderRegistry.instance()
+
+
+@pytest.fixture()
+def project() -> QgsProject:
+    """A standalone project, not the singleton one."""
+    project = QgsProject()
+    yield project
+    project.clear()
+
+
+@pytest.fixture()
+def shapefile(data: Path, tmp_path: Path) -> Path:
+    """Write a shapefile, which comes with its own sidecar files."""
+    source = QgsVectorLayer(str(data.joinpath("points.geojson")), "points", "ogr")
+    assert source.isValid()
+
+    destination = tmp_path.joinpath("points.shp")
+    options = QgsVectorFileWriter.SaveVectorOptions()
+    options.driverName = "ESRI Shapefile"
+    error, message = QgsVectorFileWriter.writeAsVectorFormatV3(
+        source,
+        str(destination),
+        QgsCoordinateTransformContext(),
+        options,
+    )[0:2]
+    assert error == QgsVectorFileWriter.WriterError.NoError, message
+    return destination
+
+
+@pytest.fixture()
+def zipped_shapefile(shapefile: Path, tmp_path: Path) -> Path:
+    """Zip the shapefile, so it can be read through the /vsizip/ prefix."""
+    archive = tmp_path.joinpath("archive.zip")
+    with ZipFile(archive, "w") as zip_file:
+        for path in shapefile.parent.glob("points.*"):
+            zip_file.write(path, path.name)
+    return archive
+
+
+def vector_layer(uri: str) -> QgsVectorLayer:
+    layer = QgsVectorLayer(uri, "layer", "ogr")
+    assert layer.isValid(), uri
+    return layer
+
+
+def raster_layer(uri: str) -> QgsRasterLayer:
+    layer = QgsRasterLayer(uri, "layer", "gdal")
+    assert layer.isValid(), uri
+    return layer
+
+
+#
+# layer_local_path()
+#
+
+
+def test_local_vector(registry, data):
+    """Test a local vector file is detected."""
+    path = data.joinpath("points.geojson")
+    layer = vector_layer(str(path))
+
+    result = layer_local_path(registry, layer, "ogr")
+
+    assert result is not None
+    assert result[0] == path
+    assert result[1].key() == "ogr"
+
+
+def test_local_geopackage(registry, data):
+    """Test the container is returned, not the URI with the layer name."""
+    path = data.joinpath("points_lines.gpkg")
+    layer = vector_layer(f"{path}|layername=points")
+
+    result = layer_local_path(registry, layer, "ogr")
+
+    assert result is not None
+    assert result[0] == path
+
+
+def test_local_raster(registry, data):
+    """Test a local raster file is detected."""
+    path = data.joinpath("raster.asc")
+    layer = raster_layer(str(path))
+
+    result = layer_local_path(registry, layer, "gdal")
+
+    assert result is not None
+    assert result[0] == path
+    assert result[1].key() == "gdal"
+
+
+def test_memory_layer(registry):
+    """Test a provider which is not file based is discarded."""
+    layer = QgsVectorLayer("Point?crs=EPSG:4326&field=id:integer", "memory", "memory")
+    assert layer.isValid()
+
+    assert layer_local_path(registry, layer, "memory") is None
+
+
+def test_unknown_provider(registry, data):
+    """Test an unknown provider is discarded."""
+    layer = vector_layer(str(data.joinpath("points.geojson")))
+
+    assert layer_local_path(registry, layer, "not_an_existing_provider") is None
+
+
+def test_uri_without_path(registry):
+    """Test an URI which can be decoded but without any path is discarded."""
+    layer = QgsRasterLayer(
+        "crs=EPSG:2056&"
+        "dpiMode=7&"
+        "format=image/jpeg&"
+        "layers=ch.swisstopo.pixelkarte-grau&"
+        "styles&"
+        "url=https://wms.geo.admin.ch/",
+        "wms",
+        "wms",
+    )
+    assert layer.isValid()
+
+    assert layer_local_path(registry, layer, "wms") is None
+
+
+def test_network_vsi_prefix(registry, data):
+    """Test a COG behind a network VSI prefix is discarded."""
+    # The layer itself does not need to be reachable, only its source is inspected
+    layer = raster_layer(str(data.joinpath("raster.asc")))
+    layer.setDataSource(
+        "/vsicurl/https://demo.snap.lizmap.com/lizmap/cog/raster.tif",
+        "cog",
+        "gdal",
+    )
+
+    assert layer_local_path(registry, layer, "gdal") is None
+
+
+def test_local_vsi_prefix(registry, zipped_shapefile):
+    """Test a local VSI prefix, /vsizip/, is not discarded as a network one."""
+    layer = vector_layer(f"/vsizip/{zipped_shapefile}/points.shp")
+
+    result = layer_local_path(registry, layer, "ogr")
+
+    assert result is not None
+    assert result[0] == zipped_shapefile
+
+
+def test_plain_remote_url(registry, data):
+    """Test a remote URL handed to GDAL without any VSI prefix is discarded."""
+    layer = raster_layer(str(data.joinpath("raster.asc")))
+    layer.setDataSource("https://demo.snap.lizmap.com/lizmap/cog/raster.tif", "cog", "gdal")
+
+    assert layer_local_path(registry, layer, "gdal") is None
+
+
+def test_missing_file(registry, data, tmp_path):
+    """Test a layer pointing to a file which does not exist is discarded."""
+    layer = vector_layer(str(data.joinpath("points.geojson")))
+    layer.setDataSource(str(tmp_path.joinpath("does_not_exist.geojson")), "missing", "ogr")
+
+    assert layer_local_path(registry, layer, "ogr") is None
+
+
+def test_directory_is_not_a_file(registry, data, tmp_path):
+    """Test a layer pointing to a directory is discarded."""
+    layer = vector_layer(str(data.joinpath("points.geojson")))
+    layer.setDataSource(str(tmp_path), "directory", "ogr")
+
+    assert layer_local_path(registry, layer, "ogr") is None
+
+
+#
+# scan_layer_files()
+#
+
+
+def test_empty_project(project):
+    """Test an empty project does not yield anything."""
+    assert list(scan_layer_files(project)) == []
+
+
+def test_only_file_based_layers(project, data):
+    """Test only file based layers are yielded."""
+    vector = vector_layer(str(data.joinpath("points.geojson")))
+    memory = QgsVectorLayer("Point?crs=EPSG:4326&field=id:integer", "memory", "memory")
+    project.addMapLayers([vector, memory])
+
+    results = list(scan_layer_files(project))
+
+    assert len(results) == 1
+    layer, path, sidecar_files = results[0]
+    assert layer.id() == vector.id()
+    assert path == data.joinpath("points.geojson")
+    assert sidecar_files == []
+
+
+def test_same_file_used_twice(project, data):
+    """Test a file used by two layers is yielded twice, the caller deduplicates."""
+    path = data.joinpath("points.geojson")
+    project.addMapLayers([vector_layer(str(path)), vector_layer(str(path))])
+
+    results = list(scan_layer_files(project))
+
+    assert [result[1] for result in results] == [path, path]
+
+
+def test_included_provider(project, data):
+    """Test the filter on included providers."""
+    project.addMapLayers(
+        [
+            vector_layer(str(data.joinpath("points.geojson"))),
+            raster_layer(str(data.joinpath("raster.asc"))),
+        ]
+    )
+
+    results = list(scan_layer_files(project, included_provider={"gdal"}))
+
+    assert [result[1] for result in results] == [data.joinpath("raster.asc")]
+
+
+def test_excluded_providers(project, data):
+    """Test the filter on excluded providers."""
+    project.addMapLayers(
+        [
+            vector_layer(str(data.joinpath("points.geojson"))),
+            raster_layer(str(data.joinpath("raster.asc"))),
+        ]
+    )
+
+    results = list(scan_layer_files(project, excluded_providers={"gdal"}))
+
+    assert [result[1] for result in results] == [data.joinpath("points.geojson")]
+
+
+def test_both_filters(project, data):
+    """Test both filters at the same time, the exclusion wins."""
+    project.addMapLayer(vector_layer(str(data.joinpath("points.geojson"))))
+
+    results = scan_layer_files(project, included_provider={"ogr"}, excluded_providers={"ogr"})
+
+    assert list(results) == []
+
+
+def test_sidecar_files(project, shapefile):
+    """Test the sidecar files of a shapefile which are existing on the disk."""
+    project.addMapLayer(vector_layer(str(shapefile)))
+
+    results = list(scan_layer_files(project))
+
+    assert len(results) == 1
+    _, path, sidecar_files = results[0]
+    assert path == shapefile
+
+    # Apparently no .prj file is generated with QGIS <= 3.34
+    if Qgis.versionInt() < 34000:
+        expected = {shapefile.with_suffix(suffix) for suffix in (".shx", ".dbf", ".cpg")}
+    else:
+        expected = {shapefile.with_suffix(suffix) for suffix in (".shx", ".dbf", ".prj", ".cpg")}
+    assert set(sidecar_files) == expected
+    # Only existing files must be returned, sidecarFilesForUri() returns candidates
+    assert all(sidecar.is_file() for sidecar in sidecar_files)
+
+
+def test_gdal_sidecar_files_are_skipped(project, data):
+    """Test the auxiliary files of the GDAL provider are never returned."""
+    # raster.asc comes with raster.asc.aux.xml and raster.prj in the data folder
+    assert data.joinpath("raster.asc.aux.xml").is_file()
+    project.addMapLayer(raster_layer(str(data.joinpath("raster.asc"))))
+
+    results = list(scan_layer_files(project))
+
+    assert len(results) == 1
+    assert results[0][2] == []

--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
@@ -236,7 +236,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "lizmap"
-version = "5.0.0rc2"
+version = "5.0.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]
@@ -637,7 +637,7 @@ name = "parsimonious"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "regex", marker = "python_full_version >= '3.12'" },
+    { name = "regex" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3c/0b/8a3b9f4a4943b56e67247c65e1b0564ec9bf0718b85f3fd9502d70afaf32/parsimonious-0.11.0.tar.gz", hash = "sha256:e080377d98957beec053580d38ae54fcdf7c470fb78670ba4bf8b5f9d5cad2a9", size = 54238, upload-time = "2025-11-12T01:33:48.172Z" }
 wheels = [
@@ -747,10 +747,10 @@ name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-types", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic-core", marker = "python_full_version >= '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
-    { name = "typing-inspection", marker = "python_full_version >= '3.12'" },
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
@@ -762,7 +762,7 @@ name = "pydantic-core"
 version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
@@ -887,9 +887,9 @@ name = "pyseeyou"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "future", marker = "python_full_version >= '3.12'" },
-    { name = "parsimonious", marker = "python_full_version >= '3.12'" },
-    { name = "toolz", marker = "python_full_version >= '3.12'" },
+    { name = "future" },
+    { name = "parsimonious" },
+    { name = "toolz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/7f/d328ea8f16b5e569aa3c977122068c65e19f8e9c41f0d2420f1cef8243ff/pyseeyou-1.0.2.tar.gz", hash = "sha256:5486167db8b431928e8927478bed2b2c9b8360e06dba148c009ce4bb1f2337b9", size = 10686, upload-time = "2021-03-10T19:38:21.625Z" }
 
@@ -992,10 +992,10 @@ name = "qt-transifex"
 version = "0.1.0"
 source = { git = "https://github.com/3liz/qt-transifex#9e9a963f9197143e27cd783047dff8e6ebd54b97" }
 dependencies = [
-    { name = "click", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "six", marker = "python_full_version >= '3.12'" },
-    { name = "transifex-python", marker = "python_full_version >= '3.12'" },
+    { name = "click" },
+    { name = "pydantic" },
+    { name = "six" },
+    { name = "transifex-python" },
 ]
 
 [[package]]
@@ -1275,10 +1275,10 @@ name = "transifex-python"
 version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "asttokens", marker = "python_full_version >= '3.12'" },
-    { name = "click", marker = "python_full_version >= '3.12'" },
-    { name = "pyseeyou", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "asttokens" },
+    { name = "click" },
+    { name = "pyseeyou" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/14/84e04ce82f1fab68061336131c93c2e95bee53a7a33fc0c6e655af958a3f/transifex_python-3.7.0.tar.gz", hash = "sha256:98cafa3726086dc385c651eb8baf20f4a20d5070522a29756651d2a8b2703e2b", size = 137251, upload-time = "2025-11-14T09:20:32.386Z" }
 
@@ -1296,7 +1296,7 @@ name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [


### PR DESCRIPTION
Rewrite upload file scanning:

* Use QgsProviderMetadata::sidecarFilesForUri  for associated files
* Add tests for file scanning

**Note**: The actual upload scheme does not take into account the sidecars; fortunately, the current list of accepted
files (UPLOAD_EXTENSIONS) references only type of resource with no sidecars file.

This may be problematic in the future If lizmap wants to include other kinds of files with sidecars.
